### PR TITLE
feat: add craft atom and craft template

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -15,12 +15,17 @@ import (
 
 func main() {
 	sentryDsn := os.Getenv("SENTRY_DSN")
+	env := os.Getenv("ENV")
+	if len(env) == 0 {
+		env = "prod"
+	}
 	if len(sentryDsn) > 0 {
 		logrus.Info("initializing sentry...")
 		// To initialize Sentry's handler, you need to initialize Sentry itself beforehand
 		err := sentry.Init(sentry.ClientOptions{
 			Dsn:           sentryDsn,
 			EnableTracing: true,
+			Environment:   env,
 			// Set TracesSampleRate to 1.0 to capture 100%
 			// of transactions for performance monitoring.
 			// We recommend adjusting this value in production,

--- a/internal/controller/craft_flow.go
+++ b/internal/controller/craft_flow.go
@@ -140,7 +140,7 @@ func ListCraftFlows(c *gin.Context) {
 }
 
 func ListCraftAtoms(c *gin.Context) {
-	craftAtoms := craft.GetSysCraftEntries()
+	craftAtoms := craft.GetCraftAtomDict()
 	var ret []map[string]string
 	for _, meta := range craftAtoms {
 		ret = append(ret, map[string]string{

--- a/internal/craft/craft_template.go
+++ b/internal/craft/craft_template.go
@@ -1,0 +1,29 @@
+package craft
+
+// craft template
+// craft模版, 如limit, translate等, 定义不同的参数可以派生出多种craft atom, 如limit5, translate-cn等
+
+type CraftTemplate struct {
+	Name                string
+	Description         string
+	ParamTemplateDefine []ParamTemplate
+	OptionFunc          func(map[string]string) []CraftOption
+}
+
+func (tmpl CraftTemplate) GetOptions(params map[string]string) []CraftOption {
+	return tmpl.OptionFunc(params)
+}
+
+// ParamTemplate 后续传递给craft template 参数全部使用 map[string]string, 这里的option template 是记录每个字段的名字和含义
+type ParamTemplate struct {
+	Key         string
+	Description string
+}
+
+// CraftAtom craft atom 由 craft template 派生出来
+type CraftAtom struct {
+	Name         string
+	Description  string
+	TemplateName string
+	Params       map[string]string
+}

--- a/internal/craft/craft_template.go
+++ b/internal/craft/craft_template.go
@@ -6,7 +6,7 @@ package craft
 type CraftTemplate struct {
 	Name                string
 	Description         string
-	ParamTemplateDefine []ParamTemplate
+	ParamTemplateDefine []ParamTemplate // param 格式, 主要给用户填写时提供参考
 	OptionFunc          func(map[string]string) []CraftOption
 }
 
@@ -18,6 +18,7 @@ func (tmpl CraftTemplate) GetOptions(params map[string]string) []CraftOption {
 type ParamTemplate struct {
 	Key         string
 	Description string
+	Default     string
 }
 
 // CraftAtom craft atom 由 craft template 派生出来

--- a/internal/craft/entry.go
+++ b/internal/craft/entry.go
@@ -14,67 +14,58 @@ import (
 func GetSysCraftTemplateDict() map[string]CraftTemplate {
 	sysCraftTempList := make(map[string]CraftTemplate)
 	sysCraftTempList["proxy"] = CraftTemplate{
-		Name:        "proxy",
-		Description: "proxy the feed ",
+		Name:                "proxy",
+		Description:         "proxy the feed",
+		ParamTemplateDefine: []ParamTemplate{},
 		OptionFunc: func(m map[string]string) []CraftOption {
 			return []CraftOption{}
 		},
 	}
 	sysCraftTempList["limit"] = CraftTemplate{
-		Name:        "limit",
-		Description: "limit the number of entries to a single page",
-		OptionFunc: func(m map[string]string) []CraftOption {
-			//todo parse params
-			return GetLimitCraftOption()
-		},
+		Name:                "limit",
+		Description:         "limit the number of entries to a single page",
+		ParamTemplateDefine: limitCraftParamTmpl,
+		OptionFunc:          limitCraftLoadParams,
 	}
 	sysCraftTempList["fulltext"] = CraftTemplate{
-		Name:        "fulltext",
-		Description: "extract fulltext for rss feed",
+		Name:                "fulltext",
+		Description:         "extract fulltext for rss feed",
+		ParamTemplateDefine: []ParamTemplate{},
 		OptionFunc: func(m map[string]string) []CraftOption {
-			//todo parse params
 			return GetFulltextCraftOptions()
 		},
 	}
 	sysCraftTempList["fulltext-plus"] = CraftTemplate{
-		Name:        "fulltext-plus",
-		Description: "emulate the browser to extract fulltext for rss feed",
+		Name:                "fulltext-plus",
+		Description:         "emulate the browser to extract fulltext for rss feed",
+		ParamTemplateDefine: []ParamTemplate{},
 		OptionFunc: func(m map[string]string) []CraftOption {
-			//todo parse params
 			return GetFulltextPlusCraftOptions()
 		},
 	}
 	sysCraftTempList["introduction"] = CraftTemplate{
-		Name:        "introduction",
-		Description: "add ai-generated introduction in the beginning of the article",
-		OptionFunc: func(m map[string]string) []CraftOption {
-			//todo parse params
-			return GetAddIntroductionCraftOptions()
-		},
+		Name:                "introduction",
+		Description:         "add ai-generated introduction in the beginning of the article",
+		ParamTemplateDefine: introCraftParamTmpl,
+		OptionFunc:          introCraftLoadParam,
 	}
 	sysCraftTempList["ignore-advertorial"] = CraftTemplate{
-		Name:        "ignore-advertorial",
-		Description: "exclude advertorial article using llm",
-		OptionFunc: func(m map[string]string) []CraftOption {
-			//todo parse params
-			return GetIgnoreAdvertorialCraftOptions()
-		},
+		Name:                "ignore-advertorial",
+		Description:         "exclude advertorial article using llm",
+		ParamTemplateDefine: llmFilterCraftParamTmpl,
+		OptionFunc:          llmFilterCraftLoadParam,
 	}
 	sysCraftTempList["translate-title"] = CraftTemplate{
-		Name:        "translate-title",
-		Description: "translate title to Chinese using LLM",
-		OptionFunc: func(m map[string]string) []CraftOption {
-			//todo parse params
-			return GetTranslateTitleCraftOptions()
-		},
+		Name:                "translate-title",
+		Description:         "translate title to Chinese using LLM",
+		ParamTemplateDefine: transTitleParamTmpl,
+		OptionFunc:          transTitleCraftLoadParam,
 	}
 	sysCraftTempList["translate-content"] = CraftTemplate{
-		Name:        "translate-content",
-		Description: "translate article content to Chinese using LLM",
-		OptionFunc: func(m map[string]string) []CraftOption {
-			//todo parse params
-			return GetTranslateContentCraftOptions()
-		},
+		Name:                "translate-content",
+		Description:         "translate article content to Chinese using LLM",
+		ParamTemplateDefine: transContentParamTmpl,
+		OptionFunc:          transContentCraftLoadParam,
 	}
 	return sysCraftTempList
 }

--- a/internal/craft/limit.go
+++ b/internal/craft/limit.go
@@ -3,6 +3,8 @@ package craft
 import (
 	"github.com/gorilla/feeds"
 	"github.com/samber/lo"
+	"github.com/sirupsen/logrus"
+	"strconv"
 )
 
 const defaultLimit = 10
@@ -16,9 +18,26 @@ func OptionLimit(n int) CraftOption {
 	}
 }
 
-func GetLimitCraftOption() []CraftOption {
+func GetLimitCraftOption(num int) []CraftOption {
 	craftOptions := []CraftOption{
-		OptionLimit(defaultLimit),
+		OptionLimit(num),
 	}
 	return craftOptions
+}
+
+func limitCraftLoadParams(m map[string]string) []CraftOption {
+	numStr, exist := m["num"]
+	if !exist {
+		numStr = "10"
+	}
+	n, err := strconv.Atoi(numStr)
+	if err != nil {
+		logrus.Warnf("invalid param [num] for craft template [limit]")
+		n = defaultLimit
+	}
+	return GetLimitCraftOption(n)
+}
+
+var limitCraftParamTmpl = []ParamTemplate{
+	{Key: "num", Description: "limit article to $num"},
 }


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request introduces a new CraftTemplate structure to define craft templates with parameters and options, refactors existing craft entries to use this new structure, and enhances various functionalities to support custom prompts and dynamic parameter loading.

- **New Features**:
    - Introduced a new CraftTemplate structure to define craft templates with parameters and options.
    - Added a new function GetSysCraftTemplateDict to retrieve system craft templates.
    - Implemented GetCraftAtomDict to generate craft atoms from craft templates.
    - Enhanced translation functions to accept custom prompts for translating article titles and content.
    - Added support for custom prompts in the ignore advertorial functionality.
    - Introduced parameter templates for various craft options, allowing dynamic parameter loading.
- **Enhancements**:
    - Refactored existing craft entries to use the new CraftTemplate structure.
    - Updated the Entry function to utilize the new craft template and atom dictionaries.
    - Improved the limit craft option to accept dynamic parameters.
    - Enhanced the introduction generation to support custom prompts.

<!-- Generated by sourcery-ai[bot]: end summary -->