### PR TITLE
feat: add craft atom manage

### DIFF
--- a/internal/controller/craft_atom.go
+++ b/internal/controller/craft_atom.go
@@ -1,0 +1,1 @@
+package controller

--- a/internal/controller/craft_atom.go
+++ b/internal/controller/craft_atom.go
@@ -113,14 +113,14 @@ func DeleteCraftAtom(c *gin.Context) {
 	c.JSON(http.StatusNoContent, nil)
 }
 
-// ListCraftAtoms godoc
+// ListSysCraftAtoms godoc
 // @Summary List all CraftAtoms
 // @Description List all CraftAtoms
 // @Tags CraftAtom
 // @Produce json
 // @Success 200 {array} dao.CraftAtom
 // @Router /craft-atoms [get]
-func ListCraftAtoms(c *gin.Context) {
+func ListSysCraftAtoms(c *gin.Context) {
 	db := util.GetDatabase()
 
 	craftAtoms, err := dao.GetAllCraftAtoms(db)

--- a/internal/controller/craft_atom.go
+++ b/internal/controller/craft_atom.go
@@ -113,14 +113,14 @@ func DeleteCraftAtom(c *gin.Context) {
 	c.JSON(http.StatusNoContent, nil)
 }
 
-// ListSysCraftAtoms godoc
+// ListCraftAtoms godoc
 // @Summary List all CraftAtoms
 // @Description List all CraftAtoms
 // @Tags CraftAtom
 // @Produce json
 // @Success 200 {array} dao.CraftAtom
 // @Router /craft-atoms [get]
-func ListSysCraftAtoms(c *gin.Context) {
+func ListCraftAtoms(c *gin.Context) {
 	db := util.GetDatabase()
 
 	craftAtoms, err := dao.GetAllCraftAtoms(db)

--- a/internal/controller/craft_atom.go
+++ b/internal/controller/craft_atom.go
@@ -1,1 +1,133 @@
 package controller
+
+import (
+	"FeedCraft/internal/dao"
+	"FeedCraft/internal/util"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+)
+
+// CreateCraftAtom godoc
+// @Summary Create a new CraftAtom
+// @Description Create a new CraftAtom
+// @Tags CraftAtom
+// @Accept json
+// @Produce json
+// @Param craftAtom body dao.CraftAtom true "CraftAtom data"
+// @Success 201 {object} dao.CraftAtom
+// @Failure 400 {object} gin.H
+// @Router /craft-atoms [post]
+func CreateCraftAtom(c *gin.Context) {
+	var craftAtom dao.CraftAtom
+	if err := c.ShouldBindJSON(&craftAtom); err != nil {
+		c.JSON(http.StatusBadRequest, util.APIResponse[any]{Msg: err.Error()})
+		return
+	}
+	db := util.GetDatabase()
+
+	if err := dao.CreateCraftAtom(db, &craftAtom); err != nil {
+		c.JSON(http.StatusBadRequest, util.APIResponse[any]{Msg: err.Error()})
+		return
+	}
+
+	c.JSON(http.StatusCreated, util.APIResponse[dao.CraftAtom]{Data: craftAtom})
+}
+
+// GetCraftAtom godoc
+// @Summary Get a CraftAtom by name
+// @Description Get a CraftAtom by name
+// @Tags CraftAtom
+// @Produce json
+// @Param name path string true "CraftAtom Name"
+// @Success 200 {object} dao.CraftAtom
+// @Failure 404 {object} gin.H
+// @Router /craft-atoms/{name} [get]
+func GetCraftAtom(c *gin.Context) {
+	name := c.Param("name")
+	db := util.GetDatabase()
+
+	craftAtom, err := dao.GetCraftAtomByName(db, name)
+	if err != nil {
+		c.JSON(http.StatusNotFound, util.APIResponse[any]{Msg: "CraftAtom not found"})
+		return
+	}
+	c.JSON(http.StatusOK, util.APIResponse[dao.CraftAtom]{Data: *craftAtom})
+}
+
+// UpdateCraftAtom godoc
+// @Summary Update a CraftAtom
+// @Description Update a CraftAtom
+// @Tags CraftAtom
+// @Accept json
+// @Produce json
+// @Param name path string true "CraftAtom Name"
+// @Param craftAtom body dao.CraftAtom true "CraftAtom data"
+// @Success 200 {object} dao.CraftAtom
+// @Failure 400 {object} gin.H
+// @Router /craft-atoms/{name} [put]
+func UpdateCraftAtom(c *gin.Context) {
+	name := c.Param("name")
+	var craftAtom dao.CraftAtom
+	if err := c.ShouldBindJSON(&craftAtom); err != nil {
+		c.JSON(http.StatusBadRequest, util.APIResponse[any]{Msg: err.Error()})
+		return
+	}
+	db := util.GetDatabase()
+
+	existingCraftAtom, err := dao.GetCraftAtomByName(db, name)
+	if err != nil {
+		c.JSON(http.StatusNotFound, util.APIResponse[any]{Msg: "CraftAtom not found"})
+		return
+	}
+
+	existingCraftAtom.Description = craftAtom.Description
+	existingCraftAtom.TemplateName = craftAtom.TemplateName
+	existingCraftAtom.Params = craftAtom.Params
+
+	if err := dao.UpdateCraftAtom(db, existingCraftAtom); err != nil {
+		c.JSON(http.StatusBadRequest, util.APIResponse[any]{Msg: err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, util.APIResponse[dao.CraftAtom]{Data: *existingCraftAtom})
+}
+
+// DeleteCraftAtom godoc
+// @Summary Delete a CraftAtom
+// @Description Delete a CraftAtom
+// @Tags CraftAtom
+// @Produce json
+// @Param name path string true "CraftAtom Name"
+// @Success 204 {object} gin.H
+// @Failure 404 {object} gin.H
+// @Router /craft-atoms/{name} [delete]
+func DeleteCraftAtom(c *gin.Context) {
+	name := c.Param("name")
+	db := util.GetDatabase()
+
+	if err := dao.DeleteCraftAtom(db, name); err != nil {
+		c.JSON(http.StatusNotFound, util.APIResponse[any]{Msg: "CraftAtom not found"})
+		return
+	}
+
+	c.JSON(http.StatusNoContent, nil)
+}
+
+// ListCraftAtoms godoc
+// @Summary List all CraftAtoms
+// @Description List all CraftAtoms
+// @Tags CraftAtom
+// @Produce json
+// @Success 200 {array} dao.CraftAtom
+// @Router /craft-atoms [get]
+func ListCraftAtoms(c *gin.Context) {
+	db := util.GetDatabase()
+
+	craftAtoms, err := dao.GetAllCraftAtoms(db)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, util.APIResponse[any]{Msg: err.Error()})
+		return
+	}
+
+	c.JSON(http.StatusOK, util.APIResponse[any]{Data: craftAtoms})
+}

--- a/internal/controller/craft_flow.go
+++ b/internal/controller/craft_flow.go
@@ -139,7 +139,7 @@ func ListCraftFlows(c *gin.Context) {
 	c.JSON(http.StatusOK, util.APIResponse[any]{Data: craftFlows})
 }
 
-func ListCraftAtoms(c *gin.Context) {
+func ListSysCraftAtoms(c *gin.Context) {
 	craftAtoms := craft.GetCraftAtomDict()
 	var ret []map[string]string
 	for _, meta := range craftAtoms {

--- a/internal/craft/craft_template.go
+++ b/internal/craft/craft_template.go
@@ -20,11 +20,3 @@ type ParamTemplate struct {
 	Description string
 	Default     string
 }
-
-// CraftAtom craft atom 由 craft template 派生出来
-type CraftAtom struct {
-	Name         string
-	Description  string
-	TemplateName string
-	Params       map[string]string
-}

--- a/internal/craft/entry.go
+++ b/internal/craft/entry.go
@@ -82,6 +82,17 @@ func GetCraftAtomDict() map[string]dao.CraftAtom {
 		}
 		craftAtomDict[name] = item
 	}
+
+	db := util.GetDatabase()
+	craftAtomList, err := dao.GetAllCraftAtoms(db)
+	if err != nil {
+		logrus.Errorf("read craft atom list from db error. only built-in atom will work now. err: %s", err)
+	} else {
+		for _, atom := range craftAtomList {
+			craftAtomDict[atom.Name] = atom
+		}
+	}
+
 	return craftAtomDict
 }
 

--- a/internal/craft/entry.go
+++ b/internal/craft/entry.go
@@ -70,11 +70,11 @@ func GetSysCraftTemplateDict() map[string]CraftTemplate {
 	return sysCraftTempList
 }
 
-func GetCraftAtomDict() map[string]CraftAtom {
+func GetCraftAtomDict() map[string]dao.CraftAtom {
 	tmplDict := GetSysCraftTemplateDict()
-	craftAtomDict := make(map[string]CraftAtom)
+	craftAtomDict := make(map[string]dao.CraftAtom)
 	for name, craftTemplate := range tmplDict {
-		item := CraftAtom{
+		item := dao.CraftAtom{
 			Name:         craftTemplate.Name, // 默认会有个跟template 同名的craft atom
 			Description:  fmt.Sprintf("(sys predefined)%s", craftTemplate.Description),
 			TemplateName: craftTemplate.Name,
@@ -104,7 +104,7 @@ func Entry(c *gin.Context) {
 const MaxCallDepth = 5
 
 // 递归地解出 craft option list
-func inner(db *gorm.DB, craftAtomDict *map[string]CraftAtom, craftTmplDict *map[string]CraftTemplate, craftName string, depthId int) ([]CraftOption, error) {
+func inner(db *gorm.DB, craftAtomDict *map[string]dao.CraftAtom, craftTmplDict *map[string]CraftTemplate, craftName string, depthId int) ([]CraftOption, error) {
 	if depthId+1 > MaxCallDepth {
 		return []CraftOption{}, fmt.Errorf("max call depth hit")
 	}

--- a/internal/dao/craft_atom.go
+++ b/internal/dao/craft_atom.go
@@ -1,0 +1,10 @@
+package dao
+
+// CraftAtom craft atom 由 craft template 派生出来
+type CraftAtom struct {
+	BaseModelWithPK
+	Name         string            `json:"name" gorm:"primaryKey" binding:"required"`
+	Description  string            `json:"description"`
+	TemplateName string            `json:"template_name" binding:"required" `
+	Params       map[string]string `json:"params" gorm:"serializer:json" gorm:"index"`
+}

--- a/internal/dao/craft_atom.go
+++ b/internal/dao/craft_atom.go
@@ -1,5 +1,7 @@
 package dao
 
+import "gorm.io/gorm"
+
 // CraftAtom craft atom 由 craft template 派生出来
 type CraftAtom struct {
 	BaseModelWithPK
@@ -7,4 +9,37 @@ type CraftAtom struct {
 	Description  string            `json:"description"`
 	TemplateName string            `json:"template_name" binding:"required" `
 	Params       map[string]string `json:"params" gorm:"serializer:json" gorm:"index"`
+}
+
+// CreateCraftAtom creates a new CraftAtom record
+func CreateCraftAtom(db *gorm.DB, craftAtom *CraftAtom) error {
+	return db.Create(craftAtom).Error
+}
+
+// GetCraftAtomByName retrieves a CraftAtom record by its Name
+func GetCraftAtomByName(db *gorm.DB, name string) (*CraftAtom, error) {
+	var craftAtom CraftAtom
+	result := db.Where("name = ?", name).First(&craftAtom)
+	return &craftAtom, result.Error
+}
+
+// GetAllCraftAtoms retrieves all CraftAtom records
+func GetAllCraftAtoms(db *gorm.DB) ([]CraftAtom, error) {
+	var craftAtoms []CraftAtom
+	result := db.Find(&craftAtoms)
+	return craftAtoms, result.Error
+}
+
+// UpdateCraftAtom updates an existing CraftAtom record
+func UpdateCraftAtom(db *gorm.DB, craftAtom *CraftAtom) error {
+	return db.Save(craftAtom).Error
+}
+
+// DeleteCraftAtom deletes a CraftAtom record by its Name
+func DeleteCraftAtom(db *gorm.DB, name string) error {
+	craftAtom, err := GetCraftAtomByName(db, name)
+	if err != nil {
+		return err
+	}
+	return db.Delete(craftAtom).Error
 }

--- a/internal/dao/migrate.go
+++ b/internal/dao/migrate.go
@@ -10,7 +10,7 @@ func MigrateDatabases() {
 	db := util.GetDatabase()
 	err := db.AutoMigrate(
 		&CustomRecipe{},
-		&CraftFlow{},
+		&CraftFlow{}, &CraftAtom{},
 	)
 	if err != nil {
 		logrus.Error("migrate database error.", err)

--- a/internal/router/registry.go
+++ b/internal/router/registry.go
@@ -77,6 +77,11 @@ func RegisterRouters(router *gin.Engine) {
 		adminApi.PUT("/craft-flows/:name", controller.UpdateCraftFlow)
 		adminApi.DELETE("/craft-flows/:name", controller.DeleteCraftFlow)
 		adminApi.GET("/sys-craft-atoms", controller.ListCraftAtoms)
+		adminApi.GET("/craft-atoms", controller.ListSysCraftAtoms)
+		adminApi.POST("/craft-atoms", controller.CreateCraftAtom)
+		adminApi.GET("/craft-atoms/:name", controller.GetCraftAtom)
+		adminApi.PUT("/craft-atoms/:name", controller.UpdateCraftAtom)
+		adminApi.DELETE("/craft-atoms/:name", controller.DeleteCraftAtom)
 
 	}
 

--- a/internal/router/registry.go
+++ b/internal/router/registry.go
@@ -76,8 +76,9 @@ func RegisterRouters(router *gin.Engine) {
 		adminApi.GET("/craft-flows/:name", controller.GetCraftFlow)
 		adminApi.PUT("/craft-flows/:name", controller.UpdateCraftFlow)
 		adminApi.DELETE("/craft-flows/:name", controller.DeleteCraftFlow)
-		adminApi.GET("/sys-craft-atoms", controller.ListCraftAtoms)
-		adminApi.GET("/craft-atoms", controller.ListSysCraftAtoms)
+		adminApi.GET("/sys-craft-atoms", controller.ListSysCraftAtoms)
+
+		adminApi.GET("/craft-atoms", controller.ListCraftAtoms)
 		adminApi.POST("/craft-atoms", controller.CreateCraftAtom)
 		adminApi.GET("/craft-atoms/:name", controller.GetCraftAtom)
 		adminApi.PUT("/craft-atoms/:name", controller.UpdateCraftAtom)

--- a/internal/router/registry.go
+++ b/internal/router/registry.go
@@ -76,7 +76,7 @@ func RegisterRouters(router *gin.Engine) {
 		adminApi.GET("/craft-flows/:name", controller.GetCraftFlow)
 		adminApi.PUT("/craft-flows/:name", controller.UpdateCraftFlow)
 		adminApi.DELETE("/craft-flows/:name", controller.DeleteCraftFlow)
-		adminApi.GET("/craft-atoms", controller.ListCraftAtoms)
+		adminApi.GET("/sys-craft-atoms", controller.ListCraftAtoms)
 
 	}
 

--- a/web/admin/src/api/craft_atom.ts
+++ b/web/admin/src/api/craft_atom.ts
@@ -1,0 +1,43 @@
+import axios, { AxiosResponse } from 'axios';
+
+export interface CraftAtom {
+  name: string;
+  description?: string;
+  template_name: string;
+  params: Record<string, string>;
+}
+
+const adminApiBase = '/api/admin';
+
+// Define the API base URL
+const craftAtomApiBase = `${adminApiBase}/craft-atoms`;
+
+// Create a CraftAtom
+export function createCraftAtom(
+  craftAtom: CraftAtom
+): Promise<AxiosResponse<CraftAtom>> {
+  return axios.post<CraftAtom>(craftAtomApiBase, craftAtom);
+}
+
+// Get a CraftAtom by name
+export function getCraftAtom(name: string): Promise<AxiosResponse<CraftAtom>> {
+  return axios.get<CraftAtom>(`${craftAtomApiBase}/${name}`);
+}
+
+// Update a CraftAtom
+export function updateCraftAtom(
+  name: string,
+  craftAtom: CraftAtom
+): Promise<AxiosResponse<CraftAtom>> {
+  return axios.put<CraftAtom>(`${craftAtomApiBase}/${name}`, craftAtom);
+}
+
+// Delete a CraftAtom
+export function deleteCraftAtom(name: string): Promise<AxiosResponse<void>> {
+  return axios.delete<void>(`${craftAtomApiBase}/${name}`);
+}
+
+// List all CraftAtoms
+export function listCraftAtoms(): Promise<AxiosResponse<CraftAtom[]>> {
+  return axios.get<CraftAtom[]>(craftAtomApiBase);
+}

--- a/web/admin/src/api/craft_flow.ts
+++ b/web/admin/src/api/craft_flow.ts
@@ -52,6 +52,6 @@ export function listCraftAtoms(): Promise<
   AxiosResponse<{ name: string; description: string }[]>
 > {
   return axios.get<{ name: string; description: string }[]>(
-    `${adminApiBase}/craft-atoms`
+    `${adminApiBase}/sys-craft-atoms`
   );
 }

--- a/web/admin/src/router/routes/modules/dashboard.ts
+++ b/web/admin/src/router/routes/modules/dashboard.ts
@@ -77,6 +77,15 @@ const DASHBOARD: AppRouteRecordRaw = {
         title: 'Craft Flow',
       },
     },
+    {
+      path: 'craft_atom',
+      name: 'craft_atom',
+      component: () => import('@/views/dashboard/craft_atom/craft_atom.vue'),
+      meta: {
+        requiresAuth: true,
+        title: 'Craft Atom',
+      },
+    },
   ],
 };
 

--- a/web/admin/src/views/dashboard/craft_atom/craft_atom.vue
+++ b/web/admin/src/views/dashboard/craft_atom/craft_atom.vue
@@ -52,16 +52,16 @@
         </a-form-item>
         <a-form-item label="Params" name="params">
           <a-space direction="vertical" style="width: 100%">
-            <div v-for="(value, key) in editedCraftAtom.params" :key="key">
+            <div v-for="(param, index) in editedCraftAtom.params" :key="index">
               <a-row :gutter="16">
                 <a-col :span="11">
-                  <a-input v-model="key" placeholder="Key" />
+                  <a-input v-model="param.key" placeholder="Key" />
                 </a-col>
                 <a-col :span="11">
-                  <a-input v-model="value" placeholder="Value" />
+                  <a-input v-model="param.value" placeholder="Value" />
                 </a-col>
                 <a-col :span="2">
-                  <a-button type="text" @click="removeParam(key)">
+                  <a-button type="text" @click="removeParam(index)">
                     <template #icon>
                       <icon-delete />
                     </template>
@@ -106,7 +106,7 @@
     name: '',
     description: '',
     template_name: '',
-    params: {},
+    params: [],
   });
   const showEditModal = ref(false);
   const isUpdating = ref(false);
@@ -141,15 +141,11 @@
   });
 
   const addParam = () => {
-    editedCraftAtom.value.params = {
-      ...editedCraftAtom.value.params,
-      newKey: '',
-    };
+    editedCraftAtom.value.params.push({ key: '', value: '' });
   };
 
-  const removeParam = (key: string) => {
-    const { [key]: _, ...rest } = editedCraftAtom.value.params;
-    editedCraftAtom.value.params = rest;
+  const removeParam = (index: number) => {
+    editedCraftAtom.value.params.splice(index, 1);
   };
 
   const saveCraftAtom = async () => {
@@ -165,7 +161,7 @@
       name: '',
       description: '',
       template_name: '',
-      params: {},
+      params: [],
     };
   };
 </script>

--- a/web/admin/src/views/dashboard/craft_atom/craft_atom.vue
+++ b/web/admin/src/views/dashboard/craft_atom/craft_atom.vue
@@ -1,8 +1,143 @@
 <template>
-  <div></div>
+  <div class="py-8 px-16">
+    <x-header title="Craft Atom Management" description="Manage Craft Atoms">
+    </x-header>
+
+    <a-space direction="horizontal" class="mb-6">
+      <a-button type="primary" :loading="isLoading" @click="listAllCraftAtoms">
+        List
+      </a-button>
+      <a-button
+        type="outline"
+        @click="
+          () => {
+            showEditModal = true;
+            isUpdating = false;
+          }
+        "
+        >Create CraftAtom
+      </a-button>
+    </a-space>
+
+    <a-table :data="craftAtoms" :columns="columns" :loading="isLoading">
+      <template #actions="{ record }">
+        <a-space>
+          <a-button type="outline" @click="editBtnHandler(record)"
+            >Edit
+          </a-button>
+          <a-button status="danger" @click="deleteCraftAtomHandler(record.name)"
+            >Delete
+          </a-button>
+        </a-space>
+      </template>
+    </a-table>
+
+    <a-modal
+      v-model:visible="showEditModal"
+      :title="isUpdating ? 'Edit Craft Atom' : 'Create Craft Atom'"
+    >
+      <a-form
+        :model="editedCraftAtom"
+        :label-col="{ span: 6 }"
+        :wrapper-col="{ span: 18 }"
+      >
+        <a-form-item label="Name" name="name">
+          <a-input v-model="editedCraftAtom.name" />
+        </a-form-item>
+        <a-form-item label="Description" name="description">
+          <a-textarea v-model="editedCraftAtom.description" />
+        </a-form-item>
+        <a-form-item label="Template Name" name="template_name">
+          <a-input v-model="editedCraftAtom.template_name" />
+        </a-form-item>
+        <a-form-item label="Params" name="params">
+          <a-input v-model="editedCraftAtom.params" />
+        </a-form-item>
+      </a-form>
+      <template #footer>
+        <a-button
+          @click="
+            () => {
+              showEditModal = false;
+              isUpdating = false;
+            }
+          "
+          >Cancel
+        </a-button>
+        <a-button type="primary" @click="saveCraftAtom">Save</a-button>
+      </template>
+    </a-modal>
+  </div>
 </template>
 
-<script setup lang="ts"></script>
+<script setup lang="ts">
+  import XHeader from '@/components/header/x-header.vue';
+  import { onBeforeMount, ref } from 'vue';
+  import {
+    CraftAtom,
+    createCraftAtom,
+    deleteCraftAtom,
+    listCraftAtoms,
+    updateCraftAtom,
+  } from '@/api/craft_atom';
+
+  const isLoading = ref(false);
+  const craftAtoms = ref<CraftAtom[]>([]);
+  const editedCraftAtom = ref<CraftAtom>({
+    name: '',
+    description: '',
+    template_name: '',
+    params: {},
+  });
+  const showEditModal = ref(false);
+  const isUpdating = ref(false);
+
+  const columns = [
+    { title: 'Name', dataIndex: 'name' },
+    { title: 'Description', dataIndex: 'description' },
+    { title: 'Template Name', dataIndex: 'template_name' },
+    { title: 'Params', dataIndex: 'params' },
+    { title: 'Actions', slotName: 'actions' },
+  ];
+
+  const editBtnHandler = (craftAtom: CraftAtom) => {
+    editedCraftAtom.value = { ...craftAtom };
+    showEditModal.value = true;
+    isUpdating.value = true;
+  };
+
+  const deleteCraftAtomHandler = async (name: string) => {
+    await deleteCraftAtom(name);
+    await listAllCraftAtoms();
+  };
+
+  async function listAllCraftAtoms() {
+    isLoading.value = true;
+    craftAtoms.value = (await listCraftAtoms()).data;
+    isLoading.value = false;
+  }
+
+  const saveCraftAtom = async () => {
+    if (isUpdating.value) {
+      await updateCraftAtom(editedCraftAtom.value.name, editedCraftAtom.value);
+    } else {
+      await createCraftAtom(editedCraftAtom.value);
+    }
+    showEditModal.value = false;
+    await listAllCraftAtoms();
+    isUpdating.value = false;
+    editedCraftAtom.value = {
+      name: '',
+      description: '',
+      template_name: '',
+      params: {},
+    };
+  };
+
+  onBeforeMount(() => {
+    listAllCraftAtoms();
+  });
+</script>
 
 <script lang="ts">
   export default {

--- a/web/admin/src/views/dashboard/craft_atom/craft_atom.vue
+++ b/web/admin/src/views/dashboard/craft_atom/craft_atom.vue
@@ -122,6 +122,7 @@
 
   const editBtnHandler = (craftAtom: CraftAtom) => {
     editedCraftAtom.value = { ...craftAtom };
+    formParams.value = Object.entries(editedCraftAtom.value.params).map(([key, value]) => ({ key, value }));
     showEditModal.value = true;
     isUpdating.value = true;
   };

--- a/web/admin/src/views/dashboard/craft_atom/craft_atom.vue
+++ b/web/admin/src/views/dashboard/craft_atom/craft_atom.vue
@@ -52,7 +52,7 @@
         </a-form-item>
         <a-form-item label="Params" name="params">
           <a-space direction="vertical" style="width: 100%">
-            <div v-for="(param, index) in editedCraftAtom.params" :key="index">
+            <div v-for="(param, index) in formParams" :key="index">
               <a-row :gutter="16">
                 <a-col :span="11">
                   <a-input v-model="param.key" placeholder="Key" />
@@ -106,8 +106,9 @@
     name: '',
     description: '',
     template_name: '',
-    params: [],
+    params: {},
   });
+  const formParams = ref<{ key: string; value: string }[]>([]);
   const showEditModal = ref(false);
   const isUpdating = ref(false);
 
@@ -141,14 +142,23 @@
   });
 
   const addParam = () => {
-    editedCraftAtom.value.params.push({ key: '', value: '' });
+    formParams.value.push({ key: '', value: '' });
   };
 
   const removeParam = (index: number) => {
-    editedCraftAtom.value.params.splice(index, 1);
+    formParams.value.splice(index, 1);
   };
 
   const saveCraftAtom = async () => {
+    // Convert formParams to map
+    const paramsMap: Record<string, string> = {};
+    formParams.value.forEach((param) => {
+      if (param.key && param.value) {
+        paramsMap[param.key] = param.value;
+      }
+    });
+    editedCraftAtom.value.params = paramsMap;
+
     if (isUpdating.value) {
       await updateCraftAtom(editedCraftAtom.value.name, editedCraftAtom.value);
     } else {
@@ -161,8 +171,9 @@
       name: '',
       description: '',
       template_name: '',
-      params: [],
+      params: {},
     };
+    formParams.value = [];
   };
 </script>
 

--- a/web/admin/src/views/dashboard/craft_atom/craft_atom.vue
+++ b/web/admin/src/views/dashboard/craft_atom/craft_atom.vue
@@ -51,18 +51,20 @@
           <a-input v-model="editedCraftAtom.template_name" />
         </a-form-item>
         <a-form-item label="Params" name="params">
-          <a-space direction="vertical" style="width: 100%;">
-            <div v-for="(param, index) in editedCraftAtom.params" :key="index">
+          <a-space direction="vertical" style="width: 100%">
+            <div v-for="(value, key) in editedCraftAtom.params" :key="key">
               <a-row :gutter="16">
                 <a-col :span="11">
-                  <a-input v-model="param.key" placeholder="Key" />
+                  <a-input v-model="key" placeholder="Key" />
                 </a-col>
                 <a-col :span="11">
-                  <a-input v-model="param.value" placeholder="Value" />
+                  <a-input v-model="value" placeholder="Value" />
                 </a-col>
                 <a-col :span="2">
-                  <a-button type="text" @click="removeParam(index)">
-                    <template #icon><icon-delete /></template>
+                  <a-button type="text" @click="removeParam(key)">
+                    <template #icon>
+                      <icon-delete />
+                    </template>
                   </a-button>
                 </a-col>
               </a-row>
@@ -104,7 +106,7 @@
     name: '',
     description: '',
     template_name: '',
-    params: [],
+    params: {},
   });
   const showEditModal = ref(false);
   const isUpdating = ref(false);
@@ -134,6 +136,22 @@
     isLoading.value = false;
   }
 
+  onBeforeMount(() => {
+    listAllCraftAtoms();
+  });
+
+  const addParam = () => {
+    editedCraftAtom.value.params = {
+      ...editedCraftAtom.value.params,
+      newKey: '',
+    };
+  };
+
+  const removeParam = (key: string) => {
+    const { [key]: _, ...rest } = editedCraftAtom.value.params;
+    editedCraftAtom.value.params = rest;
+  };
+
   const saveCraftAtom = async () => {
     if (isUpdating.value) {
       await updateCraftAtom(editedCraftAtom.value.name, editedCraftAtom.value);
@@ -150,10 +168,6 @@
       params: {},
     };
   };
-
-  onBeforeMount(() => {
-    listAllCraftAtoms();
-  });
 </script>
 
 <script lang="ts">
@@ -161,35 +175,3 @@
     name: 'CraftAtomManage',
   };
 </script>
-  const addParam = () => {
-    editedCraftAtom.value.params.push({ key: '', value: '' });
-  };
-
-  const removeParam = (index: number) => {
-    editedCraftAtom.value.params.splice(index, 1);
-  };
-
-  const saveCraftAtom = async () => {
-    const params = {};
-    editedCraftAtom.value.params.forEach(param => {
-      if (param.key && param.value) {
-        params[param.key] = param.value;
-      }
-    });
-    editedCraftAtom.value.params = params;
-
-    if (isUpdating.value) {
-      await updateCraftAtom(editedCraftAtom.value.name, editedCraftAtom.value);
-    } else {
-      await createCraftAtom(editedCraftAtom.value);
-    }
-    showEditModal.value = false;
-    await listAllCraftAtoms();
-    isUpdating.value = false;
-    editedCraftAtom.value = {
-      name: '',
-      description: '',
-      template_name: '',
-      params: [],
-    };
-  };

--- a/web/admin/src/views/dashboard/craft_atom/craft_atom.vue
+++ b/web/admin/src/views/dashboard/craft_atom/craft_atom.vue
@@ -51,7 +51,24 @@
           <a-input v-model="editedCraftAtom.template_name" />
         </a-form-item>
         <a-form-item label="Params" name="params">
-          <a-input v-model="editedCraftAtom.params" />
+          <a-space direction="vertical" style="width: 100%;">
+            <div v-for="(param, index) in editedCraftAtom.params" :key="index">
+              <a-row :gutter="16">
+                <a-col :span="11">
+                  <a-input v-model="param.key" placeholder="Key" />
+                </a-col>
+                <a-col :span="11">
+                  <a-input v-model="param.value" placeholder="Value" />
+                </a-col>
+                <a-col :span="2">
+                  <a-button type="text" @click="removeParam(index)">
+                    <template #icon><icon-delete /></template>
+                  </a-button>
+                </a-col>
+              </a-row>
+            </div>
+            <a-button type="dashed" @click="addParam">Add Param</a-button>
+          </a-space>
         </a-form-item>
       </a-form>
       <template #footer>
@@ -87,7 +104,7 @@
     name: '',
     description: '',
     template_name: '',
-    params: {},
+    params: [],
   });
   const showEditModal = ref(false);
   const isUpdating = ref(false);
@@ -144,3 +161,35 @@
     name: 'CraftAtomManage',
   };
 </script>
+  const addParam = () => {
+    editedCraftAtom.value.params.push({ key: '', value: '' });
+  };
+
+  const removeParam = (index: number) => {
+    editedCraftAtom.value.params.splice(index, 1);
+  };
+
+  const saveCraftAtom = async () => {
+    const params = {};
+    editedCraftAtom.value.params.forEach(param => {
+      if (param.key && param.value) {
+        params[param.key] = param.value;
+      }
+    });
+    editedCraftAtom.value.params = params;
+
+    if (isUpdating.value) {
+      await updateCraftAtom(editedCraftAtom.value.name, editedCraftAtom.value);
+    } else {
+      await createCraftAtom(editedCraftAtom.value);
+    }
+    showEditModal.value = false;
+    await listAllCraftAtoms();
+    isUpdating.value = false;
+    editedCraftAtom.value = {
+      name: '',
+      description: '',
+      template_name: '',
+      params: [],
+    };
+  };

--- a/web/admin/src/views/dashboard/craft_atom/craft_atom.vue
+++ b/web/admin/src/views/dashboard/craft_atom/craft_atom.vue
@@ -1,0 +1,11 @@
+<template>
+  <div></div>
+</template>
+
+<script setup lang="ts"></script>
+
+<script lang="ts">
+  export default {
+    name: 'CraftAtomManage',
+  };
+</script>


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request adds Craft Atom management capabilities, including CRUD operations and a new dashboard view for managing Craft Atoms. It also refactors the Craft Atom data structure to be handled by the DAO layer and updates the database migration script accordingly.

- **New Features**:
    - Introduced Craft Atom management functionality, including creating, updating, deleting, and listing Craft Atoms.
    - Added a new Craft Atom management view in the dashboard for the web admin interface.
- **Enhancements**:
    - Refactored Craft Atom data structure to be managed via the DAO layer.
    - Updated the database migration script to include Craft Atom.

<!-- Generated by sourcery-ai[bot]: end summary -->