### PR TITLE
feat: add new craft for fixing guid

### DIFF
--- a/internal/adapter/common_llm.go
+++ b/internal/adapter/common_llm.go
@@ -27,12 +27,12 @@ func SimpleLLMCall(model string, promptInput string) (string, error) {
 	openAIModel := model
 	if openAIModel == "" {
 		openAIModel = envClient.GetString("OPENAI_DEFAULT_MODEL")
-		logrus.Info("model not specified, using default model from env:", openAIModel)
+		//logrus.Info("model not specified, using default model from env:", openAIModel)
 	}
 
 	conf := openai.DefaultConfig(openAIAuthKey)
 	if openAIEndpoint != "" {
-		logrus.Info("using custom openai endpoint ", openAIEndpoint)
+		//logrus.Info("using custom openai endpoint ", openAIEndpoint)
 		conf.BaseURL = openAIEndpoint
 	} else {
 		logrus.Info("using default openai endpoint ")

--- a/internal/craft/entry.go
+++ b/internal/craft/entry.go
@@ -33,6 +33,14 @@ func GetSysCraftTemplateDict() map[string]CraftTemplate {
 		ParamTemplateDefine: keywordCraftParamTmpl,
 		OptionFunc:          keywordCraftLoadParams,
 	}
+	sysCraftTempList["guid-fix"] = CraftTemplate{
+		Name:                "guid-fix",
+		Description:         "fix rss guid. use article content md5 as unique id.",
+		ParamTemplateDefine: []ParamTemplate{},
+		OptionFunc: func(m map[string]string) []CraftOption {
+			return GetGuidCraftOptions()
+		},
+	}
 	sysCraftTempList["fulltext"] = CraftTemplate{
 		Name:                "fulltext",
 		Description:         "extract fulltext for rss feed",
@@ -108,7 +116,6 @@ func Entry(c *gin.Context) {
 	craftTmplDict := GetSysCraftTemplateDict()
 	db := util.GetDatabase()
 
-	//TODO IMPLEMENT CUSTOM OPTION PARAMETERS
 	craftOptionList, err := inner(db, &craftAtomDict, &craftTmplDict, craftName, 0)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, util.APIResponse[any]{Msg: err.Error()})

--- a/internal/craft/guid.go
+++ b/internal/craft/guid.go
@@ -2,6 +2,7 @@ package craft
 
 import (
 	"fmt"
+
 	"github.com/google/uuid"
 	"github.com/gorilla/feeds"
 )
@@ -25,7 +26,7 @@ func feedItemGuidGenerator(item *feeds.Item) (string, error) {
 		return uuid.New().String(), nil
 	}
 
-	combinedInput := title + content + description
+	combinedInput := item.Title + item.Content + item.Description
 	hash := getMD5Hash(combinedInput)
 	return fmt.Sprintf("%x", hash), nil
 }

--- a/internal/craft/guid.go
+++ b/internal/craft/guid.go
@@ -1,0 +1,38 @@
+package craft
+
+import (
+	"fmt"
+	"github.com/google/uuid"
+	"github.com/gorilla/feeds"
+)
+
+// 通过文章原始内容的title 和content 字段, 计算哈希值, 来生成一个唯一的guid, 替换掉原feed中的可能有问题的guid
+
+func GetGuidProcessor(transFunc TransFunc) FeedItemProcessor {
+	return func(item *feeds.Item) error {
+		guid, err := transFunc(item)
+		if err != nil {
+			return err
+		}
+		item.Id = guid
+		return nil
+	}
+}
+
+// 根据feed 中文章标题和内容生成md5作为guid, 如果几个字段都为空则返回随机值
+func feedItemGuidGenerator(item *feeds.Item) (string, error) {
+	if len(item.Title) == 0 && len(item.Content) == 0 && len(item.Description) == 0 {
+		return uuid.New().String(), nil
+	}
+	titleHash := getMD5Hash(item.Title)
+	contentFieldHash := getMD5Hash(item.Content)
+	descriptionFieldHash := getMD5Hash(item.Description)
+	return fmt.Sprintf("%s%s%s", titleHash, contentFieldHash, descriptionFieldHash), nil
+}
+
+func GetGuidCraftOptions() []CraftOption {
+	craftOptions := []CraftOption{
+		OptionTransformFeedItem(GetGuidProcessor(feedItemGuidGenerator)),
+	}
+	return craftOptions
+}

--- a/internal/craft/guid.go
+++ b/internal/craft/guid.go
@@ -26,7 +26,7 @@ func feedItemGuidGenerator(item *feeds.Item) (string, error) {
 	}
 
 	combinedInput := title + content + description
-	hash := getMD5Hash(combinedInput))
+	hash := getMD5Hash(combinedInput)
 	return fmt.Sprintf("%x", hash), nil
 }
 

--- a/internal/craft/guid.go
+++ b/internal/craft/guid.go
@@ -27,7 +27,9 @@ func feedItemGuidGenerator(item *feeds.Item) (string, error) {
 	titleHash := getMD5Hash(item.Title)
 	contentFieldHash := getMD5Hash(item.Content)
 	descriptionFieldHash := getMD5Hash(item.Description)
-	return fmt.Sprintf("%s%s%s", titleHash, contentFieldHash, descriptionFieldHash), nil
+	combinedInput := title + content + description
+	hash := md5.Sum([]byte(combinedInput))
+	return fmt.Sprintf("%x", hash), nil
 }
 
 func GetGuidCraftOptions() []CraftOption {

--- a/internal/craft/guid.go
+++ b/internal/craft/guid.go
@@ -24,11 +24,9 @@ func feedItemGuidGenerator(item *feeds.Item) (string, error) {
 	if len(item.Title) == 0 && len(item.Content) == 0 && len(item.Description) == 0 {
 		return uuid.New().String(), nil
 	}
-	titleHash := getMD5Hash(item.Title)
-	contentFieldHash := getMD5Hash(item.Content)
-	descriptionFieldHash := getMD5Hash(item.Description)
+
 	combinedInput := title + content + description
-	hash := md5.Sum([]byte(combinedInput))
+	hash := getMD5Hash(combinedInput))
 	return fmt.Sprintf("%x", hash), nil
 }
 

--- a/internal/craft/introduction.go
+++ b/internal/craft/introduction.go
@@ -62,6 +62,7 @@ func addIntroductionUsingLLM(item *feeds.Item, prompt string) string {
 }
 
 func GetAddIntroductionCraftOptions(prompt string) []CraftOption {
+	//todo 后续在将原文发送到LLM之前, 默认去掉无效的html属性和css以节省token
 	transFunc := func(item *feeds.Item) (string, error) {
 		ret := addIntroductionUsingLLM(item, prompt)
 		return ret, nil

--- a/internal/craft/introduction.go
+++ b/internal/craft/introduction.go
@@ -19,7 +19,7 @@ func getIntroductionForArticle(prompt, article string) (string, error) {
 
 const promptGenerateIntroduction = "请阅读下面的文章并写一篇不超过200字的中文摘要, 使得读者可以快速知道文章的主题和主要结论."
 
-func addIntroductionUsingGemini(item *feeds.Item, prompt string) string {
+func addIntroductionUsingLLM(item *feeds.Item, prompt string) string {
 	//TODO handle description and content field separately and correctly
 
 	finalArticleContent := ""
@@ -63,7 +63,7 @@ func addIntroductionUsingGemini(item *feeds.Item, prompt string) string {
 
 func GetAddIntroductionCraftOptions(prompt string) []CraftOption {
 	transFunc := func(item *feeds.Item) (string, error) {
-		ret := addIntroductionUsingGemini(item, prompt)
+		ret := addIntroductionUsingLLM(item, prompt)
 		return ret, nil
 	}
 	craftOption := []CraftOption{

--- a/internal/craft/option.go
+++ b/internal/craft/option.go
@@ -53,6 +53,7 @@ func GetArticleContentProcessor(transFunc TransFunc) FeedItemProcessor {
 			return err
 		}
 		item.Content = transformed
+		item.Description = transformed
 		return nil
 	}
 }

--- a/internal/craft/translate.go
+++ b/internal/craft/translate.go
@@ -59,6 +59,8 @@ var transTitleParamTmpl = []ParamTemplate{
 // translate article content
 // ===
 
+//todo 后续添加mode字段, 支持将摘要放在文章开头/文章结尾/替换掉原文
+
 // GetTranslateContentCraftOptions translate article content
 func GetTranslateContentCraftOptions(prompt string) []CraftOption {
 	transFunc := func(item *feeds.Item) (string, error) {

--- a/internal/craft/translate.go
+++ b/internal/craft/translate.go
@@ -5,9 +5,9 @@ import (
 	"github.com/gorilla/feeds"
 )
 
-const translateArticleContentPrompt = "下面是一篇文章的内容,请将其翻译为中文. 如果文章内有图片或者链接尽量保留它们. "
+const translateArticleContentPrompt = "下面是一篇文章的内容,请将其翻译为中文. 如果文章内有图片或者链接尽量保留它们, 对于专有名词也请保持原样. "
 
-const translateArticleTitlePrompt = "下面是一篇文章的标题, 请将其翻译为中文"
+const translateArticleTitlePrompt = "下面是一篇文章的标题, 请将其翻译为中文. 对于专有名词等请保持原样"
 
 func translateArticleTitle(title string, prompt string) (string, error) {
 	return adapter.CallLLMUsingContext(prompt, title)

--- a/web/admin/src/views/dashboard/custom_recipe/custom_recipe.vue
+++ b/web/admin/src/views/dashboard/custom_recipe/custom_recipe.vue
@@ -40,7 +40,7 @@
             Edit
           </a-button>
           <a-button @click="deleteRecipe(record.id)">Delete</a-button>
-          <a-link :href="`/recipe/${record?.id}`">Link</a-link>
+          <a-link :href="`${baseUrl}/recipe/${record?.id}`">Link</a-link>
         </a-space>
       </template>
     </a-table>
@@ -93,6 +93,8 @@
     updateCustomRecipe,
   } from '@/api/custom_recipe';
   import XHeader from '@/components/header/x-header.vue';
+
+  const baseUrl = import.meta.env.VITE_API_BASE_URL ?? '/';
 
   const recipes = ref<CustomRecipe[]>([]);
   const showModal = ref(false);

--- a/web/admin/src/views/dashboard/feed-viewer/feed_viewer.vue
+++ b/web/admin/src/views/dashboard/feed-viewer/feed_viewer.vue
@@ -33,7 +33,7 @@
   const feedUrl = ref('');
   const feedContent = ref<any>(null);
   const isLoading = ref(false);
-  const baseUrl = import.meta.env.VITE_API_BASE_URL;
+  const baseUrl = import.meta.env.VITE_API_BASE_URL ?? '/';
 
   async function fetchFeed() {
     isLoading.value = true;

--- a/web/admin/src/views/dashboard/feed_compare/feed_compare.vue
+++ b/web/admin/src/views/dashboard/feed_compare/feed_compare.vue
@@ -63,7 +63,7 @@
   const originalFeedContent = ref<any>(null);
   const craftAppliedFeedContent = ref<any>(null);
   const isLoading = ref(false);
-  const baseUrl = import.meta.env.VITE_API_BASE_URL;
+  const baseUrl = import.meta.env.VITE_API_BASE_URL ?? '/';
 
   async function fetchFeed(url: string) {
     const parser = new Parser();


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request introduces a new craft template for fixing GUIDs in RSS feeds by generating unique IDs using the MD5 hash of the article content. It also includes enhancements to translation prompts, renaming of a function for clarity, and setting a fallback base URL for API calls in the web admin dashboard. Additionally, unnecessary logging statements have been removed.

- **New Features**:
    - Added a new craft template 'guid-fix' to generate unique GUIDs for RSS feeds using the MD5 hash of the article content.
- **Enhancements**:
    - Updated translation prompts to preserve proper nouns and specific terms in the translated content.
    - Renamed function 'addIntroductionUsingGemini' to 'addIntroductionUsingLLM' for better clarity.
    - Added a fallback base URL for API calls in the web admin dashboard components.
- **Chores**:
    - Removed unnecessary logging statements in the LLM call function.

<!-- Generated by sourcery-ai[bot]: end summary -->