### PR TITLE
feat: push image to docker hub

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -20,11 +20,11 @@ env:
   REGISTRY: ghcr.io
   # github.repository as <account>/<repo>
   IMAGE_NAME: colin-xkl/feed-craft
+  DOCKERHUB_IMAGE_NAME: colinxkl/feed-craft
 
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -51,7 +51,7 @@ jobs:
 
       # Login against a Docker registry except on PR
       # https://github.com/docker/login-action
-      - name: Log into registry ${{ env.REGISTRY }}
+      - name: Log into extra registry ${{ env.REGISTRY }}
         if: github.event_name != 'pull_request'
         uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
         with:
@@ -59,17 +59,26 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ vars.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       # Extract metadata (tags, labels) for Docker
       # https://github.com/docker/metadata-action
       - name: Extract Docker metadata
         id: meta
         uses: docker/metadata-action@8e5442c4ef9f78752691e2d8f8d19755c6f78e81 # v5.5.1
         with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          images: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+            ${{ env.DOCKERHUB_IMAGE_NAME }}
           tags: |
             # set latest tag for default branch
             type=raw,value=latest,enable={{is_default_branch}}
             type=edge,branch=dev
+            type=main,branch=main
             type=pep440,pattern={{major}}.{{minor}},enable={{is_default_branch}}
             type=pep440,pattern={{version}},enable={{is_default_branch}}
           flavor: latest=false

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -78,7 +78,6 @@ jobs:
             # set latest tag for default branch
             type=raw,value=latest,enable={{is_default_branch}}
             type=edge,branch=dev
-            type=main,branch=main
             type=pep440,pattern={{major}}.{{minor}},enable={{is_default_branch}}
             type=pep440,pattern={{version}},enable={{is_default_branch}}
           flavor: latest=false

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -6,15 +6,15 @@ ENV GOMODCACHE=/root/.cache/go-mod-cache
 WORKDIR /app
 
 # copy Go modules and dependencies to image
-COPY go.mod ./
+COPY go.mod go.sum ./
 
 # download Go modules and dependencies
 RUN --mount=type=cache,id=gomod,target="/root/.cache/go-mod-cache" go mod download
 
 # copy directory files i.e all files ending with .go
 COPY . .
-# compile application
 
+# compile application
 RUN --mount=type=cache,id=gobuild,target="/root/.cache/go-build" GO111MODULE=on CGO_ENABLED=0 go build -o /feed-craft /app/cmd/main.go
 
 FROM node:22-slim AS frontend-builder
@@ -28,10 +28,9 @@ WORKDIR /app
 COPY web/admin/pnpm-lock.yaml web/admin/package.json /app/
 RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install
 
-COPY  web/admin /app/
+COPY web/admin /app/
 RUN pnpm run build
 
-## DEPLOY
 FROM alpine
 
 WORKDIR /app


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Enhance the CI workflow to push Docker images to Docker Hub by adding a login step and updating metadata extraction to include the Docker Hub image name.

CI:
- Add Docker Hub login step to the GitHub Actions workflow for publishing Docker images.
- Update Docker metadata extraction to include Docker Hub image name.

<!-- Generated by sourcery-ai[bot]: end summary -->