### PR TITLE
using golang 1.22

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.19-alpine AS backend-builder
+FROM golang:1.22-alpine AS backend-builder
 ENV GOCACHE=/root/.cache/go-build
 ENV GOMODCACHE=/root/.cache/go-mod-cache
 


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Update Dockerfile to use Go 1.22 for the backend builder.