### PR TITLE
feat: add HTML content cleanup via markdown conversion

### DIFF
--- a/internal/adapter/llm.go
+++ b/internal/adapter/llm.go
@@ -27,7 +27,7 @@ func CallGeminiUsingArticleContext(prompt string, article string) (string, error
 
 // CallLLMUsingContext using openai compatible api
 func CallLLMUsingContext(prompt, context string) (string, error) {
-	finalPrompt := fmt.Sprintf("%s \n `%s`", prompt, context)
+	finalPrompt := fmt.Sprintf("%s \n```\n%s\n```", prompt, context)
 	cacheKey := fmt.Sprintf("llm_call_%s", util.GetMD5Hash(finalPrompt))
 	valFunc := func() (string, error) {
 		return SimpleLLMCall(UseDefaultModel, finalPrompt)

--- a/internal/craft/cleanup.go
+++ b/internal/craft/cleanup.go
@@ -1,14 +1,14 @@
 package craft
 
 import (
+	"FeedCraft/internal/util"
 	"github.com/gorilla/feeds"
-	"internal/util"
 )
 
-func CleanupContent(htmlContent string) (string, error) {
+func CleanupContent(htmlContent string, domain string) (string, error) {
 	// First convert HTML to Markdown to strip unnecessary elements
-	markdown := util.Html2Markdown(htmlContent, nil)
-	
+	markdown := util.Html2Markdown(htmlContent, &domain)
+
 	// Then convert back to HTML for clean, semantic markup
 	cleanHtml := util.Markdown2HTML(markdown)
 	return cleanHtml, nil
@@ -16,11 +16,12 @@ func CleanupContent(htmlContent string) (string, error) {
 
 func GetCleanupCraftOptions() []CraftOption {
 	transFunc := func(item *feeds.Item) (string, error) {
-		return CleanupContent(item.Content)
+		domain, _ := util.ParseDomainFromUrl(item.Link.Href)
+		return CleanupContent(item.Content, domain)
 	}
 	cachedTransFunc := GetCommonCachedTransformer(
-		cacheKeyForArticleContent, 
-		transFunc, 
+		cacheKeyForArticleContent,
+		transFunc,
 		"cleanup article content",
 	)
 	craftOptions := []CraftOption{

--- a/internal/craft/cleanup.go
+++ b/internal/craft/cleanup.go
@@ -1,0 +1,30 @@
+package craft
+
+import (
+	"github.com/gorilla/feeds"
+	"internal/util"
+)
+
+func CleanupContent(htmlContent string) (string, error) {
+	// First convert HTML to Markdown to strip unnecessary elements
+	markdown := util.Html2Markdown(htmlContent, nil)
+	
+	// Then convert back to HTML for clean, semantic markup
+	cleanHtml := util.Markdown2HTML(markdown)
+	return cleanHtml, nil
+}
+
+func GetCleanupCraftOptions() []CraftOption {
+	transFunc := func(item *feeds.Item) (string, error) {
+		return CleanupContent(item.Content)
+	}
+	cachedTransFunc := GetCommonCachedTransformer(
+		cacheKeyForArticleContent, 
+		transFunc, 
+		"cleanup article content",
+	)
+	craftOptions := []CraftOption{
+		OptionTransformFeedItem(GetArticleContentProcessor(cachedTransFunc)),
+	}
+	return craftOptions
+}

--- a/internal/craft/common.go
+++ b/internal/craft/common.go
@@ -109,7 +109,7 @@ func GetCommonCachedTransformer(cacheKeyGenerator ContentCacheKeyGenerator, rawT
 		valFunc := func() (string, error) {
 			ret, err := rawTransformer(item)
 			if err != nil {
-				logrus.Warnf("failed to apply craft [%s] for article [%s], %v\n", craftName, originalTitle, err)
+				logrus.Warnf("failed to apply craft [%s] for article [%s], err: %v\n", craftName, originalTitle, err)
 			}
 			return ret, err
 		}

--- a/internal/craft/entry.go
+++ b/internal/craft/entry.go
@@ -66,6 +66,14 @@ func GetSysCraftTemplateDict() map[string]CraftTemplate {
 			return GetFulltextPlusCraftOptions()
 		},
 	}
+	sysCraftTempList["cleanup"] = CraftTemplate{
+		Name:                "cleanup",
+		Description:         "清理文章HTML内容，保留核心内容",
+		ParamTemplateDefine: []ParamTemplate{},
+		OptionFunc: func(m map[string]string) []CraftOption {
+			return GetCleanupCraftOptions()
+		},
+	}
 	sysCraftTempList["introduction"] = CraftTemplate{
 		Name:                "introduction",
 		Description:         "在文章开头添加 AI 生成的介绍",

--- a/internal/craft/introduction.go
+++ b/internal/craft/introduction.go
@@ -20,7 +20,7 @@ const promptGenerateIntroduction = "请阅读下面的文章并写一篇不超�
 
 func combineIntroductionAndArticle(article, intro string) string {
 	introInHtml := util.Markdown2HTML(intro)
-	return fmt.Sprintf(`<div>%s<div><hr/>%s</div>`, introInHtml, article)
+	return fmt.Sprintf(`<div>%s<div><hr/><br/>%s</div>`, introInHtml, article)
 }
 
 func addIntroductionUsingLLM(item *feeds.Item, prompt string) string {
@@ -46,7 +46,7 @@ func addIntroductionUsingLLM(item *feeds.Item, prompt string) string {
 		introduction, err = getIntroductionForArticle(prompt, originalContent)
 	}
 	if err != nil {
-		errMsg := "add introduction for article failed."
+		errMsg := fmt.Sprintf("add introduction for article failed. err: %v ", err)
 		logrus.Warnf(errMsg)
 		introduction = errMsg
 	}

--- a/internal/util/cache.go
+++ b/internal/util/cache.go
@@ -43,12 +43,12 @@ func CachedFunc(cacheKey string, valFunc func() (string, error)) (string, error)
 	final := ""
 	cached, err := CacheGetString(cacheKey)
 	if err != nil || cached == "" {
-		translated, err := valFunc()
-		if err != nil {
-			return "", err
+		processedContent, getValErr := valFunc()
+		if getValErr != nil {
+			return "", getValErr
 		} else {
-			final = translated
-			cacheErr := CacheSetString(cacheKey, translated, constant.WebContentExpire)
+			final = processedContent
+			cacheErr := CacheSetString(cacheKey, processedContent, constant.WebContentExpire)
 			if cacheErr != nil {
 				logrus.Warn("failed to cache result")
 				//logrus.Warnf("failed to cache result of craft [%s] for article [%s], %v\n", craftName,


### PR DESCRIPTION
## Summary by Sourcery

Add HTML content cleanup functionality to improve article content processing by converting HTML to Markdown and back

New Features:
- Introduce a new 'cleanup' craft template that sanitizes HTML content by converting it to Markdown and back to clean HTML

Enhancements:
- Improve error logging with more descriptive error messages
- Modify code to use more descriptive variable names
- Enhance prompt formatting for LLM calls

Chores:
- Add a new cleanup module to handle HTML content sanitization