### PR TITLE
feat: update recipe timeout control

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -6,12 +6,12 @@ name: Docker Release
 # documentation.
 
 on:
-  schedule:
-    - cron: '35 3 * * *'
+#  schedule:
+#    - cron: '35 3 * * *'
   push:
     branches: [ "main" ]
     # Publish semver tags as releases.
-    tags: [ 'v*.*.*' ]
+    tags: [ 'v*.*', 'v*.*.*' ]
   pull_request:
     branches: [ "main" ]
   release:

--- a/internal/recipe/custom_recipe.go
+++ b/internal/recipe/custom_recipe.go
@@ -11,9 +11,12 @@ import (
 	"gorm.io/gorm"
 	"net/http"
 	"net/url"
+	"time"
 )
 
 var Scheduler *util.PreheatingScheduler
+
+var recipeMaxFetchTimeout = time.Minute * 10
 
 func QueryCustomRecipeName(recipeName string) (*dao.CustomRecipe, error) {
 	db := util.GetDatabase()
@@ -56,6 +59,8 @@ func RetrieveCraftRecipeUsingPath(path string) (*resty.Response, error) {
 }
 
 func newRecipeClient() *resty.Client {
-	client := resty.New().SetBaseURL(fmt.Sprintf("http://localhost:%d", util.GetLocalPort()))
+	client := resty.New().SetBaseURL(
+		fmt.Sprintf("http://localhost:%d", util.GetLocalPort()),
+	).SetTimeout(recipeMaxFetchTimeout)
 	return client
 }


### PR DESCRIPTION
## Summary by Sourcery

Introduce a 10-minute timeout for recipe fetching and refine the Docker publish CI workflow

Enhancements:
- Set a 10-minute timeout for the custom recipe HTTP client using a new recipeMaxFetchTimeout constant

CI:
- Disable the nightly cron schedule for Docker releases
- Expand Docker publish tag filters to include both v*.* and v*.*.* patterns