### PR TITLE
修复 v2.1 recipe id 找不到的问题

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -184,3 +184,13 @@ web/admin/dist
 .aider*
 .run
 main
+
+local.env
+run_local.sh
+run_local.ps1
+/data
+
+# Docker 构建和部署相关文件
+build.ps1
+push_docker.ps1
+docker-compose*.yml

--- a/.gitignore
+++ b/.gitignore
@@ -194,3 +194,7 @@ run_local.ps1
 build.ps1
 push_docker.ps1
 docker-compose*.yml
+
+# 构建产生的二进制文件
+feedcraft
+feedcraft.exe

--- a/internal/dao/recipe.go
+++ b/internal/dao/recipe.go
@@ -28,6 +28,10 @@ func CreateCustomRecipe(db *gorm.DB, recipe *CustomRecipe) error {
 // GetCustomRecipeByID retrieves a CustomRecipe record by its ID
 func GetCustomRecipeByID(db *gorm.DB, id string) (*CustomRecipe, error) {
 	var recipe CustomRecipe
+	// 添加日志记录查询的 ID
+	if id == "" {
+		return nil, gorm.ErrRecordNotFound
+	}
 	result := db.Where("id = ?", id).First(&recipe)
 	return &recipe, result.Error
 }

--- a/internal/recipe/custom_recipe.go
+++ b/internal/recipe/custom_recipe.go
@@ -25,7 +25,8 @@ func QueryCustomRecipeName(recipeName string) (*dao.CustomRecipe, error) {
 	if err != nil {
 		logrus.Errorf("查询 recipe 失败，ID: [%s], 错误: %v", recipeName, err)
 	} else {
-		logrus.Infof("成功找到 recipe，ID: [%s], Description: [%s]", recipe.ID, recipe.Description)
+		// Log only the recipe ID to avoid exposing sensitive or lengthy data
+		logrus.Infof("成功找到 recipe，ID: [%s]", recipe.ID)
 	}
 	return recipe, err
 }

--- a/internal/recipe/custom_recipe.go
+++ b/internal/recipe/custom_recipe.go
@@ -20,11 +20,19 @@ var recipeMaxFetchTimeout = time.Minute * 10
 
 func QueryCustomRecipeName(recipeName string) (*dao.CustomRecipe, error) {
 	db := util.GetDatabase()
-	return dao.GetCustomRecipeByID(db, recipeName)
+	logrus.Infof("正在查询 recipe，ID: [%s]", recipeName)
+	recipe, err := dao.GetCustomRecipeByID(db, recipeName)
+	if err != nil {
+		logrus.Errorf("查询 recipe 失败，ID: [%s], 错误: %v", recipeName, err)
+	} else {
+		logrus.Infof("成功找到 recipe，ID: [%s], Description: [%s]", recipe.ID, recipe.Description)
+	}
+	return recipe, err
 }
 
 func CustomRecipe(c *gin.Context) {
-	recipeId := c.Param("recipeId")
+	recipeId := c.Param("id")
+	logrus.Infof("获取到的 recipe ID: [%s]", recipeId)
 	recipe, err := QueryCustomRecipeName(recipeId)
 	if err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {


### PR DESCRIPTION
From cursor：

> 现在我发现了问题！在路由注册中，参数名是 :id，但在处理函数中却使用 c.Param("recipeId") 来获取参数。这导致获取到的是空字符串。
让我检查一下数据库中是否真的有这个记录：
现在我来修复这个问题。问题的根本原因是路由参数名不匹配：
在 internal/router/registry.go 中定义的路由是 /:id
但在 internal/recipe/custom_recipe.go 中使用的是 c.Param("recipeId")
这导致获取到的参数值为空字符串，所以数据库查询时 id = ""，当然找不到记录。

## Summary by Sourcery

Align route parameter with handler, guard against empty recipe IDs, and introduce logging around custom recipe queries to fix missing recipe lookup issues

Bug Fixes:
- Correct route parameter extraction by using c.Param("id") instead of "recipeId"
- Return ErrRecordNotFound when the recipe ID parameter is empty to prevent invalid queries

Enhancements:
- Add logrus logging for recipe ID retrieval and database query outcomes in custom recipe handlers