### PR TITLE
Palette: Add copy button to Quick Start URL

### DIFF
--- a/web/admin/components.d.ts
+++ b/web/admin/components.d.ts
@@ -5,11 +5,11 @@
 // Read more: https://github.com/vuejs/core/pull/3399
 import '@vue/runtime-core'
 
-export {};
+export {}
 
 declare module '@vue/runtime-core' {
   export interface GlobalComponents {
-    RouterLink: (typeof import('vue-router'))['RouterLink'];
-    RouterView: (typeof import('vue-router'))['RouterView'];
+    RouterLink: typeof import('vue-router')['RouterLink']
+    RouterView: typeof import('vue-router')['RouterView']
   }
 }

--- a/web/admin/components.d.ts
+++ b/web/admin/components.d.ts
@@ -5,11 +5,11 @@
 // Read more: https://github.com/vuejs/core/pull/3399
 import '@vue/runtime-core'
 
-export {}
+export {};
 
 declare module '@vue/runtime-core' {
   export interface GlobalComponents {
-    RouterLink: typeof import('vue-router')['RouterLink']
-    RouterView: typeof import('vue-router')['RouterView']
+    RouterLink: (typeof import('vue-router'))['RouterLink'];
+    RouterView: (typeof import('vue-router'))['RouterView'];
   }
 }

--- a/web/admin/src/views/dashboard/welcome/welcome.vue
+++ b/web/admin/src/views/dashboard/welcome/welcome.vue
@@ -56,12 +56,17 @@
         <a-row :gutter="20">
           <a-col :span="16">
             <a-card title="快速开始" :bordered="false" hoverable>
-              <p class="py-2">
+              <div class="py-2 flex items-center gap-2">
                 地址:
-                <span class="bg-slate-200 rounded-md border-0 px-2 py-0.5"
+                <span
+                  class="bg-slate-200 rounded-md border-0 px-2 py-0.5 font-mono"
                   >/craft/{choose_craft_option}?input_url={input_rss_url}</span
                 >
-              </p>
+                <a-button size="mini" @click="copyUrl">
+                  <template #icon><icon-copy /></template>
+                  {{ t('urlGenerator.copyUrl') }}
+                </a-button>
+              </div>
               可使用的Craft Option:
               <div class="grid grid-cols-2 gap-2">
                 <div>
@@ -119,6 +124,22 @@
 
 <script lang="ts" setup>
   import logo from '@/assets/logo.png';
+  import { useI18n } from 'vue-i18n';
+  import { Message } from '@arco-design/web-vue';
+  import { IconCopy } from '@arco-design/web-vue/es/icon';
+
+  const { t } = useI18n();
+
+  const copyUrl = async () => {
+    const text = '/craft/{choose_craft_option}?input_url={input_rss_url}';
+    try {
+      await navigator.clipboard.writeText(text);
+      Message.success(t('urlGenerator.copied'));
+    } catch (err) {
+      console.error(err);
+      Message.error('Failed to copy');
+    }
+  };
 </script>
 
 <script lang="ts">


### PR DESCRIPTION
💡 **What**: Added a "Copy" button next to the Quick Start URL template on the Dashboard Welcome page.
🎯 **Why**: Users often need to copy this URL pattern to construct their own feed URLs. Previously, they had to manually select and copy the text.
📸 **Before/After**: Added a button with a copy icon. Clicking it copies the text and shows a toast notification.
♿ **Accessibility**: Button has an icon and text label (localized).

Verified with Playwright and Lint checks.


---
*PR created automatically by Jules for task [10938355589130620321](https://jules.google.com/task/10938355589130620321) started by @Colin-XKL*

## Summary by Sourcery

Add a copy-to-clipboard action for the Quick Start URL on the dashboard welcome page.

New Features:
- Add a copy button with icon and label next to the Quick Start URL template that copies the URL pattern and shows a toast message.

Enhancements:
- Improve layout and readability of the Quick Start URL by using flex alignment and monospaced styling for the URL snippet.

Chores:
- Adjust TypeScript global components declaration formatting in components.d.ts without functional changes.