### PR TITLE
Palette: Improve Curl to RSS headers input UX

### DIFF
--- a/web/admin/src/views/dashboard/curl_to_rss/curl_to_rss.vue
+++ b/web/admin/src/views/dashboard/curl_to_rss/curl_to_rss.vue
@@ -123,18 +123,24 @@
                   </div>
                   <div class="flex gap-2">
                     <a-input
+                      ref="newHeaderKeyRef"
                       v-model="newHeaderKey"
                       :placeholder="$t('curlToRss.placeholder.key')"
                       style="width: 30%"
+                      @press-enter="addHeader"
                     />
                     <a-input
                       v-model="newHeaderVal"
                       :placeholder="$t('curlToRss.placeholder.value')"
                       style="width: 60%"
+                      @press-enter="addHeader"
                     />
-                    <a-button @click="addHeader">{{
-                      $t('curlToRss.step1.add')
-                    }}</a-button>
+                    <a-button
+                      :disabled="!newHeaderKey || !newHeaderVal"
+                      @click="addHeader"
+                    >
+                      {{ $t('curlToRss.step1.add') }}
+                    </a-button>
                   </div>
                 </a-space>
               </a-form-item>
@@ -539,6 +545,7 @@
   });
   const newHeaderKey = ref('');
   const newHeaderVal = ref('');
+  const newHeaderKeyRef = ref<any>(null);
 
   // Step 2 State
   const jsonContent = ref('');
@@ -639,7 +646,7 @@
         console.error('Invalid JSON content:', e);
         treeData.value = [];
       }
-    },
+    }
   );
 
   const getRelativePath = (fullPath: string, listSel: string) => {
@@ -659,7 +666,7 @@
 
   const handleNodeSelect = (
     selectedKeys: (string | number)[],
-    { node }: { node: TreeNodeData },
+    { node }: { node: TreeNodeData }
   ) => {
     if (!activeField.value || !node.key) return;
 
@@ -702,7 +709,7 @@
       if (val === 4 && !recipeMeta.id && feedMeta.title) {
         recipeMeta.id = kebabCase(feedMeta.title);
       }
-    },
+    }
   );
 
   // Step 1 Logic
@@ -711,6 +718,7 @@
       fetchReq.headers[newHeaderKey.value] = newHeaderVal.value;
       newHeaderKey.value = '';
       newHeaderVal.value = '';
+      newHeaderKeyRef.value?.focus();
     }
   };
 
@@ -823,7 +831,7 @@
         Message.warning(t('curlToRss.msg.noItems'));
       } else {
         Message.success(
-          t('curlToRss.msg.parsedItems', { count: parsedItems.value.length }),
+          t('curlToRss.msg.parsedItems', { count: parsedItems.value.length })
         );
       }
     } catch (err) {

--- a/web/admin/src/views/dashboard/curl_to_rss/curl_to_rss.vue
+++ b/web/admin/src/views/dashboard/curl_to_rss/curl_to_rss.vue
@@ -646,7 +646,7 @@
         console.error('Invalid JSON content:', e);
         treeData.value = [];
       }
-    }
+    },
   );
 
   const getRelativePath = (fullPath: string, listSel: string) => {
@@ -666,7 +666,7 @@
 
   const handleNodeSelect = (
     selectedKeys: (string | number)[],
-    { node }: { node: TreeNodeData }
+    { node }: { node: TreeNodeData },
   ) => {
     if (!activeField.value || !node.key) return;
 
@@ -709,7 +709,7 @@
       if (val === 4 && !recipeMeta.id && feedMeta.title) {
         recipeMeta.id = kebabCase(feedMeta.title);
       }
-    }
+    },
   );
 
   // Step 1 Logic
@@ -831,7 +831,7 @@
         Message.warning(t('curlToRss.msg.noItems'));
       } else {
         Message.success(
-          t('curlToRss.msg.parsedItems', { count: parsedItems.value.length })
+          t('curlToRss.msg.parsedItems', { count: parsedItems.value.length }),
         );
       }
     } catch (err) {


### PR DESCRIPTION
This PR improves the user experience of the Headers input section in the "Curl to RSS" wizard.

Changes:
- Bound the "Enter" key on both Key and Value inputs to trigger the "Add" action.
- Added a disabled state to the "Add" button when inputs are empty.
- Implemented auto-focus on the Key input after a header is added to facilitate bulk entry.
- Switched to `@press-enter` event listener for Arco Design Vue compatibility.

Verified with local Playwright script ensuring headers can be added via keyboard and UI updates correctly.

---
*PR created automatically by Jules for task [11313820277923603721](https://jules.google.com/task/11313820277923603721) started by @Colin-XKL*

## Summary by Sourcery

Improve the headers input experience in the Curl to RSS wizard by enabling keyboard-driven header addition, validating inputs before adding, and refocusing for faster bulk entry.

New Features:
- Allow adding headers from the Curl to RSS wizard using the Enter key in either the key or value input fields.

Enhancements:
- Disable the header Add button unless both key and value fields are populated to prevent invalid entries.
- Automatically refocus the header key input after a header is added to streamline bulk input.