### PR TITLE
Palette: Make Feed Viewer metadata links clickable and copyable

### DIFF
--- a/web/admin/components.d.ts
+++ b/web/admin/components.d.ts
@@ -5,11 +5,11 @@
 // Read more: https://github.com/vuejs/core/pull/3399
 import '@vue/runtime-core'
 
-export {};
+export {}
 
 declare module '@vue/runtime-core' {
   export interface GlobalComponents {
-    RouterLink: (typeof import('vue-router'))['RouterLink'];
-    RouterView: (typeof import('vue-router'))['RouterView'];
+    RouterLink: typeof import('vue-router')['RouterLink']
+    RouterView: typeof import('vue-router')['RouterView']
   }
 }

--- a/web/admin/components.d.ts
+++ b/web/admin/components.d.ts
@@ -5,11 +5,11 @@
 // Read more: https://github.com/vuejs/core/pull/3399
 import '@vue/runtime-core'
 
-export {}
+export {};
 
 declare module '@vue/runtime-core' {
   export interface GlobalComponents {
-    RouterLink: typeof import('vue-router')['RouterLink']
-    RouterView: typeof import('vue-router')['RouterView']
+    RouterLink: (typeof import('vue-router'))['RouterLink'];
+    RouterView: (typeof import('vue-router'))['RouterView'];
   }
 }

--- a/web/admin/src/locale/en-US/feedViewer.ts
+++ b/web/admin/src/locale/en-US/feedViewer.ts
@@ -10,4 +10,7 @@ export default {
   'feedViewer.viewModeNormal': 'Normal',
   'feedViewer.viewModeRich': 'Rich Text',
   'feedViewer.message.unknownError': 'Unknown Error',
+  'feedViewer.copy': 'Copy',
+  'feedViewer.copied': 'Copied!',
+  'feedViewer.copyFailed': 'Copy Failed',
 };

--- a/web/admin/src/locale/zh-CN/feedViewer.ts
+++ b/web/admin/src/locale/zh-CN/feedViewer.ts
@@ -9,4 +9,7 @@ export default {
   'feedViewer.viewModeNormal': '普通',
   'feedViewer.viewModeRich': '富文本',
   'feedViewer.message.unknownError': '未知错误',
+  'feedViewer.copy': '复制',
+  'feedViewer.copied': '已复制!',
+  'feedViewer.copyFailed': '复制失败',
 };


### PR DESCRIPTION
This PR enhances the UX of the Feed Viewer tool by making URL fields in the feed metadata interactive. Previously, links were displayed as plain text. Now, any metadata value that appears to be a URL (starting with http/https) is rendered as a clickable link with an adjacent "Copy" button. This reduces friction for users who need to grab feed URLs or visiting site links.

**Changes:**
- `web/admin/src/views/dashboard/feed_viewer/feed_view_container.vue`: logic to detect URLs and render copy button.
- `web/admin/src/locale/en-US/feedViewer.ts`: Added localization keys.
- `web/admin/src/locale/zh-CN/feedViewer.ts`: Added localization keys.


---
*PR created automatically by Jules for task [17907384758243071250](https://jules.google.com/task/17907384758243071250) started by @Colin-XKL*

## Summary by Sourcery

Improve the Feed Viewer metadata panel by making URL fields interactive and enhancing value rendering.

New Features:
- Render feed metadata values that look like URLs as clickable links with a one-click copy-to-clipboard control.

Enhancements:
- Format non-URL metadata values more readably, including pretty-printing object values.
- Align Vue global components typing definitions with the project’s preferred style.
- Add localized copy-related messages to the Feed Viewer in English and Chinese.