### PR TITLE
Palette: Add paste button to Feed Viewer

### DIFF
--- a/web/admin/components.d.ts
+++ b/web/admin/components.d.ts
@@ -5,11 +5,11 @@
 // Read more: https://github.com/vuejs/core/pull/3399
 import '@vue/runtime-core'
 
-export {};
+export {}
 
 declare module '@vue/runtime-core' {
   export interface GlobalComponents {
-    RouterLink: (typeof import('vue-router'))['RouterLink'];
-    RouterView: (typeof import('vue-router'))['RouterView'];
+    RouterLink: typeof import('vue-router')['RouterLink']
+    RouterView: typeof import('vue-router')['RouterView']
   }
 }

--- a/web/admin/components.d.ts
+++ b/web/admin/components.d.ts
@@ -5,11 +5,11 @@
 // Read more: https://github.com/vuejs/core/pull/3399
 import '@vue/runtime-core'
 
-export {}
+export {};
 
 declare module '@vue/runtime-core' {
   export interface GlobalComponents {
-    RouterLink: typeof import('vue-router')['RouterLink']
-    RouterView: typeof import('vue-router')['RouterView']
+    RouterLink: (typeof import('vue-router'))['RouterLink'];
+    RouterView: (typeof import('vue-router'))['RouterView'];
   }
 }

--- a/web/admin/src/views/dashboard/feed_viewer/feed_viewer.vue
+++ b/web/admin/src/views/dashboard/feed_viewer/feed_viewer.vue
@@ -14,8 +14,14 @@
           type="text"
           :placeholder="t('feedViewer.placeholder')"
           allow-clear
-          @keyup.enter="fetchFeed"
-        />
+          @press-enter="fetchFeed"
+        >
+          <template #append>
+            <a-button @click="handlePaste">
+              <template #icon><icon-paste /></template>
+            </a-button>
+          </template>
+        </a-input>
         <a-button
           :loading="isLoading"
           :disabled="!feedUrl"
@@ -41,6 +47,7 @@
   import { computed, ref, onMounted } from 'vue';
   import Parser from 'rss-parser';
   import { Message } from '@arco-design/web-vue';
+  import { IconPaste } from '@arco-design/web-vue/es/icon';
   import FeedViewContainer from '@/views/dashboard/feed_viewer/feed_view_container.vue';
   import XHeader from '@/components/header/x-header.vue';
   import { useI18n } from 'vue-i18n';
@@ -54,11 +61,22 @@
   const isLoading = ref(false);
   const baseUrl = import.meta.env.VITE_API_BASE_URL ?? '';
 
+  async function handlePaste() {
+    try {
+      const text = await navigator.clipboard.readText();
+      if (text) {
+        feedUrl.value = text;
+      }
+    } catch (error) {
+      Message.warning('Failed to read clipboard');
+    }
+  }
+
   async function fetchFeed() {
     if (!feedUrl.value) return;
     isLoading.value = true;
     const requestUrl = `${baseUrl}/craft/proxy?input_url=${encodeURIComponent(
-      feedUrl.value,
+      feedUrl.value
     )}`;
     try {
       const parser = new Parser();
@@ -69,7 +87,7 @@
       feedContent.value = feed;
     } catch (error) {
       Message.warning(
-        error?.toString() ?? t('feedViewer.message.unknownError'),
+        error?.toString() ?? t('feedViewer.message.unknownError')
       );
       console.error(error);
     } finally {

--- a/web/admin/src/views/dashboard/feed_viewer/feed_viewer.vue
+++ b/web/admin/src/views/dashboard/feed_viewer/feed_viewer.vue
@@ -76,7 +76,7 @@
     if (!feedUrl.value) return;
     isLoading.value = true;
     const requestUrl = `${baseUrl}/craft/proxy?input_url=${encodeURIComponent(
-      feedUrl.value
+      feedUrl.value,
     )}`;
     try {
       const parser = new Parser();
@@ -87,7 +87,7 @@
       feedContent.value = feed;
     } catch (error) {
       Message.warning(
-        error?.toString() ?? t('feedViewer.message.unknownError')
+        error?.toString() ?? t('feedViewer.message.unknownError'),
       );
       console.error(error);
     } finally {


### PR DESCRIPTION
💡 What: Added a "Paste" button to the Feed Viewer input field.
🎯 Why: Users frequently copy feed URLs from other tabs. A dedicated paste button saves a click/key combination and makes the interface smoother.
📸 Before/After: Added a small button with paste icon next to the input.
♿ Accessibility: Button is keyboard accessible via standard button behavior.


---
*PR created automatically by Jules for task [1515745254165649827](https://jules.google.com/task/1515745254165649827) started by @Colin-XKL*

## Summary by Sourcery

Add a clipboard paste button to the Feed Viewer URL input to streamline pasting feed URLs from the clipboard.

New Features:
- Add a paste button with an icon to the Feed Viewer input that reads a URL from the clipboard and populates the field.

Enhancements:
- Align input enter behavior with the component’s press-enter event and clean up minor TypeScript declaration formatting.