### PR TITLE
docs: add documentation for system tools (viewer, compare, health)

### DIFF
--- a/doc-site/src/content/docs/en/guides/advanced/customization.md
+++ b/doc-site/src/content/docs/en/guides/advanced/customization.md
@@ -50,6 +50,8 @@ Use this dashboard to troubleshoot connectivity issues if features like "Enhance
 
 You can use the **Check Connection** button to verify if FeedCraft can successfully connect to the search provider with the provided credentials.
 
+> **Note:** For monitoring internal Craft dependencies (Recipes, Flows, Atoms), use the [Craft Dependencies](/en/guides/advanced/tools#craft-dependencies) tool.
+
 ## Advanced Configuration
 
 ### Docker Environment Variables

--- a/doc-site/src/content/docs/en/guides/advanced/tools.md
+++ b/doc-site/src/content/docs/en/guides/advanced/tools.md
@@ -1,0 +1,57 @@
+---
+title: System Tools
+description: Built-in tools for debugging feeds, comparing outputs, and checking system health.
+sidebar:
+  order: 5
+---
+
+FeedCraft provides several built-in tools to help you debug your RSS feeds and monitor the system's health. You can access these tools under the **Tools** menu in the admin dashboard.
+
+## RSS Viewer
+
+The **RSS Viewer** (Feed Viewer) allows you to preview any RSS feed as FeedCraft sees it.
+
+- **Usage**:
+  1. Navigate to **Tools > RSS Viewer**.
+  2. Enter an RSS/Atom URL.
+  3. Click **Preview**.
+- **Purpose**: Verify if FeedCraft can successfully fetch and parse a feed before setting up a recipe.
+- **Note**: The viewer uses the `proxy` craft by default, which simply fetches the feed without modification.
+
+## Feed Compare
+
+The **Feed Compare** tool lets you visualize the effect of a Craft (Atom or Flow) on a feed.
+
+- **Usage**:
+  1. Navigate to **Tools > Feed Compare**.
+  2. Enter the original RSS feed URL.
+  3. Select a **FlowCraft** or **AtomCraft** to apply.
+  4. Click **Compare**.
+- **Output**: The tool displays two columns:
+  - **Left**: The original feed content.
+  - **Right**: The feed content after being processed by the selected Craft.
+- **Use Case**: Great for testing new translation flows or summarization prompts without creating a permanent recipe.
+
+## Craft Dependencies
+
+The **Craft Dependencies** (System Health) tool visualizes the internal relationships between your Recipes, FlowCrafts, and AtomCrafts.
+
+- **Usage**:
+  1. Navigate to **Tools > Craft Dependencies**.
+  2. Click **Analyze Craft Dependencies**.
+- **Features**:
+  - Generates a tree view of all dependencies.
+  - **Health Check**: Automatically detects missing dependencies (e.g., a Recipe pointing to a deleted FlowCraft).
+  - **Visual Indicators**: Different colors for Recipes, Flows, Atoms, and missing components.
+
+> **Tip:** If you encounter errors like "Craft not found", use this tool to trace the broken link in your configuration.
+
+## Debug Tools
+
+### LLM Debug
+
+A sandbox for testing your LLM configuration. You can send test prompts to your configured LLM provider to verify connectivity and model response.
+
+### Ad Check Debug
+
+A specific tool for testing the "Ignore Advertorial" filter logic against specific content to understand why an article might be filtered out.

--- a/doc-site/src/content/docs/zh-tw/guides/advanced/customization.md
+++ b/doc-site/src/content/docs/zh-tw/guides/advanced/customization.md
@@ -50,6 +50,8 @@ sidebar:
 
 你可以使用 **檢查連線 (Check Connection)** 按鈕來驗證 FeedCraft 是否可以成功連線到配置的搜尋供應商。
 
+> **注意：** 如需監控內部 Craft 依賴關係（Recipes, Flows, Atoms），請使用 [Craft 依賴檢查](/zh-tw/guides/advanced/tools) 工具。
+
 ## 進階配置
 
 ### Docker 環境變數

--- a/doc-site/src/content/docs/zh-tw/guides/advanced/tools.md
+++ b/doc-site/src/content/docs/zh-tw/guides/advanced/tools.md
@@ -1,0 +1,57 @@
+---
+title: 系統工具
+description: 內建的除錯、比對和系統健康檢查工具。
+sidebar:
+  order: 5
+---
+
+FeedCraft 提供了一些內建工具來幫助您除錯 RSS 來源並監控系統健康狀況。您可以在管理後台的 **工具 (Tools)** 選單下訪問這些工具。
+
+## RSS 預覽 (RSS Viewer)
+
+**RSS 預覽** (Feed Viewer) 允許您按照 FeedCraft 的解析方式預覽任何 RSS 來源。
+
+- **使用方法**:
+  1. 導航至 **工具 > RSS 預覽**。
+  2. 輸入一個 RSS/Atom 地址。
+  3. 點擊 **預覽 (Preview)**。
+- **目的**: 在設定配方 (Recipe) 之前，驗證 FeedCraft 是否能夠成功抓取和解析某個 Feed。
+- **注意**: 預覽器默認使用 `proxy` 工藝，它只是簡單地抓取 Feed 而不進行修改。
+
+## Feed 比對 (Feed Compare)
+
+**Feed 比對** 工具讓您可以直觀地看到某個 Craft（Atom 或 Flow）對 Feed 的處理效果。
+
+- **使用方法**:
+  1. 導航至 **工具 > Feed 比對**。
+  2. 輸入原始 RSS Feed 地址。
+  3. 選擇一個 **FlowCraft** 或 **AtomCraft**。
+  4. 點擊 **比對 (Compare)**。
+- **輸出**: 工具顯示兩列：
+  - **左側**: 原始 Feed 內容。
+  - **右側**: 經過選定 Craft 處理後的 Feed 內容。
+- **應用場景**: 非常適合測試新的翻譯流程或摘要提示詞，而無需創建永久配方。
+
+## Craft 依賴檢查 (Craft Dependencies)
+
+**Craft 依賴檢查** (System Health) 工具可視化您的 Recipes、FlowCrafts 和 AtomCrafts 之間的內部關係。
+
+- **使用方法**:
+  1. 導航至 **工具 > Craft 依賴檢查**。
+  2. 點擊 **分析 Craft 依賴 (Analyze Craft Dependencies)**。
+- **功能**:
+  - 生成所有依賴關係的樹狀視圖。
+  - **健康檢查**: 自動檢測丟失的依賴項（例如，指向已刪除 FlowCraft 的 Recipe）。
+  - **視覺指示**: Recipes、Flows、Atoms 和丟失組件使用不同顏色標識。
+
+> **提示:** 如果遇到 "Craft not found" 等錯誤，可以使用此工具追蹤配置中的斷鏈。
+
+## 除錯工具 (Debug Tools)
+
+### LLM 除錯 (LLM Debug)
+
+用於測試 LLM 配置的沙盒。您可以向配置的 LLM 提供商發送測試提示，以驗證連接和模型響應。
+
+### 廣告檢測除錯 (Ad Check Debug)
+
+用於針對特定內容測試 "忽略軟文 (Ignore Advertorial)" 過濾邏輯的專用工具，以了解文章被過濾的原因。

--- a/doc-site/src/content/docs/zh/guides/advanced/customization.md
+++ b/doc-site/src/content/docs/zh/guides/advanced/customization.md
@@ -50,6 +50,8 @@ sidebar:
 
 你可以使用 **检查连接 (Check Connection)** 按钮来验证 FeedCraft 是否可以成功连接到配置的搜索提供商。
 
+> **注意：** 如需监控内部 Craft 依赖关系（Recipes, Flows, Atoms），请使用 [Craft 依赖检查](/zh/guides/advanced/tools) 工具。
+
 ## 高级配置
 
 ### Docker 环境变量

--- a/doc-site/src/content/docs/zh/guides/advanced/tools.md
+++ b/doc-site/src/content/docs/zh/guides/advanced/tools.md
@@ -1,0 +1,57 @@
+---
+title: 系统工具
+description: 内置的调试、对比和系统健康检查工具。
+sidebar:
+  order: 5
+---
+
+FeedCraft 提供了一些内置工具来帮助您调试 RSS 源并监控系统健康状况。您可以在管理后台的 **工具 (Tools)** 菜单下访问这些工具。
+
+## RSS 预览 (RSS Viewer)
+
+**RSS 预览** (Feed Viewer) 允许您按照 FeedCraft 的解析方式预览任何 RSS 源。
+
+- **使用方法**:
+  1. 导航至 **工具 > RSS 预览**。
+  2. 输入一个 RSS/Atom 地址。
+  3. 点击 **预览 (Preview)**。
+- **目的**: 在设置配方 (Recipe) 之前，验证 FeedCraft 是否能够成功抓取和解析某个 Feed。
+- **注意**: 预览器默认使用 `proxy` 工艺，它只是简单地抓取 Feed 而不进行修改。
+
+## Feed 对比 (Feed Compare)
+
+**Feed 对比** 工具让您可以直观地看到某个 Craft（Atom 或 Flow）对 Feed 的处理效果。
+
+- **使用方法**:
+  1. 导航至 **工具 > Feed 对比**。
+  2. 输入原始 RSS Feed 地址。
+  3. 选择一个 **FlowCraft** 或 **AtomCraft**。
+  4. 点击 **对比 (Compare)**。
+- **输出**: 工具显示两列：
+  - **左侧**: 原始 Feed 内容。
+  - **右侧**: 经过选定 Craft 处理后的 Feed 内容。
+- **应用场景**: 非常适合测试新的翻译流程或摘要提示词，而无需创建永久配方。
+
+## Craft 依赖检查 (Craft Dependencies)
+
+**Craft 依赖检查** (System Health) 工具可视化您的 Recipes、FlowCrafts 和 AtomCrafts 之间的内部关系。
+
+- **使用方法**:
+  1. 导航至 **工具 > Craft 依赖检查**。
+  2. 点击 **分析 Craft 依赖 (Analyze Craft Dependencies)**。
+- **功能**:
+  - 生成所有依赖关系的树状视图。
+  - **健康检查**: 自动检测丢失的依赖项（例如，指向已删除 FlowCraft 的 Recipe）。
+  - **视觉指示**: Recipes、Flows、Atoms 和丢失组件使用不同颜色标识。
+
+> **提示:** 如果遇到 "Craft not found" 等错误，可以使用此工具追踪配置中的断链。
+
+## 调试工具 (Debug Tools)
+
+### LLM 调试 (LLM Debug)
+
+用于测试 LLM 配置的沙盒。您可以向配置的 LLM 提供商发送测试提示，以验证连接和模型响应。
+
+### 广告检测调试 (Ad Check Debug)
+
+用于针对特定内容测试 "忽略软文 (Ignore Advertorial)" 过滤逻辑的专用工具，以了解文章被过滤的原因。


### PR DESCRIPTION
Documented new admin tools (RSS Viewer, Feed Compare, Craft Dependencies) in `doc-site/src/content/docs/*/guides/advanced/tools.md` and added cross-references in `doc-site/src/content/docs/*/guides/advanced/customization.md`. Verified build with `astro build`.

---
*PR created automatically by Jules for task [18305110831657352827](https://jules.google.com/task/18305110831657352827) started by @Colin-XKL*

## Summary by Sourcery

Document system tools available in the admin dashboard and reference them from advanced customization guides in all supported languages.

Documentation:
- Add a new System Tools guide (RSS Viewer, Feed Compare, Craft Dependencies, debug tools) to the advanced section of the English documentation.
- Add localized System Tools guides for Traditional Chinese and Simplified Chinese, covering RSS preview, feed comparison, dependency health checks, and debug tools.
- Link from advanced customization guides to the Craft Dependencies/System Tools pages for monitoring internal Craft dependencies in all supported languages.