### PR TITLE
fix(source): correct jq expressions in search provider configs

### DIFF
--- a/internal/source/fetcher/provider/litellm.go
+++ b/internal/source/fetcher/provider/litellm.go
@@ -77,10 +77,10 @@ func (p *LiteLLMProvider) Fetch(ctx context.Context, query string) ([]byte, erro
 
 func (p *LiteLLMProvider) GetDefaultParserConfig() *config.JsonParserConfig {
 	return &config.JsonParserConfig{
-		ItemsIterator: "results",
-		Title:         "title",
-		Link:          "url",
-		Description:   "snippet",
+		ItemsIterator: ".results",
+		Title:         ".title",
+		Link:          ".url",
+		Description:   ".snippet",
 		// Date might vary, usually not standard in simple search results
 	}
 }

--- a/internal/source/fetcher/provider/litellm_test.go
+++ b/internal/source/fetcher/provider/litellm_test.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"FeedCraft/internal/config"
+	"FeedCraft/internal/source/parser"
 	"context"
 	"net/http"
 	"net/http/httptest"
@@ -10,8 +11,23 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestLiteLLMProvider_Fetch(t *testing.T) {
-	mockResponse := `{"results": [{"title": "Test Title", "url": "https://example.com", "snippet": "Test Content"}]}`
+func TestLiteLLMProvider_EndToEnd(t *testing.T) {
+	// Standard API response from LiteLLM (often similar to OpenAI/Bing search results)
+	mockResponse := `{
+  "results": [
+    {
+      "url": "https://example.com/litellm1",
+      "title": "LiteLLM Title 1",
+      "snippet": "This is a snippet for the first result."
+    },
+    {
+      "url": "https://example.com/litellm2",
+      "title": "LiteLLM Title 2",
+      "snippet": "Snippet for the second LiteLLM search result."
+    }
+  ]
+}`
+
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, "/", r.URL.Path)
 		assert.Equal(t, "POST", r.Method)
@@ -25,18 +41,30 @@ func TestLiteLLMProvider_Fetch(t *testing.T) {
 	}
 
 	provider := NewLiteLLMProvider(cfg)
-	data, err := provider.Fetch(context.Background(), "test")
 
+	// 1. Fetch the data
+	data, err := provider.Fetch(context.Background(), "test litellm query")
 	assert.NoError(t, err)
-	assert.Contains(t, string(data), "Test Title")
-}
+	assert.NotNil(t, data)
 
-func TestLiteLLMProvider_GetDefaultParserConfig(t *testing.T) {
-	provider := NewLiteLLMProvider(&config.SearchProviderConfig{})
-	cfg := provider.GetDefaultParserConfig()
+	// 2. Parse the data using the default parser configuration
+	parserConfig := provider.GetDefaultParserConfig()
+	jsonParser := &parser.JsonParser{Config: parserConfig}
 
-	assert.Equal(t, ".results", cfg.ItemsIterator)
-	assert.Equal(t, ".title", cfg.Title)
-	assert.Equal(t, ".url", cfg.Link)
-	assert.Equal(t, ".snippet", cfg.Description)
+	feed, err := jsonParser.Parse(data)
+	assert.NoError(t, err)
+	assert.NotNil(t, feed)
+
+	// 3. Verify the parsed feed items
+	assert.Len(t, feed.Items, 2)
+
+	// First item verification
+	assert.Equal(t, "LiteLLM Title 1", feed.Items[0].Title)
+	assert.Equal(t, "https://example.com/litellm1", feed.Items[0].Link)
+	assert.Equal(t, "This is a snippet for the first result.", feed.Items[0].Description)
+
+	// Second item verification
+	assert.Equal(t, "LiteLLM Title 2", feed.Items[1].Title)
+	assert.Equal(t, "https://example.com/litellm2", feed.Items[1].Link)
+	assert.Equal(t, "Snippet for the second LiteLLM search result.", feed.Items[1].Description)
 }

--- a/internal/source/fetcher/provider/litellm_test.go
+++ b/internal/source/fetcher/provider/litellm_test.go
@@ -1,0 +1,42 @@
+package provider
+
+import (
+	"FeedCraft/internal/config"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLiteLLMProvider_Fetch(t *testing.T) {
+	mockResponse := `{"results": [{"title": "Test Title", "url": "https://example.com", "snippet": "Test Content"}]}`
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/", r.URL.Path)
+		assert.Equal(t, "POST", r.Method)
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(mockResponse))
+	}))
+	defer ts.Close()
+
+	cfg := &config.SearchProviderConfig{
+		APIUrl: ts.URL,
+	}
+
+	provider := NewLiteLLMProvider(cfg)
+	data, err := provider.Fetch(context.Background(), "test")
+
+	assert.NoError(t, err)
+	assert.Contains(t, string(data), "Test Title")
+}
+
+func TestLiteLLMProvider_GetDefaultParserConfig(t *testing.T) {
+	provider := NewLiteLLMProvider(&config.SearchProviderConfig{})
+	cfg := provider.GetDefaultParserConfig()
+
+	assert.Equal(t, ".results", cfg.ItemsIterator)
+	assert.Equal(t, ".title", cfg.Title)
+	assert.Equal(t, ".url", cfg.Link)
+	assert.Equal(t, ".snippet", cfg.Description)
+}

--- a/internal/source/fetcher/provider/litellm_test.go
+++ b/internal/source/fetcher/provider/litellm_test.go
@@ -16,7 +16,7 @@ func TestLiteLLMProvider_Fetch(t *testing.T) {
 		assert.Equal(t, "/", r.URL.Path)
 		assert.Equal(t, "POST", r.Method)
 		w.Header().Set("Content-Type", "application/json")
-		w.Write([]byte(mockResponse))
+		_, _ = w.Write([]byte(mockResponse))
 	}))
 	defer ts.Close()
 

--- a/internal/source/fetcher/provider/searxng.go
+++ b/internal/source/fetcher/provider/searxng.go
@@ -74,10 +74,10 @@ func (p *SearXNGProvider) Fetch(ctx context.Context, query string) ([]byte, erro
 
 func (p *SearXNGProvider) GetDefaultParserConfig() *config.JsonParserConfig {
 	return &config.JsonParserConfig{
-		ItemsIterator: "results",
-		Title:         "title",
-		Link:          "url",
-		Description:   "content",
-		Date:          "publishedDate",
+		ItemsIterator: ".results",
+		Title:         ".title",
+		Link:          ".url",
+		Description:   ".content",
+		Date:          ".publishedDate",
 	}
 }

--- a/internal/source/fetcher/provider/searxng_test.go
+++ b/internal/source/fetcher/provider/searxng_test.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"FeedCraft/internal/config"
+	"FeedCraft/internal/source/parser"
 	"context"
 	"net/http"
 	"net/http/httptest"
@@ -10,12 +11,35 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestSearXNGProvider_Fetch(t *testing.T) {
-	// Create a mock SearXNG server
-	mockResponse := `{"query": "test", "results": [{"title": "Test Title", "url": "https://example.com", "content": "Test Content", "publishedDate": "2023-10-01"}]}`
+func TestSearXNGProvider_EndToEnd(t *testing.T) {
+	// Standard API response from SearXNG
+	mockResponse := `{
+  "query": "test query",
+  "number_of_results": 2,
+  "results": [
+    {
+      "url": "https://example.com/1",
+      "title": "Example Domain 1",
+      "content": "This domain is for use in illustrative examples.",
+      "publishedDate": "2023-10-01T10:00:00Z",
+      "engine": "google"
+    },
+    {
+      "url": "https://example.com/2",
+      "title": "Example Domain 2",
+      "content": "More illustrative examples here.",
+      "engine": "bing"
+    }
+  ],
+  "answers": [],
+  "corrections": [],
+  "infoboxes": [],
+  "suggestions": []
+}`
+
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, "/search", r.URL.Path)
-		assert.Equal(t, "test", r.URL.Query().Get("q"))
+		assert.Equal(t, "test query", r.URL.Query().Get("q"))
 		assert.Equal(t, "json", r.URL.Query().Get("format"))
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(mockResponse))
@@ -30,19 +54,32 @@ func TestSearXNGProvider_Fetch(t *testing.T) {
 	}
 
 	provider := NewSearXNGProvider(cfg)
-	data, err := provider.Fetch(context.Background(), "test")
 
+	// 1. Fetch the data
+	data, err := provider.Fetch(context.Background(), "test query")
 	assert.NoError(t, err)
-	assert.Contains(t, string(data), "Test Title")
-}
+	assert.NotNil(t, data)
 
-func TestSearXNGProvider_GetDefaultParserConfig(t *testing.T) {
-	provider := NewSearXNGProvider(&config.SearchProviderConfig{})
-	cfg := provider.GetDefaultParserConfig()
+	// 2. Parse the data using the default parser configuration
+	parserConfig := provider.GetDefaultParserConfig()
+	jsonParser := &parser.JsonParser{Config: parserConfig}
 
-	assert.Equal(t, ".results", cfg.ItemsIterator)
-	assert.Equal(t, ".title", cfg.Title)
-	assert.Equal(t, ".url", cfg.Link)
-	assert.Equal(t, ".content", cfg.Description)
-	assert.Equal(t, ".publishedDate", cfg.Date)
+	feed, err := jsonParser.Parse(data)
+	assert.NoError(t, err)
+	assert.NotNil(t, feed)
+
+	// 3. Verify the parsed feed items
+	assert.Len(t, feed.Items, 2)
+
+	// First item verification
+	assert.Equal(t, "Example Domain 1", feed.Items[0].Title)
+	assert.Equal(t, "https://example.com/1", feed.Items[0].Link)
+	assert.Equal(t, "This domain is for use in illustrative examples.", feed.Items[0].Description)
+	assert.Equal(t, "2023-10-01T10:00:00Z", feed.Items[0].Published)
+
+	// Second item verification (missing publishedDate)
+	assert.Equal(t, "Example Domain 2", feed.Items[1].Title)
+	assert.Equal(t, "https://example.com/2", feed.Items[1].Link)
+	assert.Equal(t, "More illustrative examples here.", feed.Items[1].Description)
+	assert.Empty(t, feed.Items[1].Published)
 }

--- a/internal/source/fetcher/provider/searxng_test.go
+++ b/internal/source/fetcher/provider/searxng_test.go
@@ -1,0 +1,48 @@
+package provider
+
+import (
+	"FeedCraft/internal/config"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSearXNGProvider_Fetch(t *testing.T) {
+	// Create a mock SearXNG server
+	mockResponse := `{"query": "test", "results": [{"title": "Test Title", "url": "https://example.com", "content": "Test Content", "publishedDate": "2023-10-01"}]}`
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/search", r.URL.Path)
+		assert.Equal(t, "test", r.URL.Query().Get("q"))
+		assert.Equal(t, "json", r.URL.Query().Get("format"))
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(mockResponse))
+	}))
+	defer ts.Close()
+
+	cfg := &config.SearchProviderConfig{
+		APIUrl: ts.URL,
+		SearXNG: struct {
+			Engines string `json:"engines"`
+		}{},
+	}
+
+	provider := NewSearXNGProvider(cfg)
+	data, err := provider.Fetch(context.Background(), "test")
+
+	assert.NoError(t, err)
+	assert.Contains(t, string(data), "Test Title")
+}
+
+func TestSearXNGProvider_GetDefaultParserConfig(t *testing.T) {
+	provider := NewSearXNGProvider(&config.SearchProviderConfig{})
+	cfg := provider.GetDefaultParserConfig()
+
+	assert.Equal(t, ".results", cfg.ItemsIterator)
+	assert.Equal(t, ".title", cfg.Title)
+	assert.Equal(t, ".url", cfg.Link)
+	assert.Equal(t, ".content", cfg.Description)
+	assert.Equal(t, ".publishedDate", cfg.Date)
+}

--- a/internal/source/fetcher/provider/searxng_test.go
+++ b/internal/source/fetcher/provider/searxng_test.go
@@ -18,7 +18,7 @@ func TestSearXNGProvider_Fetch(t *testing.T) {
 		assert.Equal(t, "test", r.URL.Query().Get("q"))
 		assert.Equal(t, "json", r.URL.Query().Get("format"))
 		w.Header().Set("Content-Type", "application/json")
-		w.Write([]byte(mockResponse))
+		_, _ = w.Write([]byte(mockResponse))
 	}))
 	defer ts.Close()
 


### PR DESCRIPTION
### **User description**
The search-to-rss functionality was failing with an error `Generation failed: parse failed: jq execution failed: function not defined: results/0`. This was happening because `gojq` requires a leading dot (e.g. `.results` instead of `results`) for identifiers; without it, they are interpreted as function calls. 
This PR corrects the `ItemsIterator` and item mapping configuration literals (like `Title`, `Link`, etc.) in `SearXNGProvider` and `LiteLLMProvider` so that they return correct gojq expressions in their `GetDefaultParserConfig()` functions. Unit tests have also been added for these providers to assert correct fetch and parser configuration formats.

---
*PR created automatically by Jules for task [18181523111051140494](https://jules.google.com/task/18181523111051140494) started by @Colin-XKL*


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Fixed jq expression syntax in search provider configs by prepending dots
  - ItemsIterator, Title, Link, Description, Date fields now use `.field` format

- Added unit tests for SearXNGProvider and LiteLLMProvider
  - Tests verify parser config format and fetch functionality

- Resolves "function not defined" error in search-to-rss conversion


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Search Provider Config<br/>ItemsIterator: results"] -->|Add leading dot| B["Corrected Config<br/>ItemsIterator: .results"]
  B -->|gojq parsing| C["Valid jq expressions"]
  D["Unit Tests Added"] -->|Verify| C
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>litellm.go</strong><dd><code>Add leading dots to LiteLLM jq expressions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/source/fetcher/provider/litellm.go

<ul><li>Prepended dot to all jq field identifiers in <code>GetDefaultParserConfig()</code><br> <li> Changed ItemsIterator from <code>results</code> to <code>.results</code><br> <li> Changed Title from <code>title</code> to <code>.title</code><br> <li> Changed Link from <code>url</code> to <code>.url</code><br> <li> Changed Description from <code>snippet</code> to <code>.snippet</code></ul>


</details>


  </td>
  <td><a href="https://github.com/Colin-XKL/FeedCraft/pull/564/files#diff-0b0caf0f9d4c04e66c06eef7cd24d03870001b04ce540084c54847d4bc7bacc1">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>searxng.go</strong><dd><code>Add leading dots to SearXNG jq expressions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/source/fetcher/provider/searxng.go

<ul><li>Prepended dot to all jq field identifiers in <code>GetDefaultParserConfig()</code><br> <li> Changed ItemsIterator from <code>results</code> to <code>.results</code><br> <li> Changed Title from <code>title</code> to <code>.title</code><br> <li> Changed Link from <code>url</code> to <code>.url</code><br> <li> Changed Description from <code>content</code> to <code>.content</code><br> <li> Changed Date from <code>publishedDate</code> to <code>.publishedDate</code></ul>


</details>


  </td>
  <td><a href="https://github.com/Colin-XKL/FeedCraft/pull/564/files#diff-d2afcdb7dea5c7631dfb7debe3a353b0b3e8f7f0ddacf6e63a69a7244afb7829">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>litellm_test.go</strong><dd><code>Add unit tests for LiteLLMProvider</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/source/fetcher/provider/litellm_test.go

<ul><li>New test file with two test functions<br> <li> <code>TestLiteLLMProvider_Fetch</code> verifies HTTP POST request and response <br>parsing<br> <li> <code>TestLiteLLMProvider_GetDefaultParserConfig</code> asserts correct jq field <br>format with leading dots<br> <li> Uses httptest mock server for isolated testing</ul>


</details>


  </td>
  <td><a href="https://github.com/Colin-XKL/FeedCraft/pull/564/files#diff-08fbf9b8d0bbf0c1050cd0ab2156dd1f30ad407b04e930d487af9b13a23d1eac">+42/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>searxng_test.go</strong><dd><code>Add unit tests for SearXNGProvider</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/source/fetcher/provider/searxng_test.go

<ul><li>New test file with two test functions<br> <li> <code>TestSearXNGProvider_Fetch</code> verifies HTTP GET request with correct query <br>parameters<br> <li> <code>TestSearXNGProvider_GetDefaultParserConfig</code> asserts all jq fields have <br>leading dots<br> <li> Uses httptest mock server to simulate SearXNG API responses</ul>


</details>


  </td>
  <td><a href="https://github.com/Colin-XKL/FeedCraft/pull/564/files#diff-b3450db7916c423f0a92c7f5b74ee02588284bde12cfdb4319e6a9b54684a6eb">+48/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

