### PR TITLE
fix: prevent deadlock in priority dispatcher

### DIFF
--- a/internal/util/priority_dispatcher.go
+++ b/internal/util/priority_dispatcher.go
@@ -20,6 +20,10 @@ type taskResult[R any] struct {
 
 // NewPriorityDispatcher creates and starts a new PriorityDispatcher with the given number of workers.
 func NewPriorityDispatcher[R any](maxConcurrency int) *PriorityDispatcher[R] {
+	if maxConcurrency <= 0 {
+		maxConcurrency = 1
+	}
+
 	d := &PriorityDispatcher[R]{
 		normalQueue: make(chan taskWrapper[R], 1000), // Buffer for pending tasks
 		urgentQueue: make(chan taskWrapper[R], 1000),

--- a/internal/util/priority_dispatcher.go
+++ b/internal/util/priority_dispatcher.go
@@ -20,8 +20,8 @@ type taskResult[R any] struct {
 
 // NewPriorityDispatcher creates and starts a new PriorityDispatcher with the given number of workers.
 func NewPriorityDispatcher[R any](maxConcurrency int) *PriorityDispatcher[R] {
-	if maxConcurrency <= 0 {
-		maxConcurrency = 1
+if maxConcurrency <= 0 {
+		panic("priority dispatcher: maxConcurrency must be positive")
 	}
 
 	d := &PriorityDispatcher[R]{


### PR DESCRIPTION
Update `NewPriorityDispatcher` in `internal/util/priority_dispatcher.go` to guard against `maxConcurrency <= 0`, defaulting it to 1, to prevent deadlocks in `Execute()`.

---
*PR created automatically by Jules for task [2013566111777499910](https://jules.google.com/task/2013566111777499910) started by @Colin-XKL*

## Summary by Sourcery

Bug Fixes:
- Default maxConcurrency to 1 when a non-positive value is provided to NewPriorityDispatcher to prevent deadlocks in Execute.