### PR TITLE
fix: add panic recovery to priority dispatcher task execution

### DIFF
--- a/internal/util/priority_dispatcher.go
+++ b/internal/util/priority_dispatcher.go
@@ -1,5 +1,9 @@
 package util
 
+import (
+	"fmt"
+)
+
 // PriorityDispatcher is a generic worker pool that limits concurrency and supports prioritizing urgent tasks.
 // It acts as a global funnel: no matter how many tasks are submitted concurrently,
 // only a fixed number of workers will execute them, protecting downstream services from being overwhelmed.
@@ -64,8 +68,17 @@ func (d *PriorityDispatcher[R]) worker() {
 }
 
 func (d *PriorityDispatcher[R]) executeTask(task taskWrapper[R]) {
-	val, err := task.fn()
-	task.resultChan <- taskResult[R]{val: val, err: err}
+	var val R
+	var err error
+
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("panic: %v", r)
+		}
+		task.resultChan <- taskResult[R]{val: val, err: err}
+	}()
+
+	val, err = task.fn()
 }
 
 // Execute submits a task and blocks until it completes.


### PR DESCRIPTION
This commit updates `internal/util/priority_dispatcher.go` to safely execute tasks within `executeTask`. A `defer` and `recover()` block is added to catch any runtime panics during `task.fn()`. If a panic occurs, it sets `err = fmt.Errorf("panic: %v", r)`. This change guarantees that a result is always sent to `task.resultChan`, preventing the caller from hanging indefinitely if a task panics.

---
*PR created automatically by Jules for task [7891179238922411358](https://jules.google.com/task/7891179238922411358) started by @Colin-XKL*

## Summary by Sourcery

Bug Fixes:
- Prevent caller goroutines from hanging indefinitely when a dispatched task panics by always sending a result to the task's result channel.