### PR TITLE
fix: implement reference-counting eviction in KeyedLimiter to prevent memory leak

### DIFF
--- a/internal/util/keyed_limiter.go
+++ b/internal/util/keyed_limiter.go
@@ -7,27 +7,59 @@ import (
 	"golang.org/x/sync/semaphore"
 )
 
+type semEntry struct {
+	sem *semaphore.Weighted
+	ref int
+}
+
 // KeyedLimiter controls concurrency based on a string key (e.g., domain).
 type KeyedLimiter struct {
 	limit int64
-	sems  sync.Map // stores map[string]*semaphore.Weighted
+	mu    sync.Mutex
+	sems  map[string]*semEntry // stores semaphores and reference counts
 }
 
 // NewKeyedLimiter creates a new KeyedLimiter with the specified default limit.
 func NewKeyedLimiter(limit int) *KeyedLimiter {
-	return &KeyedLimiter{limit: int64(limit)}
+	return &KeyedLimiter{
+		limit: int64(limit),
+		sems:  make(map[string]*semEntry),
+	}
 }
 
 // Acquire blocks until it can acquire a permit for the given key,
 // or until the context is canceled. It returns a release function
 // that MUST be called to return the permit.
 func (l *KeyedLimiter) Acquire(ctx context.Context, key string) (func(), error) {
-	v, _ := l.sems.LoadOrStore(key, semaphore.NewWeighted(l.limit))
-	sem := v.(*semaphore.Weighted)
+	l.mu.Lock()
+	entry, ok := l.sems[key]
+	if !ok {
+		entry = &semEntry{
+			sem: semaphore.NewWeighted(l.limit),
+			ref: 0,
+		}
+		l.sems[key] = entry
+	}
+	entry.ref++
+	l.mu.Unlock()
 
-	if err := sem.Acquire(ctx, 1); err != nil {
+	if err := entry.sem.Acquire(ctx, 1); err != nil {
+		l.mu.Lock()
+		entry.ref--
+		if entry.ref == 0 {
+			delete(l.sems, key)
+		}
+		l.mu.Unlock()
 		return nil, err
 	}
 
-	return func() { sem.Release(1) }, nil
+	return func() {
+		entry.sem.Release(1)
+		l.mu.Lock()
+		entry.ref--
+		if entry.ref == 0 {
+			delete(l.sems, key)
+		}
+		l.mu.Unlock()
+	}, nil
 }

--- a/internal/util/keyed_limiter_test.go
+++ b/internal/util/keyed_limiter_test.go
@@ -1,0 +1,175 @@
+package util
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestKeyedLimiterEviction(t *testing.T) {
+	limiter := NewKeyedLimiter(2)
+	ctx := context.Background()
+
+	release, err := limiter.Acquire(ctx, "example.com")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// At this point, map should have 1 entry
+	limiter.mu.Lock()
+	if len(limiter.sems) != 1 {
+		t.Errorf("expected 1 entry, got %d", len(limiter.sems))
+	}
+	limiter.mu.Unlock()
+
+	release()
+
+	// After release, map should have 0 entries
+	limiter.mu.Lock()
+	if len(limiter.sems) != 0 {
+		t.Errorf("expected 0 entries, got %d", len(limiter.sems))
+	}
+	limiter.mu.Unlock()
+}
+
+func TestKeyedLimiterConcurrency(t *testing.T) {
+	limiter := NewKeyedLimiter(2)
+	ctx := context.Background()
+	key := "example.com"
+
+	var wg sync.WaitGroup
+	var activeCount int
+	var mu sync.Mutex
+
+	// Launch 5 goroutines to acquire the semaphore
+	for i := 0; i < 5; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			release, err := limiter.Acquire(ctx, key)
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+				return
+			}
+
+			mu.Lock()
+			activeCount++
+			if activeCount > 2 {
+				t.Errorf("exceeded max concurrency of 2, active: %d", activeCount)
+			}
+			mu.Unlock()
+
+			time.Sleep(50 * time.Millisecond) // Simulate work
+
+			mu.Lock()
+			activeCount--
+			mu.Unlock()
+
+			release()
+		}()
+	}
+
+	wg.Wait()
+
+	// After all releases, map should have 0 entries
+	limiter.mu.Lock()
+	if len(limiter.sems) != 0 {
+		t.Errorf("expected 0 entries after all goroutines finish, got %d", len(limiter.sems))
+	}
+	limiter.mu.Unlock()
+}
+
+func TestKeyedLimiterMultipleKeys(t *testing.T) {
+	limiter := NewKeyedLimiter(1)
+	ctx := context.Background()
+
+	release1, err := limiter.Acquire(ctx, "example.com")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	release2, err := limiter.Acquire(ctx, "test.com")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	limiter.mu.Lock()
+	if len(limiter.sems) != 2 {
+		t.Errorf("expected 2 entries, got %d", len(limiter.sems))
+	}
+	limiter.mu.Unlock()
+
+	release1()
+
+	limiter.mu.Lock()
+	if len(limiter.sems) != 1 {
+		t.Errorf("expected 1 entry, got %d", len(limiter.sems))
+	}
+	if _, ok := limiter.sems["test.com"]; !ok {
+		t.Errorf("expected test.com to still be in map")
+	}
+	limiter.mu.Unlock()
+
+	release2()
+
+	limiter.mu.Lock()
+	if len(limiter.sems) != 0 {
+		t.Errorf("expected 0 entries, got %d", len(limiter.sems))
+	}
+	limiter.mu.Unlock()
+}
+
+func TestKeyedLimiterContextCancellation(t *testing.T) {
+	limiter := NewKeyedLimiter(1)
+	ctx, cancel := context.WithCancel(context.Background())
+
+	release1, err := limiter.Acquire(ctx, "example.com")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Create a channel to know when the second acquire fails
+	errCh := make(chan error)
+	go func() {
+		_, err := limiter.Acquire(ctx, "example.com")
+		errCh <- err
+	}()
+
+	// Ensure the second acquire has started
+	time.Sleep(10 * time.Millisecond)
+
+	limiter.mu.Lock()
+	if l := len(limiter.sems); l != 1 {
+		t.Errorf("expected 1 entry, got %d", l)
+	}
+	if entry := limiter.sems["example.com"]; entry.ref != 2 {
+		t.Errorf("expected ref to be 2, got %d", entry.ref)
+	}
+	limiter.mu.Unlock()
+
+	// Cancel context to force the blocked acquire to return error
+	cancel()
+	err = <-errCh
+	if err != context.Canceled {
+		t.Errorf("expected context.Canceled, got %v", err)
+	}
+
+	// After cancellation, the ref count should be decremented but the entry still exists
+	limiter.mu.Lock()
+	if l := len(limiter.sems); l != 1 {
+		t.Errorf("expected 1 entry, got %d", l)
+	}
+	if entry := limiter.sems["example.com"]; entry.ref != 1 {
+		t.Errorf("expected ref to be 1, got %d", entry.ref)
+	}
+	limiter.mu.Unlock()
+
+	release1()
+
+	limiter.mu.Lock()
+	if l := len(limiter.sems); l != 0 {
+		t.Errorf("expected 0 entries, got %d", l)
+	}
+	limiter.mu.Unlock()
+}


### PR DESCRIPTION
The `KeyedLimiter` utility in `internal/util/keyed_limiter.go` uses a `sync.Map` to dynamically allocate semaphores for unique keys (e.g., domain names) to control concurrency. However, it lacks a mechanism to remove these entries once they are no longer in use. Over time, processing feeds with numerous unique domains causes the map to grow indefinitely, leading to a memory leak and potential DoS vulnerability due to memory exhaustion.

This pull request addresses the issue by implementing a reference-counting eviction mechanism for the `KeyedLimiter`:
- Replaced `sync.Map` with a standard `map` and a `sync.Mutex` for atomicity.
- Introduced a `semEntry` struct containing the semaphore and a `ref` integer to track active acquisitions.
- Updated the `Acquire` method to increment the reference count on acquisition and decrement it on release or context cancellation.
- Ensures that when a key's reference count drops to `0`, the entry is automatically deleted from the map, preventing indefinite growth.
- Included comprehensive test coverage (`internal/util/keyed_limiter_test.go`) validating the eviction behavior, context cancellation, and concurrency properties.

---
*PR created automatically by Jules for task [13609585813844533139](https://jules.google.com/task/13609585813844533139) started by @Colin-XKL*

## Summary by Sourcery

Implement reference-counted per-key semaphores in KeyedLimiter to prevent unbounded growth of the internal semaphore map and associated memory leak.

Bug Fixes:
- Ensure KeyedLimiter evicts per-key semaphore entries when their reference count drops to zero, avoiding unbounded map growth and memory leak.

Enhancements:
- Replace sync.Map with a mutex-protected map and track per-key semaphore usage via a reference-counted entry struct to support safe eviction.

Tests:
- Add unit tests covering eviction behavior, concurrent acquisitions, multiple keys, and context cancellation semantics for KeyedLimiter.