### PR TITLE
fix(util): add context awareness to priority dispatcher Execute

### DIFF
--- a/internal/adapter/common_llm.go
+++ b/internal/adapter/common_llm.go
@@ -154,10 +154,10 @@ func SimpleLLMCall(model string, promptInput string) (string, error) {
 
 		result, err := retry.DoWithData(
 			func() (string, error) {
-				return dispatcher.Execute(isUrgent, func() (string, error) {
-					ctx, cancel := context.WithTimeout(context.Background(), llmCallTimeout)
-					defer cancel()
+				ctx, cancel := context.WithTimeout(context.Background(), llmCallTimeout)
+				defer cancel()
 
+				return dispatcher.ExecuteWithContext(ctx, isUrgent, func() (string, error) {
 					content := []llms.MessageContent{
 						llms.TextParts(llms.ChatMessageTypeHuman, promptInput),
 					}

--- a/internal/util/priority_dispatcher.go
+++ b/internal/util/priority_dispatcher.go
@@ -1,5 +1,10 @@
 package util
 
+import (
+	"context"
+	"time"
+)
+
 // PriorityDispatcher is a generic worker pool that limits concurrency and supports prioritizing urgent tasks.
 // It acts as a global funnel: no matter how many tasks are submitted concurrently,
 // only a fixed number of workers will execute them, protecting downstream services from being overwhelmed.
@@ -68,21 +73,45 @@ func (d *PriorityDispatcher[R]) executeTask(task taskWrapper[R]) {
 	task.resultChan <- taskResult[R]{val: val, err: err}
 }
 
-// Execute submits a task and blocks until it completes.
+// Execute submits a task and blocks until it completes with a default 10-minute timeout limit.
 // If urgent is true, the task is sent to the urgentQueue and will be executed before normal tasks.
 func (d *PriorityDispatcher[R]) Execute(urgent bool, fn func() (R, error)) (R, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+	defer cancel()
+	return d.ExecuteWithContext(ctx, urgent, fn)
+}
+
+// ExecuteWithContext submits a task and blocks until it completes or the context is canceled.
+func (d *PriorityDispatcher[R]) ExecuteWithContext(ctx context.Context, urgent bool, fn func() (R, error)) (R, error) {
 	resultChan := make(chan taskResult[R], 1)
 	task := taskWrapper[R]{
 		fn:         fn,
 		resultChan: resultChan,
 	}
 
+	// 1. Enqueue task or abort if ctx is canceled
 	if urgent {
-		d.urgentQueue <- task
+		select {
+		case <-ctx.Done():
+			var empty R
+			return empty, ctx.Err()
+		case d.urgentQueue <- task:
+		}
 	} else {
-		d.normalQueue <- task
+		select {
+		case <-ctx.Done():
+			var empty R
+			return empty, ctx.Err()
+		case d.normalQueue <- task:
+		}
 	}
 
-	res := <-resultChan
-	return res.val, res.err
+	// 2. Wait for result or abort if ctx is canceled
+	select {
+	case <-ctx.Done():
+		var empty R
+		return empty, ctx.Err()
+	case res := <-resultChan:
+		return res.val, res.err
+	}
 }

--- a/internal/util/priority_dispatcher.go
+++ b/internal/util/priority_dispatcher.go
@@ -5,6 +5,8 @@ import (
 	"time"
 )
 
+const defaultExecuteTimeout = 10 * time.Minute
+
 // PriorityDispatcher is a generic worker pool that limits concurrency and supports prioritizing urgent tasks.
 // It acts as a global funnel: no matter how many tasks are submitted concurrently,
 // only a fixed number of workers will execute them, protecting downstream services from being overwhelmed.
@@ -76,7 +78,7 @@ func (d *PriorityDispatcher[R]) executeTask(task taskWrapper[R]) {
 // Execute submits a task and blocks until it completes with a default 10-minute timeout limit.
 // If urgent is true, the task is sent to the urgentQueue and will be executed before normal tasks.
 func (d *PriorityDispatcher[R]) Execute(urgent bool, fn func() (R, error)) (R, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+	ctx, cancel := context.WithTimeout(context.Background(), defaultExecuteTimeout)
 	defer cancel()
 	return d.ExecuteWithContext(ctx, urgent, fn)
 }


### PR DESCRIPTION
This PR mitigates a bug risk where task submission could block unbounded indefinitely on saturated worker queues within the `PriorityDispatcher`. It accomplishes this by adding `ExecuteWithContext` support to apply timeouts across both queueing and processing times and defaults the standard `Execute` call to a safe 10-minute maximum timeout.

---
*PR created automatically by Jules for task [79541921978149850](https://jules.google.com/task/79541921978149850) started by @Colin-XKL*

## Summary by Sourcery

Add context-aware task execution to the priority dispatcher to prevent unbounded blocking and apply sensible default timeouts.

New Features:
- Introduce ExecuteWithContext on PriorityDispatcher to support context-cancelable, priority-based task execution.

Bug Fixes:
- Prevent PriorityDispatcher tasks from blocking indefinitely when worker queues are saturated by honoring context cancellation and timeouts.

Enhancements:
- Update SimpleLLMCall to use the new context-aware dispatcher API so LLM calls respect end-to-end timeouts.