### PR TITLE
docs: update LLM configuration for recent changes (#96ab6bd)

### DIFF
--- a/doc-site/src/content/docs/en/guides/advanced/customization.md
+++ b/doc-site/src/content/docs/en/guides/advanced/customization.md
@@ -63,6 +63,7 @@ You can configure FeedCraft using environment variables in `docker-compose.yml`.
 - **FC_LLM_API_KEY**: API Key for OpenAI or compatible services (like DeepSeek, Gemini, etc.).
 - **FC_LLM_API_MODEL**: Default model to use (e.g., `gemini-pro`, `gpt-3.5-turbo`). **Multiple Models Support:** You can provide a comma-separated list of models (e.g., `gpt-3.5-turbo,gpt-4`). FeedCraft will randomly select a model for each request and automatically retry with others if a call fails.
 - **FC_LLM_API_BASE**: API endpoint address. For OpenAI-compatible APIs, usually ends with `/v1`.
+- **FC_LLM_MAX_CONCURRENCY**: (Optional) Maximum number of concurrent requests to LLM APIs (default is 5). Useful to prevent rate-limiting errors.
 - **FC_LLM_API_TYPE**: (Optional) `openai` (default) or `ollama`.
 
 ### External Services

--- a/doc-site/src/content/docs/zh-tw/guides/advanced/customization.md
+++ b/doc-site/src/content/docs/zh-tw/guides/advanced/customization.md
@@ -63,6 +63,7 @@ sidebar:
 - **FC_LLM_API_KEY**: OpenAI 或相容服務（如 DeepSeek, Gemini 等）的 API Key。
 - **FC_LLM_API_MODEL**: 預設使用的模型（如 `gemini-pro`, `gpt-3.5-turbo`）。**支援多個模型：** 你可以提供一個逗號分隔的模型列表（例如 `gpt-3.5-turbo,gpt-4`）。FeedCraft 會為每個請求隨機選擇一個模型，如果調用失敗，會自動重試列表中的其他模型。
 - **FC_LLM_API_BASE**: API 介面地址。如果是相容 OpenAI 的 API，通常以 `/v1` 結尾。
+- **FC_LLM_MAX_CONCURRENCY**: (可選) 限制發送至 LLM API 的最大並發請求數 (預設為 5)。可用於防止由於請求過快導致的限流報錯。
 - **FC_LLM_API_TYPE**: (可選) `openai` (預設) 或 `ollama`.
 
 ### 外部服務

--- a/doc-site/src/content/docs/zh/guides/advanced/customization.md
+++ b/doc-site/src/content/docs/zh/guides/advanced/customization.md
@@ -63,6 +63,7 @@ sidebar:
 - **FC_LLM_API_KEY**: OpenAI 或兼容服务（如 DeepSeek, Gemini 等）的 API Key。
 - **FC_LLM_API_MODEL**: 默认使用的模型（如 `gemini-pro`, `gpt-3.5-turbo`）。**支持多个模型：** 你可以提供一个逗号分隔的模型列表（例如 `gpt-3.5-turbo,gpt-4`）。FeedCraft 会为每个请求随机选择一个模型，如果调用失败，会自动重试列表中的其他模型。
 - **FC_LLM_API_BASE**: API 接口地址。如果是兼容 OpenAI 的 API，通常以 `/v1` 结尾。
+- **FC_LLM_MAX_CONCURRENCY**: (可选) 限制发送至 LLM API 的最大并发请求数 (默认为 5)。可用于防止由于请求过快导致的限流报错。
 - **FC_LLM_API_TYPE**: (可选) `openai` (默认) 或 `ollama`.
 
 ### 外部服务


### PR DESCRIPTION
## What Changed 💡
- Updated `Docker Environment Variables` section in `doc-site/src/content/docs/{lang}/guides/advanced/customization.md` across `en`, `zh`, and `zh-tw` to document the new `FC_LLM_MAX_CONCURRENCY` environment variable (#96ab6bd).

## Why 📖
Recent code changes ([#96ab6bd]) added LLM concurrency control logic and exposed the `FC_LLM_MAX_CONCURRENCY` environment variable to prevent rate-limit errors (429). The documentation sync ensures users are aware of this optional configuration.

## Files Updated
| File | Changes |
|------|---------|
| `doc-site/src/content/docs/en/guides/advanced/customization.md` | Added English docs for `FC_LLM_MAX_CONCURRENCY` |
| `doc-site/src/content/docs/zh/guides/advanced/customization.md` | Added Simplified Chinese docs for `FC_LLM_MAX_CONCURRENCY` |
| `doc-site/src/content/docs/zh-tw/guides/advanced/customization.md` | Added Traditional Chinese docs for `FC_LLM_MAX_CONCURRENCY` |

## Verification 🔍
- [x] Tests pass (Astro starlight build succeeds)
- [x] Build succeeds
- [x] Examples verified working
- [x] Links checked

---
*PR created automatically by Jules for task [3222496445710149790](https://jules.google.com/task/3222496445710149790) started by @Colin-XKL*

## Summary by Sourcery

Document the new FC_LLM_MAX_CONCURRENCY environment variable in the Docker environment configuration guides across supported languages.

Documentation:
- Add English documentation for the FC_LLM_MAX_CONCURRENCY environment variable in the advanced customization guide.
- Add Simplified Chinese documentation for the FC_LLM_MAX_CONCURRENCY environment variable in the advanced customization guide.
- Add Traditional Chinese documentation for the FC_LLM_MAX_CONCURRENCY environment variable in the advanced customization guide.