### PR TITLE
fix: Go version compatibility for priority dispatcher

### DIFF
--- a/internal/util/priority_dispatcher.go
+++ b/internal/util/priority_dispatcher.go
@@ -40,7 +40,7 @@ func NewPriorityDispatcher[R any](maxConcurrency int) *PriorityDispatcher[R] {
 	}
 
 	// Start fixed number of workers
-	for range maxConcurrency {
+	for i := 0; i < maxConcurrency; i++ {
 		go d.worker()
 	}
 

--- a/internal/util/priority_dispatcher_test.go
+++ b/internal/util/priority_dispatcher_test.go
@@ -117,6 +117,9 @@ func TestPriorityDispatcher_Priority(t *testing.T) {
 	}()
 
 	// Unblock the worker
+	// Wait to ensure urgent task is in queue
+	time.Sleep(50 * time.Millisecond)
+
 	close(blockChan)
 
 	// The first task out should be "urgent" even though it was enqueued last


### PR DESCRIPTION
Fixes the compilation error caused by using Go 1.22+ `for range int` syntax in `NewPriorityDispatcher`. Also improves stability of the `TestPriorityDispatcher_Priority` test.

---
*PR created automatically by Jules for task [6513911400360569041](https://jules.google.com/task/6513911400360569041) started by @Colin-XKL*

## Summary by Sourcery

Ensure the priority dispatcher is compatible with older Go versions and stabilize its priority handling test.

Bug Fixes:
- Replace Go 1.22-specific `for range int` worker startup with a loop compatible with older Go versions to fix compilation issues.

Tests:
- Stabilize the priority dispatcher priority test by adding a delay to ensure the urgent task is enqueued before unblocking the worker.