### PR TITLE
docs: update concurrency plan with actual KeyedLimiter implementation

### DIFF
--- a/internal/util/priority_dispatcher_test.go
+++ b/internal/util/priority_dispatcher_test.go
@@ -116,6 +116,9 @@ func TestPriorityDispatcher_Priority(t *testing.T) {
 		})
 	}()
 
+	// Wait to ensure urgent task is in queue
+	time.Sleep(50 * time.Millisecond)
+
 	// Unblock the worker
 	close(blockChan)
 

--- a/proposal/llm_concurrency_and_retry_plan.md
+++ b/proposal/llm_concurrency_and_retry_plan.md
@@ -73,7 +73,7 @@ go get golang.org/x/sync/semaphore
 
 - **路径**: `internal/util/keyed_limiter.go`
 - **实现细节**:
-  - 封装基于 `sync.Map` 和 `semaphore.Weighted` 的动态限流器。
+  - 封装基于固定大小哈希桶 (fixed-size hash-bucket) 和 `semaphore.Weighted` 的限流器，而不使用动态的 `sync.Map`，从而保证 OOM 安全。
   - 提供 `Acquire(ctx context.Context, key string) (release func(), err error)` 方法。
 
 ### 3.4 LLM 客户端连接复用与重试组装
@@ -85,9 +85,9 @@ go get golang.org/x/sync/semaphore
 
 ### 3.5 Fulltext 抓取并发限制
 
-- **路径**: (假定爬取核心点在 `internal/craft/fulltext.go` 或独立的 extractor 中)
+- **路径**: `internal/craft/fulltext.go`
 - **实现细节**:
-  - 初始化全局 `domainLimiter`，读取配置如 `FC_DOMAIN_MAX_CONCURRENCY` (默认例如 3)。
+  - 初始化全局 `domainLimiter`，读取配置 `DOMAIN_MAX_CONCURRENCY` (默认例如 3)。
   - 在发起 HTTP 真实抓取动作前，解析 `URL` 提取 `Host`，通过 `domainLimiter.Acquire` 拿锁，成功结束后释放。
 
 ### 3.6 Craft 处理全面并发化


### PR DESCRIPTION
Update the `llm_concurrency_and_retry_plan.md` proposal to reflect the actual merged limiter implementation, addressing the inaccuracies about `sync.Map`, environment variable names, and initialization paths. Included a small test fix for a race condition in `priority_dispatcher_test.go`.

---
*PR created automatically by Jules for task [2365262722478773877](https://jules.google.com/task/2365262722478773877) started by @Colin-XKL*

## Summary by Sourcery

Update concurrency proposal docs to reflect the current keyed limiter implementation and stabilize a priority dispatcher test by avoiding a race.

Documentation:
- Align the LLM concurrency proposal with the actual keyed limiter design, documented paths, and configuration names.

Tests:
- Stabilize the priority dispatcher priority test by ensuring the urgent task is queued before unblocking the worker.