### PR TITLE
fix: enforce strict domain concurrency limits by ignoring ports

### DIFF
--- a/internal/craft/fulltext.go
+++ b/internal/craft/fulltext.go
@@ -3,6 +3,7 @@ package craft
 import (
 	"FeedCraft/internal/util"
 	"context"
+	"fmt"
 	"github.com/go-shiori/go-readability"
 	"github.com/gorilla/feeds"
 	"github.com/sirupsen/logrus"
@@ -39,15 +40,19 @@ func ExecuteWithDomainLimit(targetURL string, timeout time.Duration, action Extr
 	if err != nil {
 		return "", err
 	}
+	host := parsed.Hostname()
+	if host == "" {
+		return "", fmt.Errorf("empty hostname in URL: %s", targetURL)
+	}
 
 	// 统一处理超时控制，额外预留 10 秒给可能发生的排队等待
 	ctx, cancel := context.WithTimeout(context.Background(), timeout+10*time.Second)
 	defer cancel()
 
 	// 尝试获取该域名的并发许可证
-	release, err := domainLimiter.Acquire(ctx, parsed.Host)
+	release, err := domainLimiter.Acquire(ctx, host)
 	if err != nil {
-		logrus.Warnf("Failed to acquire permit for domain %s: %v", parsed.Host, err)
+		logrus.Warnf("Failed to acquire permit for domain %s: %v", host, err)
 		return "", err
 	}
 	defer release() // 无论 action 是否 panic/error，确保必定释放

--- a/internal/craft/fulltext_plus.go
+++ b/internal/craft/fulltext_plus.go
@@ -3,6 +3,7 @@ package craft
 import (
 	"FeedCraft/internal/util"
 	"context"
+	"fmt"
 	"net/url"
 	"strconv"
 	"strings"
@@ -19,7 +20,10 @@ func getRenderedHTML2(websiteUrl string, options util.BrowserlessOptions) (strin
 		logrus.Errorf("parse url failed: %v", err)
 		return "", err
 	}
-	host := parseUrl.Host
+	host := parseUrl.Hostname()
+	if host == "" {
+		return "", fmt.Errorf("empty hostname in URL: %s", websiteUrl)
+	}
 
 	// Acquire concurrency permit for this domain
 	ctx, cancel := context.WithTimeout(context.Background(), options.Timeout+10*time.Second)

--- a/internal/util/priority_dispatcher_test.go
+++ b/internal/util/priority_dispatcher_test.go
@@ -116,6 +116,8 @@ func TestPriorityDispatcher_Priority(t *testing.T) {
 		})
 	}()
 
+	time.Sleep(50 * time.Millisecond)
+
 	// Unblock the worker
 	close(blockChan)
 


### PR DESCRIPTION
The issue was that the `parsed.Host` method returns the domain and port if one is provided (e.g. `example.com:8080`), leading to different slots in the `domainLimiter` for the exact same underlying host if the URL happens to specify a port.

To correct this, I updated `internal/craft/fulltext.go` and `internal/craft/fulltext_plus.go` to use `parsed.Hostname()` instead. `Hostname()` strips the port and provides only the domain. Furthermore, I added defensive validation explicitly rejecting the request if the extracted hostname results in an empty string.

I also fixed a race condition in `internal/util/priority_dispatcher_test.go` by adding a short delay that unblocks the test workers more deterministically, as it popped up as a flaky failure during local test executions.

---
*PR created automatically by Jules for task [16782991373025246111](https://jules.google.com/task/16782991373025246111) started by @Colin-XKL*

## Summary by Sourcery

Enforce domain-level concurrency limits based on hostnames rather than host:port and stabilize a flaky priority dispatcher test.

Bug Fixes:
- Ensure domain concurrency limiting treats URLs with different ports as the same domain by using the URL hostname instead of host:port.
- Reject requests where URL parsing yields an empty hostname to avoid invalid domain limiter usage.
- Stabilize the priority dispatcher priority test by adding a short delay to reliably unblock worker goroutines.