### PR TITLE
fix(llm): prevent duplicate client creation via double-checked locking

### DIFF
--- a/internal/adapter/common_llm.go
+++ b/internal/adapter/common_llm.go
@@ -35,6 +35,8 @@ var (
 	// This prevents rate-limit errors (429) while allowing retried requests to jump the queue.
 	llmDispatcher *util.PriorityDispatcher[string]
 	llmDispOnce   sync.Once
+
+	clientCreationMutex sync.Mutex
 )
 
 func getLLMDispatcher() *util.PriorityDispatcher[string] {
@@ -54,6 +56,43 @@ func getLLMDispatcher() *util.PriorityDispatcher[string] {
 		logrus.Infof("LLM Global Priority Dispatcher initialized with max concurrency: %d", concurrency)
 	})
 	return llmDispatcher
+}
+
+func getOrCreateLLMClient(cacheKey, llmApiType, llmApiBase, llmApiKey, currentModel string) (llms.Model, error) {
+	if cached, ok := llmClients.Load(cacheKey); ok {
+		return cached.(llms.Model), nil
+	}
+
+	clientCreationMutex.Lock()
+	defer clientCreationMutex.Unlock()
+
+	if cached, ok := llmClients.Load(cacheKey); ok {
+		return cached.(llms.Model), nil
+	}
+
+	var llm llms.Model
+	var err error
+	if llmApiType == "ollama" {
+		llm, err = ollama.New(
+			ollama.WithServerURL(llmApiBase),
+			ollama.WithModel(currentModel),
+		)
+	} else {
+		opts := []openai.Option{
+			openai.WithToken(llmApiKey),
+			openai.WithModel(currentModel),
+		}
+		if llmApiBase != "" {
+			opts = append(opts, openai.WithBaseURL(llmApiBase))
+		}
+		llm, err = openai.New(opts...)
+	}
+
+	if err == nil {
+		llmClients.Store(cacheKey, llm)
+	}
+
+	return llm, err
 }
 
 func SimpleLLMCall(model string, promptInput string) (string, error) {
@@ -120,34 +159,12 @@ func SimpleLLMCall(model string, promptInput string) (string, error) {
 		}
 
 		cacheKey := fmt.Sprintf("%s|%s|%s|%s", llmApiType, llmApiBase, llmApiKey, currentModel)
-		var llm llms.Model
 
-		if cached, ok := llmClients.Load(cacheKey); ok {
-			llm = cached.(llms.Model)
-		} else {
-			var err error
-			if llmApiType == "ollama" {
-				llm, err = ollama.New(
-					ollama.WithServerURL(llmApiBase),
-					ollama.WithModel(currentModel),
-				)
-			} else {
-				opts := []openai.Option{
-					openai.WithToken(llmApiKey),
-					openai.WithModel(currentModel),
-				}
-				if llmApiBase != "" {
-					opts = append(opts, openai.WithBaseURL(llmApiBase))
-				}
-				llm, err = openai.New(opts...)
-			}
-
-			if err != nil {
-				lastErr = err
-				logrus.Warnf("Failed to initialize LLM client for model %s: %v", currentModel, err)
-				continue
-			}
-			llmClients.Store(cacheKey, llm)
+		llm, err := getOrCreateLLMClient(cacheKey, llmApiType, llmApiBase, llmApiKey, currentModel)
+		if err != nil {
+			lastErr = err
+			logrus.Warnf("Failed to initialize LLM client for model %s: %v", currentModel, err)
+			continue
 		}
 
 		dispatcher := getLLMDispatcher()

--- a/internal/util/priority_dispatcher_test.go
+++ b/internal/util/priority_dispatcher_test.go
@@ -116,6 +116,9 @@ func TestPriorityDispatcher_Priority(t *testing.T) {
 		})
 	}()
 
+	// Wait to ensure urgent task is in queue before unblocking
+	time.Sleep(50 * time.Millisecond)
+
 	// Unblock the worker
 	close(blockChan)
 


### PR DESCRIPTION
Fixes a TOCTOU race condition in `common_llm.go` where concurrent goroutines checking the `llmClients` cache for the same `cacheKey` could end up constructing duplicate `llms.Model` clients and overwriting each other in the `sync.Map`.

A new `getOrCreateLLMClient` helper uses a package-level `sync.Mutex` with a double-checked locking strategy to ensure instantiation runs exactly once per missing key.

Also includes a minor test fix in `internal/util/priority_dispatcher_test.go` to solve a flaky concurrency test failure.

---
*PR created automatically by Jules for task [17133244240139756997](https://jules.google.com/task/17133244240139756997) started by @Colin-XKL*

## Summary by Sourcery

Prevent duplicate LLM client creation under concurrent access by centralizing client initialization with synchronized, cache-aware helper logic.

Bug Fixes:
- Eliminate a race condition that could create and overwrite duplicate LLM clients when multiple goroutines request the same configuration concurrently.
- Stabilize a flaky priority dispatcher concurrency test by ensuring the urgent task is enqueued before unblocking the worker.

Enhancements:
- Introduce a shared get-or-create helper for LLM clients to consolidate and reuse client initialization logic across calls.