### PR TITLE
feat: add topic feed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -145,3 +145,4 @@ feedcraft.exe
 *.log
 **/*.log
 .gocache
+.claude/settings.local.json

--- a/internal/craft/adapter.go
+++ b/internal/craft/adapter.go
@@ -1,0 +1,27 @@
+package craft
+
+import (
+	"context"
+
+	"FeedCraft/internal/model"
+)
+
+// LegacyOptionAdapter wraps a legacy CraftOption so it can be used as a FeedProcessor.
+type LegacyOptionAdapter struct {
+	Option CraftOption
+	Extra  ExtraPayload
+}
+
+// Process implements the engine.FeedProcessor interface
+func (a *LegacyOptionAdapter) Process(ctx context.Context, feed *model.CraftFeed) (*model.CraftFeed, error) {
+	// 1. Convert internal model back to Gorilla feeds format for legacy processor
+	legacyFeed := feed.ToFeedsFeed()
+
+	// 2. Apply the legacy functional mutation
+	if err := a.Option(legacyFeed, a.Extra); err != nil {
+		return nil, err
+	}
+
+	// 3. Convert the mutated feeds.Feed back into the internal CraftFeed model
+	return model.FromFeedsFeed(legacyFeed), nil
+}

--- a/internal/craft/common.go
+++ b/internal/craft/common.go
@@ -5,6 +5,7 @@ import (
 	"FeedCraft/internal/constant"
 	"FeedCraft/internal/source"
 	"FeedCraft/internal/util"
+	"FeedCraft/internal/engine"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -103,15 +104,18 @@ func CommonCraftHandlerUsingCraftOptionList(c *gin.Context, optionList []CraftOp
 		return
 	}
 
-	// Create the source instance
+	// Create the legacy source instance
 	sourceInstance, err := factory(sourceConfig)
 	if err != nil {
 		c.String(http.StatusInternalServerError, err.Error())
 		return
 	}
 
-	// Generate the base feed
-	baseFeed, err := sourceInstance.Generate(c.Request.Context())
+	// Wrap in LegacySourceAdapter
+	provider := &source.LegacySourceAdapter{LegacySource: sourceInstance}
+
+	// Fetch raw feed using new Provider interface
+	rawCraftFeed, err := provider.Fetch(c.Request.Context())
 	if err != nil {
 		c.String(http.StatusInternalServerError, err.Error())
 		return
@@ -119,16 +123,27 @@ func CommonCraftHandlerUsingCraftOptionList(c *gin.Context, optionList []CraftOp
 
 	// Get the base URL for link resolution
 	baseURL := sourceInstance.BaseURL()
+	payload := ExtraPayload{originalFeedUrl: baseURL}
 
-	// Craft the feed using the new, unified function
-	craftedFeed, err := NewCraftedFeedFromGofeed(baseFeed, baseURL, optionList...)
+	// Build the FlowCraft processor using adapters
+	processors := make([]engine.FeedProcessor, len(optionList))
+	for i, opt := range optionList {
+		processors[i] = &LegacyOptionAdapter{
+			Option: opt,
+			Extra:  payload,
+		}
+	}
+	flowCraft := &engine.FlowCraftProcessor{Processors: processors}
+
+	// Process the feed using the new Processor interface
+	finalCraftFeed, err := flowCraft.Process(c.Request.Context(), rawCraftFeed)
 	if err != nil {
 		c.String(http.StatusInternalServerError, err.Error())
 		return
 	}
 
 	// Render the result
-	rssStr, err := craftedFeed.OutputFeed.ToRss()
+	rssStr, err := finalCraftFeed.ToFeedsFeed().ToRss()
 	if err != nil {
 		c.String(http.StatusInternalServerError, err.Error())
 		return

--- a/internal/dao/migrate.go
+++ b/internal/dao/migrate.go
@@ -18,7 +18,8 @@ func MigrateDatabases() {
 		// &CustomRecipe{},
 		&CustomRecipeV2{}, // Create the new V2 table
 		&CraftFlow{}, &CraftAtom{},
-		&User{}, // 确保 User 表被初始化
+		&TopicFeed{}, // Add TopicFeed migration
+		&User{},      // 确保 User 表被初始化
 		&SystemSetting{},
 	)
 	if err != nil {

--- a/internal/dao/topic.go
+++ b/internal/dao/topic.go
@@ -1,0 +1,70 @@
+package dao
+
+import (
+	"gorm.io/gorm"
+)
+
+// TopicFeed represents the persistence model for a multi-source aggregation node.
+type TopicFeed struct {
+	BaseModelWithoutPK
+	ID          string `gorm:"primaryKey" json:"id" binding:"required"`
+	Title       string `json:"title,omitempty"`
+	Description string `json:"description,omitempty"`
+
+	// List of URIs representing inputs.
+	// Uses a custom protocol for internal resources to make routing elegant and standard.
+	// Examples:
+	//   - "feedcraft://recipe/my-tech-recipe" (Internal RecipeFeed)
+	//   - "feedcraft://topic/sub-topic-id"    (Nested internal TopicFeed)
+	//   - "https://external.com/rss.xml"      (External raw feed)
+	InputURIs []string `json:"input_uris" binding:"required" gorm:"serializer:json"`
+
+	// Configuration for the aggregator pipeline
+	AggregatorConfig []AggregatorStep `json:"aggregator_config" gorm:"serializer:json"`
+}
+
+// AggregatorStep defines a single processing step in an Aggregator pipeline.
+type AggregatorStep struct {
+	Type   string            `json:"type" binding:"required"` // e.g., "deduplicate", "sort", "limit"
+	Option map[string]string `json:"option"`                  // e.g., {"by": "date_desc"} or {"max": "50"}
+}
+
+// TableName overrides the default table name for TopicFeed.
+func (TopicFeed) TableName() string {
+	return "topic_feeds"
+}
+
+// CreateTopicFeed creates a new TopicFeed record in the database.
+func CreateTopicFeed(db *gorm.DB, topic *TopicFeed) error {
+	return db.Create(topic).Error
+}
+
+// GetTopicFeedByID retrieves a TopicFeed record by its ID.
+func GetTopicFeedByID(db *gorm.DB, id string) (*TopicFeed, error) {
+	var topic TopicFeed
+	if id == "" {
+		return nil, gorm.ErrRecordNotFound
+	}
+	result := db.Where("id = ?", id).First(&topic)
+	return &topic, result.Error
+}
+
+// UpdateTopicFeed updates an existing TopicFeed record.
+func UpdateTopicFeed(db *gorm.DB, topic *TopicFeed) error {
+	return db.Save(topic).Error
+}
+
+// DeleteTopicFeed deletes a TopicFeed record by its ID.
+func DeleteTopicFeed(db *gorm.DB, id string) error {
+	var topic TopicFeed
+	return db.Where("id = ?", id).Delete(&topic).Error
+}
+
+// ListTopicFeeds retrieves all TopicFeed records.
+func ListTopicFeeds(db *gorm.DB) ([]*TopicFeed, error) {
+	var topics []*TopicFeed
+	if err := db.Find(&topics).Error; err != nil {
+		return topics, err
+	}
+	return topics, nil
+}

--- a/internal/engine/aggregator.go
+++ b/internal/engine/aggregator.go
@@ -1,0 +1,101 @@
+package engine
+
+import (
+	"context"
+	"sort"
+	"strings"
+
+	"FeedCraft/internal/model"
+)
+
+// DeduplicateProcessor removes duplicate articles from a feed.
+type DeduplicateProcessor struct {
+	// Strategy defines how to identify duplicates. E.g., "by_link", "by_id". Defaults to "by_link".
+	Strategy string
+}
+
+func (p *DeduplicateProcessor) Process(ctx context.Context, feed *model.CraftFeed) (*model.CraftFeed, error) {
+	if feed == nil || len(feed.Articles) == 0 {
+		return feed, nil
+	}
+
+	seen := make(map[string]bool)
+	var uniqueArticles []*model.CraftArticle
+
+	for _, article := range feed.Articles {
+		var key string
+		switch strings.ToLower(p.Strategy) {
+		case "by_id":
+			key = article.Id
+		default: // default to by_link
+			key = article.Link
+		}
+
+		if key == "" {
+			// If key is empty, we don't deduplicate it (or we could choose to drop it, but keeping is safer)
+			uniqueArticles = append(uniqueArticles, article)
+			continue
+		}
+
+		if !seen[key] {
+			seen[key] = true
+			uniqueArticles = append(uniqueArticles, article)
+		}
+	}
+
+	feed.Articles = uniqueArticles
+	return feed, nil
+}
+
+// SortProcessor reorders the articles in a feed.
+type SortProcessor struct {
+	// SortBy defines the sorting criterion and order. E.g., "date_desc", "date_asc", "quality_desc".
+	// Defaults to "date_desc".
+	SortBy string
+}
+
+func (p *SortProcessor) Process(ctx context.Context, feed *model.CraftFeed) (*model.CraftFeed, error) {
+	if feed == nil || len(feed.Articles) <= 1 {
+		return feed, nil
+	}
+
+	articles := feed.Articles
+	sortBy := strings.ToLower(p.SortBy)
+	if sortBy == "" {
+		sortBy = "date_desc" // default
+	}
+
+	sort.SliceStable(articles, func(i, j int) bool {
+		a, b := articles[i], articles[j]
+		switch sortBy {
+		case "date_asc":
+			return a.Updated.Before(b.Updated)
+		case "quality_desc":
+			return a.QualityScore > b.QualityScore
+		case "quality_asc":
+			return a.QualityScore < b.QualityScore
+		default: // date_desc
+			return a.Updated.After(b.Updated)
+		}
+	})
+
+	feed.Articles = articles
+	return feed, nil
+}
+
+// LimitProcessor truncates the number of articles in a feed.
+type LimitProcessor struct {
+	MaxItems int
+}
+
+func (p *LimitProcessor) Process(ctx context.Context, feed *model.CraftFeed) (*model.CraftFeed, error) {
+	if feed == nil || len(feed.Articles) == 0 {
+		return feed, nil
+	}
+
+	if p.MaxItems > 0 && len(feed.Articles) > p.MaxItems {
+		feed.Articles = feed.Articles[:p.MaxItems]
+	}
+
+	return feed, nil
+}

--- a/internal/engine/aggregator_test.go
+++ b/internal/engine/aggregator_test.go
@@ -1,0 +1,123 @@
+package engine
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"FeedCraft/internal/model"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDeduplicateProcessor(t *testing.T) {
+	feed := &model.CraftFeed{
+		Articles: []*model.CraftArticle{
+			{Id: "1", Link: "http://a.com"},
+			{Id: "2", Link: "http://b.com"},
+			{Id: "3", Link: "http://a.com"}, // Duplicate link
+			{Id: "2", Link: "http://c.com"}, // Duplicate ID
+		},
+	}
+
+	t.Run("By Link", func(t *testing.T) {
+		p := &DeduplicateProcessor{Strategy: "by_link"}
+		// Clone feed to avoid mutating original for next test
+		f := &model.CraftFeed{Articles: append([]*model.CraftArticle{}, feed.Articles...)}
+
+		res, err := p.Process(context.Background(), f)
+		assert.NoError(t, err)
+		assert.Len(t, res.Articles, 3)
+		assert.Equal(t, "1", res.Articles[0].Id)
+		assert.Equal(t, "2", res.Articles[1].Id)
+		assert.Equal(t, "2", res.Articles[2].Id) // ID 2 is kept twice because links differ (b.com, c.com)
+	})
+
+	t.Run("By ID", func(t *testing.T) {
+		p := &DeduplicateProcessor{Strategy: "by_id"}
+		f := &model.CraftFeed{Articles: append([]*model.CraftArticle{}, feed.Articles...)}
+
+		res, err := p.Process(context.Background(), f)
+		assert.NoError(t, err)
+		assert.Len(t, res.Articles, 3)
+		assert.Equal(t, "http://a.com", res.Articles[0].Link)
+		assert.Equal(t, "http://b.com", res.Articles[1].Link)
+		assert.Equal(t, "http://a.com", res.Articles[2].Link) // Link a.com is kept twice because IDs differ (1, 3)
+	})
+}
+
+func TestSortProcessor(t *testing.T) {
+	now := time.Now()
+	feed := &model.CraftFeed{
+		Articles: []*model.CraftArticle{
+			{Id: "1", Updated: now.Add(-1 * time.Hour), QualityScore: 10}, // oldest
+			{Id: "2", Updated: now, QualityScore: 30},                     // newest
+			{Id: "3", Updated: now.Add(-30 * time.Minute), QualityScore: 20},
+		},
+	}
+
+	t.Run("Date Descending", func(t *testing.T) {
+		p := &SortProcessor{SortBy: "date_desc"}
+		f := &model.CraftFeed{Articles: append([]*model.CraftArticle{}, feed.Articles...)}
+		res, err := p.Process(context.Background(), f)
+		assert.NoError(t, err)
+		assert.Equal(t, "2", res.Articles[0].Id) // newest first
+		assert.Equal(t, "3", res.Articles[1].Id)
+		assert.Equal(t, "1", res.Articles[2].Id)
+	})
+
+	t.Run("Quality Descending", func(t *testing.T) {
+		p := &SortProcessor{SortBy: "quality_desc"}
+		f := &model.CraftFeed{Articles: append([]*model.CraftArticle{}, feed.Articles...)}
+		res, err := p.Process(context.Background(), f)
+		assert.NoError(t, err)
+		assert.Equal(t, "2", res.Articles[0].Id) // highest quality first
+		assert.Equal(t, "3", res.Articles[1].Id)
+		assert.Equal(t, "1", res.Articles[2].Id)
+	})
+}
+
+func TestLimitProcessor(t *testing.T) {
+	feed := &model.CraftFeed{
+		Articles: []*model.CraftArticle{
+			{Id: "1"}, {Id: "2"}, {Id: "3"}, {Id: "4"},
+		},
+	}
+
+	p := &LimitProcessor{MaxItems: 2}
+	res, err := p.Process(context.Background(), feed)
+	assert.NoError(t, err)
+	assert.Len(t, res.Articles, 2)
+	assert.Equal(t, "1", res.Articles[0].Id)
+	assert.Equal(t, "2", res.Articles[1].Id)
+}
+
+func TestFlowCraftProcessor_Aggregator(t *testing.T) {
+	now := time.Now()
+	feed := &model.CraftFeed{
+		Articles: []*model.CraftArticle{
+			{Id: "1", Link: "http://a.com", Updated: now.Add(-1 * time.Hour)},
+			{Id: "2", Link: "http://b.com", Updated: now},
+			{Id: "3", Link: "http://a.com", Updated: now.Add(1 * time.Hour)}, // duplicate link, but newest!
+			{Id: "4", Link: "http://c.com", Updated: now.Add(-2 * time.Hour)},
+		},
+	}
+
+	// Important: To keep the *newest* duplicate, we should sort BEFORE we deduplicate.
+	aggregator := &FlowCraftProcessor{
+		Processors: []FeedProcessor{
+			&SortProcessor{SortBy: "date_desc"},
+			&DeduplicateProcessor{Strategy: "by_link"},
+			&LimitProcessor{MaxItems: 2},
+		},
+	}
+
+	res, err := aggregator.Process(context.Background(), feed)
+	assert.NoError(t, err)
+	assert.Len(t, res.Articles, 2)
+
+	// Because we sort desc first, the order is: 3, 2, 1, 4
+	// Then we deduplicate: keep 3, keep 2, drop 1 (dup link of 3), keep 4
+	// Then limit 2: keep 3, 2.
+	assert.Equal(t, "3", res.Articles[0].Id)
+	assert.Equal(t, "2", res.Articles[1].Id)
+}

--- a/internal/engine/flow.go
+++ b/internal/engine/flow.go
@@ -1,0 +1,26 @@
+package engine
+
+import (
+	"context"
+
+	"FeedCraft/internal/model"
+)
+
+// FlowCraftProcessor allows composing multiple FeedProcessors together sequentially.
+type FlowCraftProcessor struct {
+	Processors []FeedProcessor
+}
+
+func (f *FlowCraftProcessor) Process(ctx context.Context, feed *model.CraftFeed) (*model.CraftFeed, error) {
+	currentFeed := feed
+	var err error
+
+	for _, p := range f.Processors {
+		currentFeed, err = p.Process(ctx, currentFeed)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return currentFeed, nil
+}

--- a/internal/engine/interfaces.go
+++ b/internal/engine/interfaces.go
@@ -1,0 +1,18 @@
+package engine
+
+import (
+	"context"
+	"FeedCraft/internal/model"
+)
+
+// FeedProvider represents any node that can generate or output a CraftFeed.
+// Examples: RawFeed sources (HTML, RSS, Search), RecipeFeed, TopicFeed.
+type FeedProvider interface {
+	Fetch(ctx context.Context) (*model.CraftFeed, error)
+}
+
+// FeedProcessor represents any node that takes a CraftFeed, processes it, and returns a new CraftFeed.
+// Examples: AtomCrafts (Translate, FullText, Summary), FlowCraft, Aggregator.
+type FeedProcessor interface {
+	Process(ctx context.Context, feed *model.CraftFeed) (*model.CraftFeed, error)
+}

--- a/internal/engine/topic.go
+++ b/internal/engine/topic.go
@@ -1,0 +1,74 @@
+package engine
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"FeedCraft/internal/model"
+	"github.com/sirupsen/logrus"
+	"golang.org/x/sync/errgroup"
+)
+
+// TopicFeed aggregates multiple FeedProviders into a single Feed.
+type TopicFeed struct {
+	ID          string
+	Title       string
+	Description string
+	Link        string
+
+	// Inputs are the upstream providers (RecipeFeeds, other TopicFeeds, or RawFeeds).
+	Inputs []FeedProvider
+
+	// Aggregator is an optional processor to handle deduplication, sorting, limiting, etc.
+	Aggregator FeedProcessor
+}
+
+// Fetch implements the FeedProvider interface.
+func (t *TopicFeed) Fetch(ctx context.Context) (*model.CraftFeed, error) {
+	var g errgroup.Group
+	var mu sync.Mutex
+	var allArticles []*model.CraftArticle
+
+	for _, input := range t.Inputs {
+		// Capture loop variable
+		provider := input
+		g.Go(func() error {
+			// We pass the context to allow cancellation or timeouts,
+			// but we don't want one failure to cancel the others in an aggregator.
+			feed, err := provider.Fetch(ctx)
+			if err != nil {
+				logrus.Warnf("TopicFeed [%s]: failed to fetch from a provider: %v", t.ID, err)
+				// Return nil so errgroup doesn't cancel other goroutines
+				return nil
+			}
+
+			if feed != nil && len(feed.Articles) > 0 {
+				mu.Lock()
+				allArticles = append(allArticles, feed.Articles...)
+				mu.Unlock()
+			}
+			return nil
+		})
+	}
+
+	// We don't expect errors from Wait() since we return nil above, but we still wait for completion
+	_ = g.Wait()
+
+	mergedFeed := &model.CraftFeed{
+		Id:          t.ID,
+		Title:       t.Title,
+		Description: t.Description,
+		Link:        t.Link,
+		Updated:     time.Now(),
+		Created:     time.Now(),
+		Articles:    allArticles,
+	}
+
+	// If there's an aggregator pipeline (e.g., deduplicate -> sort -> limit), run it.
+	if t.Aggregator != nil {
+		return t.Aggregator.Process(ctx, mergedFeed)
+	}
+
+	return mergedFeed, nil
+}

--- a/internal/engine/topic_test.go
+++ b/internal/engine/topic_test.go
@@ -1,0 +1,108 @@
+package engine
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"FeedCraft/internal/model"
+	"github.com/stretchr/testify/assert"
+)
+
+// MockProvider is a simple FeedProvider for testing.
+type MockProvider struct {
+	Feed *model.CraftFeed
+	Err  error
+	Delay time.Duration
+}
+
+func (m *MockProvider) Fetch(ctx context.Context) (*model.CraftFeed, error) {
+	if m.Delay > 0 {
+		time.Sleep(m.Delay)
+	}
+	return m.Feed, m.Err
+}
+
+func TestTopicFeed_Fetch_Success(t *testing.T) {
+	provider1 := &MockProvider{
+		Feed: &model.CraftFeed{
+			Articles: []*model.CraftArticle{
+				{Id: "1", Title: "Article 1"},
+				{Id: "2", Title: "Article 2"},
+			},
+		},
+	}
+	provider2 := &MockProvider{
+		Feed: &model.CraftFeed{
+			Articles: []*model.CraftArticle{
+				{Id: "3", Title: "Article 3"},
+			},
+		},
+	}
+
+	topic := &TopicFeed{
+		ID:     "topic-1",
+		Inputs: []FeedProvider{provider1, provider2},
+	}
+
+	result, err := topic.Fetch(context.Background())
+	assert.NoError(t, err)
+	assert.NotNil(t, result)
+	assert.Equal(t, "topic-1", result.Id)
+
+	// Should contain 3 articles total
+	assert.Len(t, result.Articles, 3)
+}
+
+func TestTopicFeed_Fetch_PartialFailure(t *testing.T) {
+	provider1 := &MockProvider{
+		Feed: &model.CraftFeed{
+			Articles: []*model.CraftArticle{
+				{Id: "1", Title: "Article 1"},
+			},
+		},
+	}
+	providerFail := &MockProvider{
+		Err: errors.New("network error"),
+	}
+
+	topic := &TopicFeed{
+		ID:     "topic-2",
+		Inputs: []FeedProvider{provider1, providerFail},
+	}
+
+	// Should not return error overall, just log the warning and return partial success
+	result, err := topic.Fetch(context.Background())
+	assert.NoError(t, err)
+	assert.NotNil(t, result)
+
+	// Should contain 1 article from provider1
+	assert.Len(t, result.Articles, 1)
+	assert.Equal(t, "1", result.Articles[0].Id)
+}
+
+func TestTopicFeed_Fetch_WithAggregator(t *testing.T) {
+	provider := &MockProvider{
+		Feed: &model.CraftFeed{
+			Articles: []*model.CraftArticle{
+				{Id: "1", Title: "A"},
+				{Id: "2", Title: "B"},
+				{Id: "3", Title: "C"},
+			},
+		},
+	}
+
+	// An aggregator that limits to 2 items
+	aggregator := &LimitProcessor{MaxItems: 2}
+
+	topic := &TopicFeed{
+		Inputs:     []FeedProvider{provider},
+		Aggregator: aggregator,
+	}
+
+	result, err := topic.Fetch(context.Background())
+	assert.NoError(t, err)
+	assert.NotNil(t, result)
+	assert.Len(t, result.Articles, 2)
+}

--- a/internal/model/feed.go
+++ b/internal/model/feed.go
@@ -1,0 +1,239 @@
+package model
+
+import (
+	"time"
+
+	"github.com/gorilla/feeds"
+	"github.com/mmcdole/gofeed"
+	"github.com/samber/lo"
+)
+
+// CraftFeed is the standard internal data carrier for the FeedCraft pipeline.
+type CraftFeed struct {
+	Title       string
+	Link        string // The actual URL of the site
+	Description string
+	Updated     time.Time
+	Created     time.Time
+	Id          string // The URL of the feed itself
+	Copyright   string
+	AuthorName  string
+	AuthorEmail string
+	ImageURL    string
+	ImageTitle  string
+
+	// The items in the feed
+	Articles []*CraftArticle
+}
+
+// CraftArticle represents a single item in the feed pipeline.
+// It contains standard RSS fields as well as internal tracking metadata.
+type CraftArticle struct {
+	Title       string
+	Link        string
+	Description string
+	Id          string // GUID
+	Updated     time.Time
+	Created     time.Time
+	Content     string
+	AuthorName  string
+	AuthorEmail string
+
+	// Internal metadata for future expansion (Topic aggregation, fission, etc.)
+	OriginalFeedID string // The ID of the raw source it came from
+	QualityScore   float64
+	Depth          int // For tracking fission loops
+}
+
+// FromGofeed converts an external gofeed.Feed (usually from the Source layer) into a CraftFeed.
+func FromGofeed(parsedFeed *gofeed.Feed) *CraftFeed {
+	if parsedFeed == nil {
+		return nil
+	}
+
+	updatedTime := time.Now()
+	if parsedFeed.UpdatedParsed != nil && !parsedFeed.UpdatedParsed.IsZero() {
+		updatedTime = *parsedFeed.UpdatedParsed
+	}
+
+	publishedTime := time.Now()
+	if parsedFeed.PublishedParsed != nil && !parsedFeed.PublishedParsed.IsZero() {
+		publishedTime = *parsedFeed.PublishedParsed
+	}
+
+	cf := &CraftFeed{
+		Title:       parsedFeed.Title,
+		Link:        parsedFeed.Link,
+		Description: parsedFeed.Description,
+		Updated:     updatedTime,
+		Created:     publishedTime,
+		Id:          parsedFeed.FeedLink,
+		Copyright:   parsedFeed.Copyright,
+	}
+
+	if len(parsedFeed.Authors) > 0 && parsedFeed.Authors[0] != nil {
+		cf.AuthorName = parsedFeed.Authors[0].Name
+		cf.AuthorEmail = parsedFeed.Authors[0].Email
+	}
+	if parsedFeed.Image != nil {
+		cf.ImageURL = parsedFeed.Image.URL
+		cf.ImageTitle = parsedFeed.Image.Title
+	}
+
+	cf.Articles = lo.Map(parsedFeed.Items, func(item *gofeed.Item, _ int) *CraftArticle {
+		return ArticleFromGofeed(item)
+	})
+
+	return cf
+}
+
+func ArticleFromGofeed(item *gofeed.Item) *CraftArticle {
+	if item == nil {
+		return nil
+	}
+
+	updatedTime := time.Now()
+	if item.UpdatedParsed != nil && !item.UpdatedParsed.IsZero() {
+		updatedTime = *item.UpdatedParsed
+	}
+
+	publishedTime := time.Now()
+	if item.PublishedParsed != nil && !item.PublishedParsed.IsZero() {
+		publishedTime = *item.PublishedParsed
+	}
+
+	content := item.Content
+	if len(content) == 0 {
+		content = item.Description
+	}
+
+	article := &CraftArticle{
+		Title:       item.Title,
+		Link:        item.Link,
+		Description: item.Description,
+		Id:          item.GUID,
+		Updated:     updatedTime,
+		Created:     publishedTime,
+		Content:     content, // fallback to description if content is empty
+	}
+
+	authorItem := lo.FirstOrEmpty(item.Authors)
+	if authorItem != nil {
+		article.AuthorName = authorItem.Name
+		article.AuthorEmail = authorItem.Email
+	}
+
+	return article
+}
+
+// ToFeedsFeed converts the internal CraftFeed out to the Gorilla feeds format for final XML generation.
+func (cf *CraftFeed) ToFeedsFeed() *feeds.Feed {
+	if cf == nil {
+		return nil
+	}
+
+	ff := &feeds.Feed{
+		Title:       cf.Title,
+		Link:        &feeds.Link{Href: cf.Link},
+		Description: cf.Description,
+		Updated:     cf.Updated,
+		Created:     cf.Created,
+		Id:          cf.Id,
+		Copyright:   cf.Copyright,
+	}
+
+	if cf.AuthorName != "" || cf.AuthorEmail != "" {
+		ff.Author = &feeds.Author{
+			Name:  cf.AuthorName,
+			Email: cf.AuthorEmail,
+		}
+	}
+	if cf.ImageURL != "" {
+		ff.Image = &feeds.Image{
+			Url:   cf.ImageURL,
+			Title: cf.ImageTitle,
+			Link:  cf.ImageURL,
+		}
+	}
+
+	ff.Items = lo.Map(cf.Articles, func(article *CraftArticle, _ int) *feeds.Item {
+		return article.ToFeedsItem()
+	})
+
+	return ff
+}
+
+func (ca *CraftArticle) ToFeedsItem() *feeds.Item {
+	if ca == nil {
+		return nil
+	}
+
+	item := &feeds.Item{
+		Title:       ca.Title,
+		Link:        &feeds.Link{Href: ca.Link},
+		Description: ca.Description,
+		Id:          ca.Id,
+		Updated:     ca.Updated,
+		Created:     ca.Created,
+		Content:     ca.Content,
+	}
+
+	if ca.AuthorName != "" || ca.AuthorEmail != "" {
+		item.Author = &feeds.Author{
+			Name:  ca.AuthorName,
+			Email: ca.AuthorEmail,
+		}
+	}
+
+	return item
+}
+
+// FromFeedsFeed converts a Gorilla feeds.Feed back to a CraftFeed.
+// This is primarily used by the LegacyOptionAdapter to capture state after legacy CraftOptions run.
+func FromFeedsFeed(ff *feeds.Feed) *CraftFeed {
+	if ff == nil {
+		return nil
+	}
+
+	cf := &CraftFeed{
+		Title:       ff.Title,
+		Description: ff.Description,
+		Updated:     ff.Updated,
+		Created:     ff.Created,
+		Id:          ff.Id,
+		Copyright:   ff.Copyright,
+	}
+
+	if ff.Link != nil {
+		cf.Link = ff.Link.Href
+	}
+	if ff.Author != nil {
+		cf.AuthorName = ff.Author.Name
+		cf.AuthorEmail = ff.Author.Email
+	}
+	if ff.Image != nil {
+		cf.ImageURL = ff.Image.Url
+		cf.ImageTitle = ff.Image.Title
+	}
+
+	cf.Articles = lo.Map(ff.Items, func(item *feeds.Item, _ int) *CraftArticle {
+		ca := &CraftArticle{
+			Title:       item.Title,
+			Description: item.Description,
+			Id:          item.Id,
+			Updated:     item.Updated,
+			Created:     item.Created,
+			Content:     item.Content,
+		}
+		if item.Link != nil {
+			ca.Link = item.Link.Href
+		}
+		if item.Author != nil {
+			ca.AuthorName = item.Author.Name
+			ca.AuthorEmail = item.Author.Email
+		}
+		return ca
+	})
+
+	return cf
+}

--- a/internal/source/adapter.go
+++ b/internal/source/adapter.go
@@ -1,0 +1,47 @@
+package source
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+
+	"FeedCraft/internal/model"
+	"github.com/sirupsen/logrus"
+)
+
+// LegacySourceAdapter wraps a legacy Source so it can be used as a FeedProvider.
+type LegacySourceAdapter struct {
+	LegacySource Source
+}
+
+func (a *LegacySourceAdapter) Fetch(ctx context.Context) (*model.CraftFeed, error) {
+	rawFeed, err := a.LegacySource.Generate(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	cf := model.FromGofeed(rawFeed)
+
+	// Ensure feed link is absolute, replicating logic from legacy TransformFeed
+	cf.Link = getAbsFeedLink(a.LegacySource.BaseURL(), cf.Link)
+
+	return cf, nil
+}
+
+func getAbsFeedLink(feedUrl, feedLinkAttr string) string {
+	feedLinkUrl, err := url.Parse(feedLinkAttr)
+	if err != nil || feedLinkUrl == nil {
+		logrus.Warnf("invalid feed link url [%s] for feed [%s]", feedLinkAttr, feedUrl)
+	} else {
+		if feedLinkUrl.IsAbs() {
+			return feedLinkAttr
+		}
+	}
+	parsedFeedUrl, err := url.Parse(feedUrl)
+	if err != nil {
+		logrus.Errorf("invalid feed url [%s]. err: %v", feedUrl, err)
+	} else {
+		return fmt.Sprintf("%s://%s", parsedFeedUrl.Scheme, parsedFeedUrl.Host)
+	}
+	return feedLinkAttr
+}

--- a/proposal/refactor_xxxfeed_architecture.md
+++ b/proposal/refactor_xxxfeed_architecture.md
@@ -1,0 +1,90 @@
+# FeedCraft 底层架构重构规划 (Code Refactoring Plan)
+
+## 1. 重构目标
+
+将现有的 `Source - Craft - Recipe` 架构，全面升级为以**“数据产出物 (Feed)”**为核心的流式架构，并引入 `TopicFeed` 聚合能力。
+核心命名体系将全面向 `xxxFeed` 靠拢，实现概念上的极致统一。
+
+## 2. 核心模型与接口定义 (internal/model & engine)
+
+### 2.1 统一数据载体 (The Water)
+消除对第三方 `gofeed.Feed` 的强依赖，在内部使用自定义模型：
+*   **`CraftFeed`**: 包含全局元数据及 Article 列表。
+*   **`CraftArticle`**: 对应原来的 Item/Entry，包含标题、正文，以及新增的追踪字段（如 `Depth`, `QualityScore`, `OriginalFeedID`）。
+
+### 2.2 核心接口定义 (The Interfaces)
+在 `internal/engine` 中定义两个极简接口：
+
+1.  **FeedProvider**: 任何能产出 `CraftFeed` 的节点。
+    ```go
+    type FeedProvider interface {
+        // 使用 Fetch 替代 GetFeed，避免 RecipeFeed.GetFeed() 的冗余感
+        Fetch(ctx context.Context) (*model.CraftFeed, error)
+    }
+    ```
+2.  **FeedProcessor**: 任何能加工 `CraftFeed` 的节点。
+    ```go
+    type FeedProcessor interface {
+        Process(ctx context.Context, feed *model.CraftFeed) (*model.CraftFeed, error)
+    }
+    ```
+
+## 3. 具体业务对象的实现映射
+
+### 3.1 RawFeed (原 Source 层)
+*   **重构动作**：将现有的 `HtmlSource`, `SearchSource`, `RssSource` 等模块的返回值，从 `gofeed.Feed` 改为 `model.CraftFeed`。
+*   **定位**：它们实现了 `FeedProvider` 接口，是流水线的起点。
+
+### 3.2 Crafts (加工层保持原样，仅改签名)
+*   **重构动作**：将所有的 `AtomCraft`（如 translate, summary）的接口签名改为接收和返回 `model.CraftFeed`。
+*   **FlowCraft**：本质上是一个包含 `[]FeedProcessor` 的结构体。
+
+### 3.3 RecipeFeed (单线配方源)
+*   **重构动作**：重构引擎层，将数据库中的 `Recipe` 模型在运行时构建为一个实现 `FeedProvider` 接口的对象。
+*   **执行逻辑**：
+    ```go
+    type RecipeFeed struct {
+        Base  FeedProvider     // 例如 RssSource (RawFeed)
+        Craft FeedProcessor    // 例如 FlowCraft
+    }
+    func (r *RecipeFeed) Fetch(ctx) (*CraftFeed, error) {
+        rawFeed, _ := r.Base.Fetch(ctx)
+        return r.Craft.Process(ctx, rawFeed)
+    }
+    ```
+
+### 3.4 TopicFeed (多线聚合源)
+*   **重构动作**：新增 `TopicFeed` 结构，它同样实现 `FeedProvider` 接口，支持嵌套组合。
+*   **执行逻辑**：
+    ```go
+    type TopicFeed struct {
+        Inputs     []FeedProvider  // 可以是 RecipeFeed，也可以是其他 TopicFeed
+        Aggregator FeedProcessor   // 负责去重、排序、截断的特殊处理器
+    }
+    func (t *TopicFeed) Fetch(ctx) (*CraftFeed, error) {
+        // 1. 并发调用所有的 Inputs.Fetch() 获取多个子 Feed
+        // 2. 将数据合并为一个大的临时 CraftFeed
+        // 3. 调用 t.Aggregator.Process() 进行过滤和截断
+        // 4. 返回最终的 CraftFeed
+    }
+    ```
+
+## 4. 重构实施步骤 (Implementation Steps)
+
+1.  **Phase 1: 模型基建**
+    *   在 `internal/model` 创建 `CraftFeed` 和 `CraftArticle`。
+    *   提供 `ToGofeed()` 和 `FromGofeed()` 转换函数，保证现有前端阅读器和第三方库的兼容。
+2.  **Phase 2: 接口改造**
+    *   修改所有 `Source` 抓取器的返回值。
+    *   修改所有 `Craft` 插件的入参和出参。
+    *   *此时，编译会报大量错误，需要逐个修复引擎层的调用。*
+3.  **Phase 3: 引擎升级 (RecipeFeed)**
+    *   重写现有的执行流，使其符合 `Provider -> Processor` 的新接口模式。测试所有的基础单线流是否正常工作。
+4.  **Phase 4: 引入 TopicFeed**
+    *   实现并发抓取逻辑 (使用 `errgroup`)。
+    *   实现 `Aggregator` 处理器（包含基础的 URL 去重和条数 Limit）。
+    *   暴露新的路由 `GET /topic/:id`。
+
+## 5. 遗留问题与风险点
+*   在 Phase 2 和 Phase 3 期间，整个应用可能处于不可用状态。建议在单独的 `feature/refactor-lego-flow` 分支上进行开发。
+*   缓存层的适配：原来的 Recipe 是直接缓存 XML，现在可能需要考虑是缓存最终的 XML 还是中间的 `CraftFeed` 对象（建议依然缓存最终输出的 XML 文本，保持简单）。

--- a/proposal/refactor_xxxfeed_architecture.md
+++ b/proposal/refactor_xxxfeed_architecture.md
@@ -8,11 +8,14 @@
 ## 2. 核心模型与接口定义 (internal/model & engine)
 
 ### 2.1 统一数据载体 (The Water)
+
 消除对第三方 `gofeed.Feed` 的强依赖，在内部使用自定义模型：
-*   **`CraftFeed`**: 包含全局元数据及 Article 列表。
-*   **`CraftArticle`**: 对应原来的 Item/Entry，包含标题、正文，以及新增的追踪字段（如 `Depth`, `QualityScore`, `OriginalFeedID`）。
+
+- **`CraftFeed`**: 包含全局元数据及 Article 列表。
+- **`CraftArticle`**: 对应原来的 Item/Entry，包含标题、正文，以及新增的追踪字段（如 `Depth`, `QualityScore`, `OriginalFeedID`）。
 
 ### 2.2 核心接口定义 (The Interfaces)
+
 在 `internal/engine` 中定义两个极简接口：
 
 1.  **FeedProvider**: 任何能产出 `CraftFeed` 的节点。
@@ -32,59 +35,64 @@
 ## 3. 具体业务对象的实现映射
 
 ### 3.1 RawFeed (原 Source 层)
-*   **重构动作**：将现有的 `HtmlSource`, `SearchSource`, `RssSource` 等模块的返回值，从 `gofeed.Feed` 改为 `model.CraftFeed`。
-*   **定位**：它们实现了 `FeedProvider` 接口，是流水线的起点。
+
+- **重构动作**：将现有的 `HtmlSource`, `SearchSource`, `RssSource` 等模块的返回值，从 `gofeed.Feed` 改为 `model.CraftFeed`。
+- **定位**：它们实现了 `FeedProvider` 接口，是流水线的起点。
 
 ### 3.2 Crafts (加工层保持原样，仅改签名)
-*   **重构动作**：将所有的 `AtomCraft`（如 translate, summary）的接口签名改为接收和返回 `model.CraftFeed`。
-*   **FlowCraft**：本质上是一个包含 `[]FeedProcessor` 的结构体。
+
+- **重构动作**：将所有的 `AtomCraft`（如 translate, summary）的接口签名改为接收和返回 `model.CraftFeed`。
+- **FlowCraft**：本质上是一个包含 `[]FeedProcessor` 的结构体。
 
 ### 3.3 RecipeFeed (单线配方源)
-*   **重构动作**：重构引擎层，将数据库中的 `Recipe` 模型在运行时构建为一个实现 `FeedProvider` 接口的对象。
-*   **执行逻辑**：
-    ```go
-    type RecipeFeed struct {
-        Base  FeedProvider     // 例如 RssSource (RawFeed)
-        Craft FeedProcessor    // 例如 FlowCraft
-    }
-    func (r *RecipeFeed) Fetch(ctx) (*CraftFeed, error) {
-        rawFeed, _ := r.Base.Fetch(ctx)
-        return r.Craft.Process(ctx, rawFeed)
-    }
-    ```
+
+- **重构动作**：重构引擎层，将数据库中的 `Recipe` 模型在运行时构建为一个实现 `FeedProvider` 接口的对象。
+- **执行逻辑**：
+  ```go
+  type RecipeFeed struct {
+      Base  FeedProvider     // 例如 RssSource (RawFeed)
+      Craft FeedProcessor    // 例如 FlowCraft
+  }
+  func (r *RecipeFeed) Fetch(ctx) (*CraftFeed, error) {
+      rawFeed, _ := r.Base.Fetch(ctx)
+      return r.Craft.Process(ctx, rawFeed)
+  }
+  ```
 
 ### 3.4 TopicFeed (多线聚合源)
-*   **重构动作**：新增 `TopicFeed` 结构，它同样实现 `FeedProvider` 接口，支持嵌套组合。
-*   **执行逻辑**：
-    ```go
-    type TopicFeed struct {
-        Inputs     []FeedProvider  // 可以是 RecipeFeed，也可以是其他 TopicFeed
-        Aggregator FeedProcessor   // 负责去重、排序、截断的特殊处理器
-    }
-    func (t *TopicFeed) Fetch(ctx) (*CraftFeed, error) {
-        // 1. 并发调用所有的 Inputs.Fetch() 获取多个子 Feed
-        // 2. 将数据合并为一个大的临时 CraftFeed
-        // 3. 调用 t.Aggregator.Process() 进行过滤和截断
-        // 4. 返回最终的 CraftFeed
-    }
-    ```
+
+- **重构动作**：新增 `TopicFeed` 结构，它同样实现 `FeedProvider` 接口，支持嵌套组合。
+- **执行逻辑**：
+  ```go
+  type TopicFeed struct {
+      Inputs     []FeedProvider  // 可以是 RecipeFeed，也可以是其他 TopicFeed
+      Aggregator FeedProcessor   // 负责去重、排序、截断的特殊处理器
+  }
+  func (t *TopicFeed) Fetch(ctx) (*CraftFeed, error) {
+      // 1. 并发调用所有的 Inputs.Fetch() 获取多个子 Feed
+      // 2. 将数据合并为一个大的临时 CraftFeed
+      // 3. 调用 t.Aggregator.Process() 进行过滤和截断
+      // 4. 返回最终的 CraftFeed
+  }
+  ```
 
 ## 4. 重构实施步骤 (Implementation Steps)
 
 1.  **Phase 1: 模型基建**
-    *   在 `internal/model` 创建 `CraftFeed` 和 `CraftArticle`。
-    *   提供 `ToGofeed()` 和 `FromGofeed()` 转换函数，保证现有前端阅读器和第三方库的兼容。
+    - 在 `internal/model` 创建 `CraftFeed` 和 `CraftArticle`。
+    - 提供 `ToGofeed()` 和 `FromGofeed()` 转换函数，保证现有前端阅读器和第三方库的兼容。
 2.  **Phase 2: 接口改造**
-    *   修改所有 `Source` 抓取器的返回值。
-    *   修改所有 `Craft` 插件的入参和出参。
-    *   *此时，编译会报大量错误，需要逐个修复引擎层的调用。*
+    - 修改所有 `Source` 抓取器的返回值。
+    - 修改所有 `Craft` 插件的入参和出参。
+    - _此时，编译会报大量错误，需要逐个修复引擎层的调用。_
 3.  **Phase 3: 引擎升级 (RecipeFeed)**
-    *   重写现有的执行流，使其符合 `Provider -> Processor` 的新接口模式。测试所有的基础单线流是否正常工作。
+    - 重写现有的执行流，使其符合 `Provider -> Processor` 的新接口模式。测试所有的基础单线流是否正常工作。
 4.  **Phase 4: 引入 TopicFeed**
-    *   实现并发抓取逻辑 (使用 `errgroup`)。
-    *   实现 `Aggregator` 处理器（包含基础的 URL 去重和条数 Limit）。
-    *   暴露新的路由 `GET /topic/:id`。
+    - 实现并发抓取逻辑 (使用 `errgroup`)。
+    - 实现 `Aggregator` 处理器（包含基础的 URL 去重和条数 Limit）。
+    - 暴露新的路由 `GET /topic/:id`。
 
 ## 5. 遗留问题与风险点
-*   在 Phase 2 和 Phase 3 期间，整个应用可能处于不可用状态。建议在单独的 `feature/refactor-lego-flow` 分支上进行开发。
-*   缓存层的适配：原来的 Recipe 是直接缓存 XML，现在可能需要考虑是缓存最终的 XML 还是中间的 `CraftFeed` 对象（建议依然缓存最终输出的 XML 文本，保持简单）。
+
+- 在 Phase 2 和 Phase 3 期间，整个应用可能处于不可用状态。建议在单独的 `feature/refactor-lego-flow` 分支上进行开发。
+- 缓存层的适配：原来的 Recipe 是直接缓存 XML，现在可能需要考虑是缓存最终的 XML 还是中间的 `CraftFeed` 对象（建议依然缓存最终输出的 XML 文本，保持简单）。


### PR DESCRIPTION
## Summary by Sourcery

Introduce a new feed-centric engine pipeline with unified models and adapters, and add support for aggregating multiple feeds into topic-based feeds.

New Features:
- Add CraftFeed and CraftArticle as unified internal feed models decoupled from gofeed.
- Introduce TopicFeed to aggregate multiple feed providers with optional post-processing via an aggregator pipeline.
- Expose aggregation utilities (deduplicate, sort, limit) and a composable FlowCraftProcessor for building processing pipelines.

Enhancements:
- Refactor the common craft handler to run legacy sources and options through the new FeedProvider/FeedProcessor engine pipeline.
- Add adapters to wrap legacy sources and craft options so they interoperate with the new feed engine.
- Define minimal FeedProvider and FeedProcessor interfaces to standardize feed generation and processing across the system.

Documentation:
- Add a refactoring proposal document describing the new xxxFeed-centric architecture and migration plan.

Tests:
- Add unit tests for aggregator processors (deduplication, sorting, limiting) and their composition in FlowCraftProcessor.
- Add unit tests for TopicFeed covering successful aggregation, partial failures, and aggregator integration.

Chores:
- Add a TopicFeed persistence model with aggregator configuration, CRUD helpers, and include it in database migrations.