### PR TITLE
feat: add Topic Feed CRUD API and Admin Web Pages

### DIFF
--- a/internal/controller/topic_feed.go
+++ b/internal/controller/topic_feed.go
@@ -1,0 +1,99 @@
+package controller
+
+import (
+	"FeedCraft/internal/dao"
+	"FeedCraft/internal/util"
+	"errors"
+	"github.com/gin-gonic/gin"
+	"gorm.io/gorm"
+	"net/http"
+)
+
+func CreateTopicFeed(c *gin.Context) {
+	var topicData dao.TopicFeed
+	if err := c.ShouldBindJSON(&topicData); err != nil {
+		c.JSON(http.StatusBadRequest, util.APIResponse[any]{Msg: err.Error()})
+		return
+	}
+	db := util.GetDatabase()
+
+	if err := dao.CreateTopicFeed(db, &topicData); err != nil {
+		c.JSON(http.StatusInternalServerError, util.APIResponse[any]{Msg: err.Error()})
+		return
+	}
+
+	c.JSON(http.StatusCreated, util.APIResponse[any]{Data: topicData})
+}
+
+func GetTopicFeed(c *gin.Context) {
+	id := c.Param("id")
+	db := util.GetDatabase()
+
+	topicData, err := dao.GetTopicFeedByID(db, id)
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			c.JSON(http.StatusNotFound, util.APIResponse[any]{Msg: "Topic feed not found"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, util.APIResponse[any]{Msg: err.Error()})
+		return
+	}
+
+	c.JSON(http.StatusOK, util.APIResponse[any]{Data: topicData})
+}
+
+func ListTopicFeeds(c *gin.Context) {
+	db := util.GetDatabase()
+	topicList, err := dao.ListTopicFeeds(db)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, util.APIResponse[any]{Msg: err.Error()})
+		return
+	}
+
+	c.JSON(http.StatusOK, util.APIResponse[any]{Data: topicList})
+}
+
+func UpdateTopicFeed(c *gin.Context) {
+	id := c.Param("id")
+	var topicData dao.TopicFeed
+	if err := c.ShouldBindJSON(&topicData); err != nil {
+		c.JSON(http.StatusBadRequest, util.APIResponse[any]{Msg: err.Error()})
+		return
+	}
+
+	// Ensure the ID in the URL matches the ID in the body
+	if id != topicData.ID {
+		topicData.ID = id
+	}
+
+	db := util.GetDatabase()
+
+	_, err := dao.GetTopicFeedByID(db, id)
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			c.JSON(http.StatusNotFound, util.APIResponse[any]{Msg: "Topic feed not found"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, util.APIResponse[any]{Msg: err.Error()})
+		return
+	}
+
+	if err := dao.UpdateTopicFeed(db, &topicData); err != nil {
+		c.JSON(http.StatusInternalServerError, util.APIResponse[any]{Msg: err.Error()})
+		return
+	}
+
+	c.JSON(http.StatusOK, util.APIResponse[any]{Data: topicData})
+}
+
+func DeleteTopicFeed(c *gin.Context) {
+	id := c.Param("id")
+	db := util.GetDatabase()
+
+	if err := dao.DeleteTopicFeed(db, id); err != nil {
+		c.JSON(http.StatusInternalServerError, util.APIResponse[any]{Msg: err.Error()})
+		return
+	}
+
+	c.JSON(http.StatusOK, util.APIResponse[any]{})
+}

--- a/internal/router/registry.go
+++ b/internal/router/registry.go
@@ -81,6 +81,12 @@ func RegisterRouters(router *gin.Engine) {
 		adminApi.POST("/craft-debug/advertorial", craft.DebugCheckIfAdvertorial)
 		adminApi.POST("/craft-debug/common-llm-call-test", admin.LLMDebug)
 
+		adminApi.POST("/topics", controller.CreateTopicFeed)
+		adminApi.GET("/topics", controller.ListTopicFeeds)
+		adminApi.GET("/topics/:id", controller.GetTopicFeed)
+		adminApi.PUT("/topics/:id", controller.UpdateTopicFeed)
+		adminApi.DELETE("/topics/:id", controller.DeleteTopicFeed)
+
 		adminApi.POST("/recipes", controller.CreateCustomRecipe)
 		adminApi.GET("/recipes", controller.ListCustomRecipe)
 		adminApi.GET("/recipes/:id", controller.GetCustomRecipe)

--- a/web/admin/components.d.ts
+++ b/web/admin/components.d.ts
@@ -5,11 +5,11 @@
 // Read more: https://github.com/vuejs/core/pull/3399
 import '@vue/runtime-core'
 
-export {};
+export {}
 
 declare module '@vue/runtime-core' {
   export interface GlobalComponents {
-    RouterLink: (typeof import('vue-router'))['RouterLink'];
-    RouterView: (typeof import('vue-router'))['RouterView'];
+    RouterLink: typeof import('vue-router')['RouterLink']
+    RouterView: typeof import('vue-router')['RouterView']
   }
 }

--- a/web/admin/src/api/topic.ts
+++ b/web/admin/src/api/topic.ts
@@ -1,0 +1,52 @@
+import axios from 'axios';
+import { APIResponse } from './types';
+
+export interface AggregatorStep {
+  type: string;
+  option: Record<string, string>;
+}
+
+export interface TopicFeed {
+  id: string;
+  title?: string;
+  description?: string;
+  input_uris: string[];
+  aggregator_config: AggregatorStep[];
+}
+
+const adminApiBase = '/api/admin';
+
+export function createTopicFeed(
+  data: TopicFeed
+): Promise<APIResponse<TopicFeed>> {
+  return axios
+    .post<APIResponse<TopicFeed>>(`${adminApiBase}/topics`, data)
+    .then((res) => res.data);
+}
+
+export function listTopicFeeds(): Promise<APIResponse<TopicFeed[]>> {
+  return axios
+    .get<APIResponse<TopicFeed[]>>(`${adminApiBase}/topics`)
+    .then((res) => res.data);
+}
+
+export function getTopicFeed(id: string): Promise<APIResponse<TopicFeed>> {
+  return axios
+    .get<APIResponse<TopicFeed>>(`${adminApiBase}/topics/${id}`)
+    .then((res) => res.data);
+}
+
+export function updateTopicFeed(
+  id: string,
+  data: TopicFeed
+): Promise<APIResponse<TopicFeed>> {
+  return axios
+    .put<APIResponse<TopicFeed>>(`${adminApiBase}/topics/${id}`, data)
+    .then((res) => res.data);
+}
+
+export function deleteTopicFeed(id: string): Promise<APIResponse<void>> {
+  return axios
+    .delete<APIResponse<void>>(`${adminApiBase}/topics/${id}`)
+    .then((res) => res.data);
+}

--- a/web/admin/src/locale/en-US/menu.ts
+++ b/web/admin/src/locale/en-US/menu.ts
@@ -23,6 +23,7 @@ export default {
   'menu.craftAtom': 'AtomCraft',
   'menu.craftFlow': 'FlowCraft',
   'menu.customRecipe': 'Custom Recipe',
+  'menu.topicFeed': 'Topic Feed',
   'menu.allCraftList': 'All Craft List',
   'menu.quickStart': 'Quick Start',
   'menu.dashboard.welcome': 'Welcome',

--- a/web/admin/src/locale/zh-CN/menu.ts
+++ b/web/admin/src/locale/zh-CN/menu.ts
@@ -23,6 +23,7 @@ export default {
   'menu.craftAtom': '原子工艺 (AtomCraft)',
   'menu.craftFlow': '组合工艺 (FlowCraft)',
   'menu.customRecipe': '自定义配方',
+  'menu.topicFeed': '主题订阅',
   'menu.allCraftList': '所有 Craft 列表',
   'menu.quickStart': '快速开始',
   'menu.dashboard.welcome': '欢迎页',

--- a/web/admin/src/router/routes/modules/worktable.ts
+++ b/web/admin/src/router/routes/modules/worktable.ts
@@ -13,6 +13,16 @@ const WORKTABLE: AppRouteRecordRaw = {
   },
   children: [
     {
+      path: 'topic_feed',
+      name: 'TopicFeed',
+      component: () =>
+        import('@/views/dashboard/topic_feed/topic_feed.vue'),
+      meta: {
+        requiresAuth: true,
+        locale: 'menu.topicFeed',
+      },
+    },
+    {
       path: 'custom_recipe',
       name: 'CustomRecipe',
       component: () =>

--- a/web/admin/src/views/dashboard/topic_feed/topic_feed.vue
+++ b/web/admin/src/views/dashboard/topic_feed/topic_feed.vue
@@ -1,0 +1,243 @@
+<template>
+  <div class="container">
+    <Breadcrumb :items="['menu.worktable', 'menu.topicFeed']" />
+    <a-card class="general-card" :title="$t('menu.topicFeed')">
+      <template #extra>
+        <a-button type="primary" @click="handleAdd">
+          <template #icon>
+            <icon-plus />
+          </template>
+          Create Topic
+        </a-button>
+      </template>
+
+      <a-table :data="topics" :loading="loading" :pagination="false">
+        <template #columns>
+          <a-table-column title="ID" data-index="id" />
+          <a-table-column title="Title" data-index="title" />
+          <a-table-column title="Description" data-index="description" />
+          <a-table-column title="Input URIs">
+            <template #cell="{ record }">
+              <div v-for="(uri, idx) in record.input_uris" :key="idx">
+                {{ uri }}
+              </div>
+            </template>
+          </a-table-column>
+          <a-table-column title="Actions">
+            <template #cell="{ record }">
+              <a-space>
+                <a-button type="text" size="small" @click="handleEdit(record)">
+                  Edit
+                </a-button>
+                <a-popconfirm
+                  content="Are you sure you want to delete this topic?"
+                  @ok="handleDelete(record.id)"
+                >
+                  <a-button type="text" status="danger" size="small">
+                    Delete
+                  </a-button>
+                </a-popconfirm>
+              </a-space>
+            </template>
+          </a-table-column>
+        </template>
+      </a-table>
+    </a-card>
+
+    <a-modal
+      v-model:visible="modalVisible"
+      :title="isEdit ? 'Edit Topic' : 'Create Topic'"
+      @ok="handleSubmit"
+      @cancel="modalVisible = false"
+    >
+      <a-form :model="formData" layout="vertical">
+        <a-form-item
+          field="id"
+          label="ID"
+          :rules="[{ required: true, message: 'ID is required' }]"
+        >
+          <a-input v-model="formData.id" :disabled="isEdit" />
+        </a-form-item>
+        <a-form-item field="title" label="Title">
+          <a-input v-model="formData.title" />
+        </a-form-item>
+        <a-form-item field="description" label="Description">
+          <a-textarea v-model="formData.description" />
+        </a-form-item>
+
+        <a-form-item label="Input URIs">
+          <div v-for="(uri, idx) in formData.input_uris" :key="idx" class="uri-input">
+            <a-input v-model="formData.input_uris[idx]" placeholder="e.g. feedcraft://recipe/my-recipe" />
+            <a-button type="text" status="danger" @click="removeUri(idx)">
+              <icon-delete />
+            </a-button>
+          </div>
+          <a-button type="dashed" long @click="addUri">
+            <icon-plus /> Add URI
+          </a-button>
+        </a-form-item>
+
+        <a-form-item label="Aggregator Config">
+          <div v-for="(step, idx) in formData.aggregator_config" :key="idx" class="aggregator-step">
+            <a-space>
+              <a-select v-model="step.type" style="width: 120px" placeholder="Type">
+                <a-option value="deduplicate">Deduplicate</a-option>
+                <a-option value="sort">Sort</a-option>
+                <a-option value="limit">Limit</a-option>
+              </a-select>
+              <a-input v-model="step.optionKey" placeholder="Option Key" style="width: 100px" />
+              <a-input v-model="step.optionValue" placeholder="Option Value" style="width: 100px" />
+              <a-button type="text" status="danger" @click="removeStep(idx)">
+                <icon-delete />
+              </a-button>
+            </a-space>
+          </div>
+          <a-button type="dashed" long @click="addStep" style="margin-top: 8px">
+            <icon-plus /> Add Step
+          </a-button>
+        </a-form-item>
+      </a-form>
+    </a-modal>
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { ref, onMounted } from 'vue';
+import { Message } from '@arco-design/web-vue';
+import {
+  listTopicFeeds,
+  createTopicFeed,
+  updateTopicFeed,
+  deleteTopicFeed,
+  TopicFeed,
+} from '@/api/topic';
+
+const topics = ref<TopicFeed[]>([]);
+const loading = ref(false);
+const modalVisible = ref(false);
+const isEdit = ref(false);
+
+const defaultFormData = {
+  id: '',
+  title: '',
+  description: '',
+  input_uris: [],
+  aggregator_config: [],
+};
+
+const formData = ref<any>(JSON.parse(JSON.stringify(defaultFormData)));
+
+const fetchTopics = async () => {
+  loading.value = true;
+  try {
+    const res = await listTopicFeeds();
+    topics.value = res.data;
+  } catch (err) {
+    Message.error('Failed to fetch topics');
+  } finally {
+    loading.value = false;
+  }
+};
+
+const handleAdd = () => {
+  isEdit.value = false;
+  formData.value = JSON.parse(JSON.stringify(defaultFormData));
+  modalVisible.value = true;
+};
+
+const handleEdit = (record: TopicFeed) => {
+  isEdit.value = true;
+  const configWithKV = (record.aggregator_config || []).map(step => {
+    const key = Object.keys(step.option || {})[0] || '';
+    const value = step.option?.[key] || '';
+    return {
+      type: step.type,
+      optionKey: key,
+      optionValue: value
+    };
+  });
+
+  formData.value = {
+    ...record,
+    aggregator_config: configWithKV,
+  };
+  modalVisible.value = true;
+};
+
+const handleDelete = async (id: string) => {
+  try {
+    await deleteTopicFeed(id);
+    Message.success('Deleted successfully');
+    fetchTopics();
+  } catch (err) {
+    Message.error('Failed to delete');
+  }
+};
+
+const addUri = () => {
+  formData.value.input_uris.push('');
+};
+
+const removeUri = (idx: number) => {
+  formData.value.input_uris.splice(idx, 1);
+};
+
+const addStep = () => {
+  formData.value.aggregator_config.push({ type: 'limit', optionKey: 'max', optionValue: '50' });
+};
+
+const removeStep = (idx: number) => {
+  formData.value.aggregator_config.splice(idx, 1);
+};
+
+const handleSubmit = async () => {
+  try {
+    const payload: TopicFeed = {
+      id: formData.value.id,
+      title: formData.value.title,
+      description: formData.value.description,
+      input_uris: formData.value.input_uris.filter((u: string) => u.trim() !== ''),
+      aggregator_config: formData.value.aggregator_config.map((s: any) => ({
+        type: s.type,
+        option: s.optionKey ? { [s.optionKey]: s.optionValue } : {}
+      }))
+    };
+
+    if (isEdit.value) {
+      await updateTopicFeed(payload.id, payload);
+      Message.success('Updated successfully');
+    } else {
+      await createTopicFeed(payload);
+      Message.success('Created successfully');
+    }
+    modalVisible.value = false;
+    fetchTopics();
+  } catch (err) {
+    Message.error(isEdit.value ? 'Failed to update' : 'Failed to create');
+  }
+};
+
+onMounted(() => {
+  fetchTopics();
+});
+</script>
+
+<script lang="ts">
+  export default {
+    name: 'TopicFeed',
+  };
+</script>
+
+<style scoped>
+.container {
+  padding: 0 20px 20px 20px;
+}
+.uri-input {
+  display: flex;
+  margin-bottom: 8px;
+  gap: 8px;
+}
+.aggregator-step {
+  margin-bottom: 8px;
+}
+</style>


### PR DESCRIPTION
This PR introduces the CRUD API and admin web pages for the "Topic Feed" feature based on the design in `proposal/topic_aggregation_design.md`.

It implements the backend controllers and routes for manipulating Topic Feeds, as well as the frontend API client and Vue components for interacting with this data within the Worktable section of the admin panel. Fully verified via testing and frontend integration verification.

---
*PR created automatically by Jules for task [2388603272297568221](https://jules.google.com/task/2388603272297568221) started by @Colin-XKL*

## Summary by Sourcery

Add CRUD support for Topic Feeds in the admin backend and expose a corresponding management page in the Worktable section of the admin UI.

New Features:
- Introduce RESTful admin API endpoints to create, list, retrieve, update, and delete Topic Feeds.
- Add a TypeScript API client and Vue-based Topic Feed management page under the Worktable section for creating and editing topics, input URIs, and aggregator configuration.

Enhancements:
- Extend admin routing and i18n menu entries to surface the new Topic Feed page in both English and Chinese locales.