### PR TITLE
feat: add template options to curl-to-rss

### DIFF
--- a/doc-site/src/content/docs/en/guides/advanced/curl-to-rss.md
+++ b/doc-site/src/content/docs/en/guides/advanced/curl-to-rss.md
@@ -1,6 +1,6 @@
 ---
 title: CURL to RSS
-description: Convert any JSON API response into an RSS feed using jq selectors.
+description: Convert any JSON API response into an RSS feed with jq selectors and optional templates.
 sidebar:
   order: 3
   badge:
@@ -8,14 +8,14 @@ sidebar:
     variant: success
 ---
 
-FeedCraft includes a **CURL to RSS** tool that allows you to fetch data from JSON APIs and transform it into an RSS feed using `jq` selectors.
+FeedCraft includes a **CURL to RSS** tool that allows you to fetch data from JSON APIs, extract fields with `jq`, and optionally post-process them with templates before generating an RSS feed.
 
 ## Overview
 
 The CURL to RSS tool helps you:
 
 1.  **Fetch** JSON data from an API endpoint (supporting custom headers and methods).
-2.  **Parse** the JSON structure using `jq` syntax to map fields to RSS items.
+2.  **Parse** the JSON structure using `jq` syntax, then optionally use templates to build the final RSS fields.
 3.  **Metadata** Define feed details like title and description.
 4.  **Save** the configuration as a Custom Recipe directly.
 
@@ -39,12 +39,14 @@ Click **Fetch and Next** to retrieve the data.
 
 Once the JSON is fetched, you will see the raw response in the left panel (visualized as a tree). You can now define selectors to extract feed items.
 
-The tool uses **[jq](https://jqlang.github.io/jq/)** syntax for querying JSON.
+The tool uses **[jq](https://jqlang.github.io/jq/)** syntax for querying JSON, and it can optionally apply Go templates to the extracted values.
 
 - **List Selector** (Items Iterator): The path to the array of items.
   - Tip: You can click on a node in the tree view to auto-fill selectors.
 - **Title Selector**: The path to the item's title _relative to the item object_.
+- **Title Template**: Optional. Post-process the extracted title, for example `{{ .Fields.Title | trimSpace }}`.
 - **Link Selector**: The path to the item's URL.
+- **Link Template**: Optional. Useful when the API only returns an ID, for example `https://some-website.com/article/{{ .Item.id }}`.
 - **Date Selector**: (Optional) Path to the publication date.
 - **Content Selector**: (Optional) Path to the full content or summary.
 

--- a/doc-site/src/content/docs/zh/guides/advanced/curl-to-rss.md
+++ b/doc-site/src/content/docs/zh/guides/advanced/curl-to-rss.md
@@ -1,6 +1,6 @@
 ---
 title: 从CURL语句生成RSS
-description: 使用 jq 选择器将任意 JSON API 响应转换为 RSS 订阅源。
+description: 使用 jq 提取字段，并通过可选模板将任意 JSON API 响应转换为 RSS 订阅源。
 sidebar:
   order: 3
   badge:
@@ -8,14 +8,14 @@ sidebar:
     variant: success
 ---
 
-FeedCraft 包含一个 **从CURL语句生成RSS (CURL to RSS)** 工具，允许你从 JSON API 获取数据并使用 `jq` 选择器将其转换为 RSS 订阅源。
+FeedCraft 包含一个 **从CURL语句生成RSS (CURL to RSS)** 工具，允许你从 JSON API 获取数据，先用 `jq` 提取字段，再通过可选模板将其转换为 RSS 订阅源。
 
 ## 概览
 
 JSON RSS 生成器可以帮助你：
 
 1.  **抓取 (Fetch)**：从 API 端点抓取 JSON 数据（支持自定义请求头和方法）。
-2.  **解析 (Parse)**：使用 `jq` 语法解析 JSON 结构，将字段映射到 RSS 条目。
+2.  **解析 (Parse)**：使用 `jq` 语法解析 JSON 结构，并可通过模板拼接或清理 RSS 字段。
 3.  **元数据 (Metadata)**：定义订阅源的标题和描述等详情。
 4.  **保存 (Save)**：直接将配置保存为自定义食谱。
 
@@ -39,12 +39,14 @@ JSON RSS 生成器可以帮助你：
 
 获取到 JSON 后，你将在左侧面板看到以树形可视化的响应。现在你可以定义选择器来提取订阅源条目。
 
-该工具使用 **[jq](https://jqlang.github.io/jq/)** 语法来查询 JSON。
+该工具使用 **[jq](https://jqlang.github.io/jq/)** 语法来查询 JSON，并支持对提取结果再做一层 Go template 加工。
 
 - **列表选择器 (Items Iterator)**：条目数组的路径。
   - 提示：你可以点击树视图中的节点来自动填充选择器。
 - **标题选择器 (Title Selector)**：条目标题的路径（相对于条目对象）。
+- **标题模板 (Title Template)**：（可选）对提取到的标题做进一步处理，例如 `{{ .Fields.Title | trimSpace }}`。
 - **链接选择器 (Link Selector)**：条目 URL 的路径。
+- **链接模板 (Link Template)**：（可选）当接口没有完整链接时，可以拼接，例如 `https://some-website.com/article/{{ .Item.id }}`。
 - **日期选择器 (Date Selector)**：（可选）发布日期的路径。
 - **内容选择器 (Content Selector)**：（可选）完整内容或摘要的路径。
 

--- a/internal/config/source_config.go
+++ b/internal/config/source_config.go
@@ -37,11 +37,15 @@ type HtmlParserConfig struct {
 
 // JsonParserConfig holds the configuration for parsing JSON content.
 type JsonParserConfig struct {
-	ItemsIterator string `json:"items_iterator"`
-	Title         string `json:"title"`
-	Link          string `json:"link"`
-	Date          string `json:"date,omitempty"`
-	Description   string `json:"description,omitempty"`
+	ItemsIterator       string `json:"items_iterator"`
+	Title               string `json:"title"`
+	TitleTemplate       string `json:"title_template,omitempty"`
+	Link                string `json:"link"`
+	LinkTemplate        string `json:"link_template,omitempty"`
+	Date                string `json:"date,omitempty"`
+	DateTemplate        string `json:"date_template,omitempty"`
+	Description         string `json:"description,omitempty"`
+	DescriptionTemplate string `json:"description_template,omitempty"`
 	// ... other fields
 }
 

--- a/internal/controller/curl_to_rss.go
+++ b/internal/controller/curl_to_rss.go
@@ -1,6 +1,8 @@
 package controller
 
 import (
+	"FeedCraft/internal/config"
+	"FeedCraft/internal/source/parser"
 	"FeedCraft/internal/util"
 	"bytes"
 	"encoding/json"
@@ -9,7 +11,6 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/go-resty/resty/v2"
-	"github.com/itchyny/gojq"
 )
 
 type JsonFetchReq struct {
@@ -23,9 +24,13 @@ type JsonParseReq struct {
 	JsonContent     string `json:"json_content"`
 	ListSelector    string `json:"list_selector"`
 	TitleSelector   string `json:"title_selector"`
+	TitleTemplate   string `json:"title_template"`
 	LinkSelector    string `json:"link_selector"`
+	LinkTemplate    string `json:"link_template"`
 	DateSelector    string `json:"date_selector"`
+	DateTemplate    string `json:"date_template"`
 	ContentSelector string `json:"content_selector"`
+	ContentTemplate string `json:"content_template"`
 }
 
 func CurlParseCmd(c *gin.Context) {
@@ -175,101 +180,30 @@ func CurlParse(c *gin.Context) {
 		return
 	}
 
-	// Execute List Selector
-	listQuery, err := gojq.Parse(req.ListSelector)
+	parsedFields, err := parser.ParseJSONItems(input, &config.JsonParserConfig{
+		ItemsIterator:       req.ListSelector,
+		Title:               req.TitleSelector,
+		TitleTemplate:       req.TitleTemplate,
+		Link:                req.LinkSelector,
+		LinkTemplate:        req.LinkTemplate,
+		Date:                req.DateSelector,
+		DateTemplate:        req.DateTemplate,
+		Description:         req.ContentSelector,
+		DescriptionTemplate: req.ContentTemplate,
+	})
 	if err != nil {
-		c.JSON(http.StatusBadRequest, util.APIResponse[any]{StatusCode: -1, Msg: "List selector error: " + err.Error()})
+		c.JSON(http.StatusBadRequest, util.APIResponse[any]{StatusCode: -1, Msg: err.Error()})
 		return
 	}
 
-	iter := listQuery.Run(input)
-	var rawItems []interface{}
-	for {
-		v, ok := iter.Next()
-		if !ok {
-			break
-		}
-		if err, ok := v.(error); ok {
-			c.JSON(http.StatusBadRequest, util.APIResponse[any]{StatusCode: -1, Msg: "List extraction error: " + err.Error()})
-			return
-		}
-		// If v is a slice, we iterate it. If it's a single object, we take it.
-		// Usually list selector should return an array.
-		// If the selector returns multiple results (like .items[]), append them.
-		// If it returns one array (like .items), we should iterate that array.
-
-		// gojq behavior:
-		// .items returns [obj, obj] -> v is []interface{}
-		// .items[] returns obj, obj... -> v is interface{} (called multiple times)
-
-		if arr, ok := v.([]interface{}); ok {
-			rawItems = append(rawItems, arr...)
-		} else {
-			rawItems = append(rawItems, v)
-		}
-	}
-
-	var parsedItems []ParsedItem
-
-	// Parse other selectors for each item
-	// We need to pre-compile selectors for performance, though not critical here
-	compile := func(q string) (*gojq.Query, error) {
-		if q == "" {
-			return nil, nil
-		}
-		return gojq.Parse(q)
-	}
-
-	titleQ, err := compile(req.TitleSelector)
-	if err != nil {
-		c.JSON(http.StatusBadRequest, util.APIResponse[any]{StatusCode: -1, Msg: "invalid TitleSelector: " + err.Error()})
-		return
-	}
-	linkQ, err := compile(req.LinkSelector)
-	if err != nil {
-		c.JSON(http.StatusBadRequest, util.APIResponse[any]{StatusCode: -1, Msg: "invalid LinkSelector: " + err.Error()})
-		return
-	}
-	dateQ, err := compile(req.DateSelector)
-	if err != nil {
-		c.JSON(http.StatusBadRequest, util.APIResponse[any]{StatusCode: -1, Msg: "invalid DateSelector: " + err.Error()})
-		return
-	}
-	contentQ, err := compile(req.ContentSelector)
-	if err != nil {
-		c.JSON(http.StatusBadRequest, util.APIResponse[any]{StatusCode: -1, Msg: "invalid ContentSelector: " + err.Error()})
-		return
-	}
-
-	runQuery := func(q *gojq.Query, obj interface{}) string {
-		if q == nil {
-			return ""
-		}
-		iter := q.Run(obj)
-		v, ok := iter.Next()
-		if !ok {
-			return ""
-		}
-		if err, ok := v.(error); ok {
-			return "Error: " + err.Error()
-		}
-		// Convert v to string
-		if s, ok := v.(string); ok {
-			return s
-		}
-		// If not string, maybe json representation
-		b, _ := json.Marshal(v)
-		return string(b)
-	}
-
-	for _, rawItem := range rawItems {
-		item := ParsedItem{}
-		item.Title = runQuery(titleQ, rawItem)
-		item.Link = runQuery(linkQ, rawItem)
-		item.Date = runQuery(dateQ, rawItem)
-		item.Content = runQuery(contentQ, rawItem)
-
-		parsedItems = append(parsedItems, item)
+	parsedItems := make([]ParsedItem, 0, len(parsedFields))
+	for _, field := range parsedFields {
+		parsedItems = append(parsedItems, ParsedItem{
+			Title:   field.Title,
+			Link:    field.Link,
+			Date:    field.Date,
+			Content: field.Description,
+		})
 	}
 
 	c.JSON(http.StatusOK, util.APIResponse[[]ParsedItem]{

--- a/internal/source/parser/json_parser.go
+++ b/internal/source/parser/json_parser.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/itchyny/gojq"
 	"github.com/mmcdole/gofeed"
 )
 
@@ -25,117 +24,29 @@ func (p *JsonParser) Parse(data []byte) (*gofeed.Feed, error) {
 	}
 
 	feed := &gofeed.Feed{}
-
-	// Navigate to items array
-	var itemsArray []interface{}
-
-	// If ItemsIterator is empty or ".", use root
-	if p.Config.ItemsIterator == "" || p.Config.ItemsIterator == "." {
-		if arr, ok := rawData.([]interface{}); ok {
-			itemsArray = arr
-		} else {
-			itemsArray = []interface{}{rawData}
-		}
-	} else {
-		query, err := gojq.Parse(p.Config.ItemsIterator)
-		if err != nil {
-			return nil, fmt.Errorf("failed to parse items_iterator '%s': %w", p.Config.ItemsIterator, err)
-		}
-		iter := query.Run(rawData)
-		for {
-			v, ok := iter.Next()
-			if !ok {
-				break
-			}
-			if err, ok := v.(error); ok {
-				return nil, fmt.Errorf("jq execution failed: %w", err)
-			}
-			if arr, ok := v.([]interface{}); ok {
-				itemsArray = append(itemsArray, arr...)
-			} else {
-				itemsArray = append(itemsArray, v)
-			}
-		}
-	}
-
-	// Compile field selectors
-	compile := func(s string) (*gojq.Query, error) {
-		if s == "" {
-			return nil, nil
-		}
-		return gojq.Parse(s)
-	}
-
-	titleQ, err := compile(p.Config.Title)
+	items, err := ParseJSONItems(rawData, p.Config)
 	if err != nil {
-		return nil, fmt.Errorf("invalid title selector: %w", err)
+		return nil, err
 	}
 
-	linkQ, err := compile(p.Config.Link)
-	if err != nil {
-		return nil, fmt.Errorf("invalid link selector: %w", err)
-	}
-
-	dateQ, err := compile(p.Config.Date)
-	if err != nil {
-		return nil, fmt.Errorf("invalid date selector: %w", err)
-	}
-
-	descQ, err := compile(p.Config.Description)
-	if err != nil {
-		return nil, fmt.Errorf("invalid description selector: %w", err)
-	}
-
-	runQuery := func(q *gojq.Query, data interface{}) (interface{}, error) {
-		if q == nil {
-			return nil, nil
-		}
-		iter := q.Run(data)
-		v, ok := iter.Next()
-		if !ok {
-			return nil, nil
-		}
-		if err, ok := v.(error); ok {
-			return nil, err
-		}
-		return v, nil
-	}
-
-	for _, itemNode := range itemsArray {
+	for _, parsedFields := range items {
 		item := &gofeed.Item{}
 
-		if val, err := runQuery(titleQ, itemNode); err != nil {
-			return nil, fmt.Errorf("failed to extract title: %w", err)
-		} else if val != nil {
-			item.Title = fmt.Sprintf("%v", val)
-		}
+		item.Title = parsedFields.Title
+		item.Link = parsedFields.Link
 
-		if val, err := runQuery(linkQ, itemNode); err != nil {
-			return nil, fmt.Errorf("failed to extract link: %w", err)
-		} else if val != nil {
-			item.Link = fmt.Sprintf("%v", val)
-		}
-
-		if val, err := runQuery(dateQ, itemNode); err != nil {
-			return nil, fmt.Errorf("failed to extract date: %w", err)
-		} else if val != nil {
-			dateStr := fmt.Sprintf("%v", val)
-			item.Published = dateStr
+		if parsedFields.Date != "" {
+			item.Published = parsedFields.Date
 			// Attempt to parse into PublishedParsed
-			if t, err := time.Parse(time.RFC3339, dateStr); err == nil {
+			if t, err := time.Parse(time.RFC3339, parsedFields.Date); err == nil {
 				item.PublishedParsed = &t
-			} else if t, err := time.Parse("2006-01-02", dateStr); err == nil {
+			} else if t, err := time.Parse("2006-01-02", parsedFields.Date); err == nil {
 				item.PublishedParsed = &t
 			}
 		}
 
-		if val, err := runQuery(descQ, itemNode); err != nil {
-			return nil, fmt.Errorf("failed to extract description: %w", err)
-		} else if val != nil {
-			item.Description = fmt.Sprintf("%v", val)
-			item.Content = item.Description
-		}
-
+		item.Description = parsedFields.Description
+		item.Content = parsedFields.Description
 		feed.Items = append(feed.Items, item)
 	}
 

--- a/internal/source/parser/json_parser_test.go
+++ b/internal/source/parser/json_parser_test.go
@@ -54,6 +54,63 @@ func TestJsonParser_Parse(t *testing.T) {
 	}
 }
 
+func TestJsonParser_Parse_WithTemplates(t *testing.T) {
+	jsonContent := `{
+	  "items": [
+	    {
+	      "id": " article-1 ",
+	      "title": "  Hello World  ",
+	      "summary": ""
+	    }
+	  ]
+	}`
+
+	cfg := &config.JsonParserConfig{
+		ItemsIterator:       ".items[]",
+		Title:               ".title",
+		TitleTemplate:       "{{ .Fields.Title | trimSpace }}",
+		Link:                ".id",
+		LinkTemplate:        "https://some-website.com/article/{{ .Fields.Link | trimSpace }}",
+		Description:         ".summary",
+		DescriptionTemplate: "{{ default .Fields.Description \"No summary\" }}",
+	}
+
+	parser := &JsonParser{Config: cfg}
+	feed, err := parser.Parse([]byte(jsonContent))
+
+	assert.NoError(t, err)
+	if assert.NotNil(t, feed) && assert.Len(t, feed.Items, 1) {
+		assert.Equal(t, "Hello World", feed.Items[0].Title)
+		assert.Equal(t, "https://some-website.com/article/article-1", feed.Items[0].Link)
+		assert.Equal(t, "No summary", feed.Items[0].Description)
+	}
+}
+
+func TestJsonParser_Parse_WithItemTemplateOnly(t *testing.T) {
+	jsonContent := `{
+	  "items": [
+	    {
+	      "id": "42",
+	      "title": "Entry"
+	    }
+	  ]
+	}`
+
+	cfg := &config.JsonParserConfig{
+		ItemsIterator: ".items[]",
+		Title:         ".title",
+		LinkTemplate:  "https://example.com/article/{{ .Item.id }}",
+	}
+
+	parser := &JsonParser{Config: cfg}
+	feed, err := parser.Parse([]byte(jsonContent))
+
+	assert.NoError(t, err)
+	if assert.NotNil(t, feed) && assert.Len(t, feed.Items, 1) {
+		assert.Equal(t, "https://example.com/article/42", feed.Items[0].Link)
+	}
+}
+
 func TestJsonParser_Parse_Error(t *testing.T) {
 	// Test case where field selector causes a runtime error in jq
 	// e.g. trying to iterate a string
@@ -77,4 +134,21 @@ func TestJsonParser_Parse_Error(t *testing.T) {
 	assert.Error(t, err)
 	assert.Nil(t, feed)
 	assert.Contains(t, err.Error(), "failed to extract title")
+}
+
+func TestJsonParser_Parse_TemplateError(t *testing.T) {
+	jsonContent := `{"items":[{"title":"Hello"}]}`
+
+	cfg := &config.JsonParserConfig{
+		ItemsIterator: ".items[]",
+		Title:         ".title",
+		TitleTemplate: "{{ .Fields.Title ",
+	}
+
+	parser := &JsonParser{Config: cfg}
+	feed, err := parser.Parse([]byte(jsonContent))
+
+	assert.Error(t, err)
+	assert.Nil(t, feed)
+	assert.Contains(t, err.Error(), "invalid title template")
 }

--- a/internal/source/parser/json_transform.go
+++ b/internal/source/parser/json_transform.go
@@ -1,0 +1,234 @@
+package parser
+
+import (
+	"FeedCraft/internal/config"
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"text/template"
+
+	"github.com/itchyny/gojq"
+)
+
+type JsonParsedFields struct {
+	Title       string
+	Link        string
+	Date        string
+	Description string
+}
+
+type jsonFieldDefinition struct {
+	name     string
+	selector string
+	tmpl     string
+	query    *gojq.Query
+	parsed   *template.Template
+}
+
+type jsonTemplateContext struct {
+	Item   interface{}
+	Fields JsonParsedFields
+}
+
+func ParseJSONItems(rawData interface{}, cfg *config.JsonParserConfig) ([]JsonParsedFields, error) {
+	if cfg == nil {
+		return nil, fmt.Errorf("parser config is nil")
+	}
+
+	itemsArray, err := extractJSONItems(rawData, cfg.ItemsIterator)
+	if err != nil {
+		return nil, err
+	}
+
+	fields, err := compileJSONFieldDefinitions(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	result := make([]JsonParsedFields, 0, len(itemsArray))
+	for _, itemNode := range itemsArray {
+		parsedItem, err := parseJSONItemFields(itemNode, fields)
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, parsedItem)
+	}
+
+	return result, nil
+}
+
+func extractJSONItems(rawData interface{}, itemsIterator string) ([]interface{}, error) {
+	if itemsIterator == "" || itemsIterator == "." {
+		if arr, ok := rawData.([]interface{}); ok {
+			return arr, nil
+		}
+		return []interface{}{rawData}, nil
+	}
+
+	query, err := gojq.Parse(itemsIterator)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse items_iterator '%s': %w", itemsIterator, err)
+	}
+
+	iter := query.Run(rawData)
+	var itemsArray []interface{}
+	for {
+		v, ok := iter.Next()
+		if !ok {
+			break
+		}
+		if err, ok := v.(error); ok {
+			return nil, fmt.Errorf("jq execution failed: %w", err)
+		}
+		if arr, ok := v.([]interface{}); ok {
+			itemsArray = append(itemsArray, arr...)
+			continue
+		}
+		itemsArray = append(itemsArray, v)
+	}
+
+	return itemsArray, nil
+}
+
+func compileJSONFieldDefinitions(cfg *config.JsonParserConfig) ([]jsonFieldDefinition, error) {
+	fields := []jsonFieldDefinition{
+		{name: "title", selector: cfg.Title, tmpl: cfg.TitleTemplate},
+		{name: "link", selector: cfg.Link, tmpl: cfg.LinkTemplate},
+		{name: "date", selector: cfg.Date, tmpl: cfg.DateTemplate},
+		{name: "description", selector: cfg.Description, tmpl: cfg.DescriptionTemplate},
+	}
+
+	for i := range fields {
+		if fields[i].selector != "" {
+			query, err := gojq.Parse(fields[i].selector)
+			if err != nil {
+				return nil, fmt.Errorf("invalid %s selector: %w", fields[i].name, err)
+			}
+			fields[i].query = query
+		}
+
+		if fields[i].tmpl != "" {
+			tmpl, err := template.New(fields[i].name).
+				Option("missingkey=zero").
+				Funcs(template.FuncMap{
+					"trim": func(value interface{}, cutset string) string {
+						return strings.Trim(stringifyTemplateValue(value), cutset)
+					},
+					"trimSpace": func(value interface{}) string {
+						return strings.TrimSpace(stringifyTemplateValue(value))
+					},
+					"default": func(value interface{}, fallback string) string {
+						current := stringifyTemplateValue(value)
+						if current == "" {
+							return fallback
+						}
+						return current
+					},
+				}).
+				Parse(fields[i].tmpl)
+			if err != nil {
+				return nil, fmt.Errorf("invalid %s template: %w", fields[i].name, err)
+			}
+			fields[i].parsed = tmpl
+		}
+	}
+
+	return fields, nil
+}
+
+func parseJSONItemFields(itemNode interface{}, fields []jsonFieldDefinition) (JsonParsedFields, error) {
+	parsed := JsonParsedFields{}
+	rawValues := map[string]string{}
+
+	for _, field := range fields {
+		value, err := runJSONFieldQuery(field, itemNode)
+		if err != nil {
+			return JsonParsedFields{}, err
+		}
+		rawValues[field.name] = value
+		switch field.name {
+		case "title":
+			parsed.Title = value
+		case "link":
+			parsed.Link = value
+		case "date":
+			parsed.Date = value
+		case "description":
+			parsed.Description = value
+		}
+	}
+
+	ctx := jsonTemplateContext{
+		Item: itemNode,
+		Fields: JsonParsedFields{
+			Title:       rawValues["title"],
+			Link:        rawValues["link"],
+			Date:        rawValues["date"],
+			Description: rawValues["description"],
+		},
+	}
+
+	for _, field := range fields {
+		if field.parsed == nil {
+			continue
+		}
+
+		rendered, err := renderJSONFieldTemplate(field, ctx)
+		if err != nil {
+			return JsonParsedFields{}, err
+		}
+
+		switch field.name {
+		case "title":
+			parsed.Title = rendered
+		case "link":
+			parsed.Link = rendered
+		case "date":
+			parsed.Date = rendered
+		case "description":
+			parsed.Description = rendered
+		}
+	}
+
+	return parsed, nil
+}
+
+func runJSONFieldQuery(field jsonFieldDefinition, itemNode interface{}) (string, error) {
+	if field.query == nil {
+		return "", nil
+	}
+
+	iter := field.query.Run(itemNode)
+	v, ok := iter.Next()
+	if !ok {
+		return "", nil
+	}
+	if err, ok := v.(error); ok {
+		return "", fmt.Errorf("failed to extract %s: %w", field.name, err)
+	}
+
+	return stringifyTemplateValue(v), nil
+}
+
+func renderJSONFieldTemplate(field jsonFieldDefinition, ctx jsonTemplateContext) (string, error) {
+	var rendered bytes.Buffer
+	if err := field.parsed.Execute(&rendered, ctx); err != nil {
+		return "", fmt.Errorf("failed to render %s template: %w", field.name, err)
+	}
+	return rendered.String(), nil
+}
+
+func stringifyTemplateValue(v interface{}) string {
+	if v == nil {
+		return ""
+	}
+	if s, ok := v.(string); ok {
+		return s
+	}
+	b, err := json.Marshal(v)
+	if err == nil {
+		return string(b)
+	}
+	return fmt.Sprintf("%v", v)
+}

--- a/web/admin/src/api/json_rss.ts
+++ b/web/admin/src/api/json_rss.ts
@@ -12,9 +12,13 @@ export interface JsonParseReq {
   json_content: string;
   list_selector: string;
   title_selector: string;
+  title_template: string;
   link_selector: string;
+  link_template: string;
   date_selector: string;
+  date_template: string;
   content_selector: string;
+  content_template: string;
 }
 
 export interface ParsedItem {

--- a/web/admin/src/locale/en-US/curlToRss.ts
+++ b/web/admin/src/locale/en-US/curlToRss.ts
@@ -1,11 +1,11 @@
 export default {
   'curlToRss.title': 'Curl to RSS',
   'curlToRss.description':
-    'Generate RSS feeds from any JSON API by defining parsing rules.',
+    'Generate RSS feeds from any JSON API with field extraction rules and optional templates.',
   'curlToRss.step.requestConfig': 'Request Config',
   'curlToRss.step.requestConfig.desc': 'Configure JSON source',
   'curlToRss.step.parsingRules': 'Parsing Rules',
-  'curlToRss.step.parsingRules.desc': 'Define jq selectors',
+  'curlToRss.step.parsingRules.desc': 'Define field extraction and output templates',
   'curlToRss.step.feedMetadata': 'Feed Metadata',
   'curlToRss.step.feedMetadata.desc': 'Set feed details',
   'curlToRss.step.saveRecipe': 'Save Recipe',
@@ -23,15 +23,24 @@ export default {
   'curlToRss.step1.fetchAndNext': 'Fetch & Next',
   'curlToRss.step2.responseJson': 'Response JSON',
   'curlToRss.step2.alert':
-    'Define selectors to extract feed items. Use dot notation (e.g., <code>.data.items</code>).',
+    'Use jq selectors to extract raw values, then optionally use templates to build the final field output. The items selector supports <code>.data.items</code> and <code>.data.items[]</code>.',
   'curlToRss.step2.iteration': 'Iteration',
   'curlToRss.step2.itemsIterator':
     'Items Iterator (e.g. .data.items or .items[])',
-  'curlToRss.step2.itemFields': 'Item Fields (Relative to Iterator)',
+  'curlToRss.step2.itemFields': 'Item Fields',
   'curlToRss.step2.titleSelector': 'Title Selector',
+  'curlToRss.step2.titleTemplate': 'Title Template (Optional)',
   'curlToRss.step2.linkSelector': 'Link Selector',
+  'curlToRss.step2.linkTemplate': 'Link Template (Optional)',
   'curlToRss.step2.dateSelector': 'Date Selector',
-  'curlToRss.step2.contentSelector': 'Content/Description Selector',
+  'curlToRss.step2.dateTemplate': 'Date Template (Optional)',
+  'curlToRss.step2.contentSelector': 'Content/Summary Selector',
+  'curlToRss.step2.contentTemplate': 'Content/Summary Template (Optional)',
+  'curlToRss.step2.templateHelpTitle': 'Template Help',
+  'curlToRss.step2.templateHelpDesc':
+    'Selectors extract raw values from the current item. Templates let you combine, clean up, or fill in the final text using the current item and extracted fields.',
+  'curlToRss.step2.templateExamples':
+    'Examples:\nBuild a link: https://some-website.com/article/{{ .Item.id }}\nTrim a title: {{ .Fields.Title | trimSpace }}\nFallback summary: {{ default .Fields.Description "No summary" }}',
   'curlToRss.step2.previewResults': 'Preview Results ({count})',
   'curlToRss.step2.previewPlaceholder': 'Preview results will appear here',
   'curlToRss.step2.previewPlaceholder.help':
@@ -82,7 +91,13 @@ export default {
   'curlToRss.placeholder.curl': 'curl -X POST ...',
   'curlToRss.placeholder.items': '.items',
   'curlToRss.placeholder.title': '.title',
+  'curlToRss.placeholder.titleTemplate': '{{ .Fields.Title | trimSpace }}',
   'curlToRss.placeholder.link': '.url',
+  'curlToRss.placeholder.linkTemplate':
+    'https://some-website.com/article/{{ .Item.id }}',
   'curlToRss.placeholder.date': '.created_at',
+  'curlToRss.placeholder.dateTemplate': '{{ .Fields.Date }}',
   'curlToRss.placeholder.content': '.content',
+  'curlToRss.placeholder.contentTemplate':
+    '{{ default .Fields.Description "No summary" }}',
 };

--- a/web/admin/src/locale/en-US/curlToRss.ts
+++ b/web/admin/src/locale/en-US/curlToRss.ts
@@ -5,7 +5,8 @@ export default {
   'curlToRss.step.requestConfig': 'Request Config',
   'curlToRss.step.requestConfig.desc': 'Configure JSON source',
   'curlToRss.step.parsingRules': 'Parsing Rules',
-  'curlToRss.step.parsingRules.desc': 'Define field extraction and output templates',
+  'curlToRss.step.parsingRules.desc':
+    'Define field extraction and output templates',
   'curlToRss.step.feedMetadata': 'Feed Metadata',
   'curlToRss.step.feedMetadata.desc': 'Set feed details',
   'curlToRss.step.saveRecipe': 'Save Recipe',

--- a/web/admin/src/locale/zh-CN/curlToRss.ts
+++ b/web/admin/src/locale/zh-CN/curlToRss.ts
@@ -1,11 +1,11 @@
 export default {
   'curlToRss.title': 'Curl 转 RSS',
   'curlToRss.description':
-    '通过定义解析规则，从任何 JSON API 生成 RSS 订阅源。',
+    '通过字段提取规则和可选模板，从任何 JSON API 生成 RSS 订阅源。',
   'curlToRss.step.requestConfig': '请求配置',
   'curlToRss.step.requestConfig.desc': '配置 JSON 源',
   'curlToRss.step.parsingRules': '解析规则',
-  'curlToRss.step.parsingRules.desc': '定义 jq 选择器',
+  'curlToRss.step.parsingRules.desc': '定义字段提取和结果模板',
   'curlToRss.step.feedMetadata': 'Feed 元数据',
   'curlToRss.step.feedMetadata.desc': '设置订阅详情',
   'curlToRss.step.saveRecipe': '保存配方',
@@ -22,14 +22,23 @@ export default {
   'curlToRss.step1.fetchAndNext': '获取并下一步',
   'curlToRss.step2.responseJson': '响应 JSON',
   'curlToRss.step2.alert':
-    '定义选择器以提取 Feed 条目。使用点号表示法 (例如 <code>.data.items</code>)。',
+    '先用 jq 选择器提取字段，再按需用模板加工最终结果。列表选择器支持 <code>.data.items</code> 或 <code>.data.items[]</code>。',
   'curlToRss.step2.iteration': '迭代',
   'curlToRss.step2.itemsIterator': '条目迭代器 (例如 .data.items 或 .items[])',
-  'curlToRss.step2.itemFields': '条目字段 (相对于迭代器)',
-  'curlToRss.step2.titleSelector': '标题选择器',
-  'curlToRss.step2.linkSelector': '链接选择器',
-  'curlToRss.step2.dateSelector': '日期选择器',
-  'curlToRss.step2.contentSelector': '内容/描述选择器',
+  'curlToRss.step2.itemFields': '条目字段',
+  'curlToRss.step2.titleSelector': '标题提取规则',
+  'curlToRss.step2.titleTemplate': '标题模板（可选）',
+  'curlToRss.step2.linkSelector': '链接提取规则',
+  'curlToRss.step2.linkTemplate': '链接模板（可选）',
+  'curlToRss.step2.dateSelector': '日期提取规则',
+  'curlToRss.step2.dateTemplate': '日期模板（可选）',
+  'curlToRss.step2.contentSelector': '内容/摘要提取规则',
+  'curlToRss.step2.contentTemplate': '内容/摘要模板（可选）',
+  'curlToRss.step2.templateHelpTitle': '模板说明',
+  'curlToRss.step2.templateHelpDesc':
+    '提取规则负责从当前条目取值，模板负责拼接、补全或清理最终文本。模板可访问当前条目对象和已提取字段。',
+  'curlToRss.step2.templateExamples':
+    '示例：\n链接拼接：https://some-website.com/article/{{ .Item.id }}\n清理标题：{{ .Fields.Title | trimSpace }}\n默认摘要：{{ default .Fields.Description "暂无摘要" }}',
   'curlToRss.step2.previewResults': '预览结果 ({count})',
   'curlToRss.step2.previewPlaceholder': '预览结果将出现在这里',
   'curlToRss.step2.previewPlaceholder.help': '请配置上方选择器并点击“运行预览”',
@@ -77,7 +86,13 @@ export default {
   'curlToRss.placeholder.curl': 'curl -X POST ...',
   'curlToRss.placeholder.items': '.items',
   'curlToRss.placeholder.title': '.title',
+  'curlToRss.placeholder.titleTemplate': '{{ .Fields.Title | trimSpace }}',
   'curlToRss.placeholder.link': '.url',
+  'curlToRss.placeholder.linkTemplate':
+    'https://some-website.com/article/{{ .Item.id }}',
   'curlToRss.placeholder.date': '.created_at',
+  'curlToRss.placeholder.dateTemplate': '{{ .Fields.Date }}',
   'curlToRss.placeholder.content': '.content',
+  'curlToRss.placeholder.contentTemplate':
+    '{{ default .Fields.Description "暂无摘要" }}',
 };

--- a/web/admin/src/views/dashboard/curl_to_rss/curl_to_rss.vue
+++ b/web/admin/src/views/dashboard/curl_to_rss/curl_to_rss.vue
@@ -347,7 +347,9 @@
                       <a-textarea
                         v-model="parseReq.content_template"
                         :auto-size="{ minRows: 2, maxRows: 4 }"
-                        :placeholder="$t('curlToRss.placeholder.contentTemplate')"
+                        :placeholder="
+                          $t('curlToRss.placeholder.contentTemplate')
+                        "
                       />
                     </a-form-item>
                   </a-card>

--- a/web/admin/src/views/dashboard/curl_to_rss/curl_to_rss.vue
+++ b/web/admin/src/views/dashboard/curl_to_rss/curl_to_rss.vue
@@ -198,6 +198,26 @@
                 <a-alert type="info" class="mb-4">
                   <span v-html="$t('curlToRss.step2.alert')"></span>
                 </a-alert>
+                <a-alert type="normal" class="mb-4">
+                  <div class="text-sm font-medium mb-2">
+                    {{ $t('curlToRss.step2.templateHelpTitle') }}
+                  </div>
+                  <div class="text-sm text-gray-600 mb-2">
+                    {{ $t('curlToRss.step2.templateHelpDesc') }}
+                  </div>
+                  <div class="flex flex-wrap gap-2 mb-2">
+                    <a-tag
+                      v-for="variable in templateVariables"
+                      :key="variable"
+                      size="small"
+                    >
+                      {{ variable }}
+                    </a-tag>
+                  </div>
+                  <div class="text-xs text-gray-500 whitespace-pre-line">
+                    {{ $t('curlToRss.step2.templateExamples') }}
+                  </div>
+                </a-alert>
 
                 <a-form :model="parseReq" layout="vertical">
                   <a-card
@@ -251,6 +271,13 @@
                         @focus="activeField = 'title_selector'"
                       />
                     </a-form-item>
+                    <a-form-item :label="$t('curlToRss.step2.titleTemplate')">
+                      <a-textarea
+                        v-model="parseReq.title_template"
+                        :auto-size="{ minRows: 2, maxRows: 4 }"
+                        :placeholder="$t('curlToRss.placeholder.titleTemplate')"
+                      />
+                    </a-form-item>
                     <a-form-item :label="$t('curlToRss.step2.linkSelector')">
                       <template #label>
                         {{ $t('curlToRss.step2.linkSelector') }}
@@ -266,6 +293,13 @@
                           'border-primary': activeField === 'link_selector',
                         }"
                         @focus="activeField = 'link_selector'"
+                      />
+                    </a-form-item>
+                    <a-form-item :label="$t('curlToRss.step2.linkTemplate')">
+                      <a-textarea
+                        v-model="parseReq.link_template"
+                        :auto-size="{ minRows: 2, maxRows: 4 }"
+                        :placeholder="$t('curlToRss.placeholder.linkTemplate')"
                       />
                     </a-form-item>
                     <a-form-item :label="$t('curlToRss.step2.dateSelector')">
@@ -285,6 +319,13 @@
                         @focus="activeField = 'date_selector'"
                       />
                     </a-form-item>
+                    <a-form-item :label="$t('curlToRss.step2.dateTemplate')">
+                      <a-textarea
+                        v-model="parseReq.date_template"
+                        :auto-size="{ minRows: 2, maxRows: 4 }"
+                        :placeholder="$t('curlToRss.placeholder.dateTemplate')"
+                      />
+                    </a-form-item>
                     <a-form-item :label="$t('curlToRss.step2.contentSelector')">
                       <template #label>
                         {{ $t('curlToRss.step2.contentSelector') }}
@@ -300,6 +341,13 @@
                           'border-primary': activeField === 'content_selector',
                         }"
                         @focus="activeField = 'content_selector'"
+                      />
+                    </a-form-item>
+                    <a-form-item :label="$t('curlToRss.step2.contentTemplate')">
+                      <a-textarea
+                        v-model="parseReq.content_template"
+                        :auto-size="{ minRows: 2, maxRows: 4 }"
+                        :placeholder="$t('curlToRss.placeholder.contentTemplate')"
                       />
                     </a-form-item>
                   </a-card>
@@ -565,11 +613,22 @@
   const parseReq = reactive({
     list_selector: '',
     title_selector: '',
+    title_template: '',
     link_selector: '',
+    link_template: '',
     date_selector: '',
+    date_template: '',
     content_selector: '',
+    content_template: '',
   });
   const parsedItems = ref<ParsedItem[]>([]);
+  const templateVariables = [
+    '.Item.id',
+    '.Fields.Title',
+    '.Fields.Link',
+    '.Fields.Date',
+    '.Fields.Description',
+  ];
 
   // Step 3 State
   const feedMeta = reactive({
@@ -881,9 +940,13 @@
       json_parser: {
         items_iterator: parseReq.list_selector,
         title: parseReq.title_selector,
+        title_template: parseReq.title_template,
         link: parseReq.link_selector,
+        link_template: parseReq.link_template,
         date: parseReq.date_selector,
+        date_template: parseReq.date_template,
         description: parseReq.content_selector,
+        description_template: parseReq.content_template,
       },
       feed_meta: {
         title: feedMeta.title,


### PR DESCRIPTION
- Updated description to emphasize jq field extraction and optional templating
- Added title and link template options for further customization
- Highlighted Go template support for post‑processing extracted fields
- Adjusted section headings and examples to reflect new capabilities

## Summary by Sourcery

Add templating support to curl-to-rss JSON parsing and centralize JSON item extraction and transformation logic.

New Features:
- Support optional Go templates for title, link, date, and content fields when converting JSON to RSS.
- Expose template configuration options in the curl-to-rss admin UI, including helper docs, examples, and placeholders.

Enhancements:
- Refactor JSON parsing to reuse a shared JSON item extraction and field transformation helper, replacing inline gojq logic in controllers and parsers.
- Improve copy and structure of curl-to-rss documentation and UI text to explain field extraction versus templating and supported patterns.

Tests:
- Add tests covering JSON parser behavior with field templates, item-only templates, and template error handling.