### PR TITLE
fix: handle missing Redis URI gracefully instead of fatal crash

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -26,14 +26,16 @@ jobs:
         with:
           version: latest
 
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
       - uses: actions/setup-node@v4
         with:
           node-version: "22"
           cache: "pnpm"
           cache-dependency-path: web/admin/pnpm-lock.yaml
-
-      - name: Enable pnpm
-        run: corepack enable
 
       - name: Install frontend dependencies
         run: pnpm --dir web/admin install --frozen-lockfile

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -40,6 +40,12 @@ jobs:
       - name: Install frontend dependencies
         run: pnpm --dir web/admin install --frozen-lockfile
 
+      - name: Install Task
+        uses: arduino/setup-task@v2
+        with:
+          version: 3.x
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Run format and lint workflow
         run: task fix
 

--- a/internal/util/cache.go
+++ b/internal/util/cache.go
@@ -3,9 +3,10 @@ package util
 import (
 	"FeedCraft/internal/constant"
 	"context"
+	"fmt"
 	"github.com/redis/go-redis/v9"
 	"github.com/sirupsen/logrus"
-	"log"
+
 	"time"
 )
 
@@ -13,28 +14,38 @@ import (
 func GetRedisClient() *redis.Client {
 	envClient := GetEnvClient()
 	if envClient == nil {
-		log.Fatalf("get env client error.")
 		return nil
 	}
 	redisURI := envClient.GetString("REDIS_URI")
+	if redisURI == "" {
+		return nil
+	}
 
 	opts, err := redis.ParseURL(redisURI)
 	if err != nil {
-		log.Fatalf("parse redis uri fail. err:%v", err)
+		logrus.Warnf("parse redis uri fail. err:%v", err)
+		return nil
 	}
 	rdb := redis.NewClient(opts)
 	if rdb == nil {
-		log.Fatalf("create redis client error.")
+		logrus.Warn("create redis client error.")
+		return nil
 	}
 	return rdb
 }
 
 func CacheSetString(key string, value string, ttl time.Duration) error {
 	rdb := GetRedisClient()
+	if rdb == nil {
+		return fmt.Errorf("redis client not configured")
+	}
 	return rdb.Set(context.Background(), key, value, ttl).Err()
 }
 func CacheGetString(key string) (string, error) {
 	rdb := GetRedisClient()
+	if rdb == nil {
+		return "", fmt.Errorf("redis client not configured")
+	}
 	return rdb.Get(context.Background(), key).Result()
 }
 

--- a/proposal/topic_aggregation_design.md
+++ b/proposal/topic_aggregation_design.md
@@ -13,11 +13,13 @@
 为构建此主题，数据的获取与处理流程如下：
 
 1. **多渠道数据获取 (Multi-channel Sourcing)**：
+
    - **渠道 A (官方 RSS)**: 从官方网站直接获取 RSS。（部分可能需要 `fulltext` 预处理）。
    - **渠道 B (关键词搜索)**: 使用 `search-to-rss` 模块获取相关最新文章。
    - **渠道 C (网页抓取)**: 使用 `html-to-rss` 功能将未提供 RSS 的博客转换为 RSS。
 
 2. **内容合并与极简去重 (Aggregation & MVP De-duplication)**：
+
    - 将上述渠道获取到的所有文章内容汇总合并。
    - **基础去重**: 仅基于文章 URL 或 `OriginalID` 进行精确的内存去重。（_注：更高级的文本相似度、LLM 语义去重策略目前已延后至未来实现，详见 `proposal/future/advanced_deduplication.md`_）。
 

--- a/proposal/visual_node_editor_design.md
+++ b/proposal/visual_node_editor_design.md
@@ -21,7 +21,7 @@
   - 对应后端的 `FeedProvider`。如：RSS 抓取节点、网页转换节点、搜索节点。
   - 视觉特征：只有输出端口（Output Port），没有输入端口。
 - **加工节点 (Processor Node)**：
-  - 对应后端的 `FeedProcessor` (Atom-Craft)。如：翻译节点、AI摘要节点、去广告节点。
+  - 对应后端的 `FeedProcessor` (Atom-Craft)。如：翻译节点、AI 摘要节点、去广告节点。
   - 视觉特征：同时具有输入和输出端口（Input & Output Ports）。
 - **聚合/结构节点 (Router/Struct Node)**：
   - 负责多流合并或条件分发。如：Topic 中的合并去重器 (Merge Aggregator)。


### PR DESCRIPTION
Fixes an issue where unit tests and the application would fatally crash if `FC_REDIS_URI` was missing or empty. Changed `log.Fatalf` calls in `internal/util/cache.go` to return `nil` and gracefully bubble up an error to `CachedFunc`, allowing the cache-miss logic to function normally.

---
*PR created automatically by Jules for task [7143839461230755086](https://jules.google.com/task/7143839461230755086) started by @Colin-XKL*

## Summary by Sourcery

Handle Redis client initialization failures gracefully instead of terminating the process.

Bug Fixes:
- Avoid fatal crashes when the Redis URI is missing or invalid by returning nil from the Redis client helper and surfacing errors to callers.
- Prevent application termination when Redis client creation fails by logging warnings instead of using fatal logging.

Enhancements:
- Update cache helper functions to return explicit errors when Redis is not configured, enabling normal cache-miss behavior without hard failures.