### PR TITLE
fix: gracefully handle copy link failure in TopicFeed

### DIFF
--- a/web/admin/src/locale/en-US/topic.ts
+++ b/web/admin/src/locale/en-US/topic.ts
@@ -25,6 +25,7 @@ export default {
   'topic.aggregator': 'Aggregation',
   'topic.publicUrl': 'Subscription URL',
   'topic.copyLink': 'Copy Link',
+  'topic.copyLinkFailed': 'Failed to copy link',
   'topic.viewFeed': 'Open Feed',
   'topic.viewDetails': 'View Details',
   'topic.editAction': 'Edit',

--- a/web/admin/src/locale/zh-CN/topic.ts
+++ b/web/admin/src/locale/zh-CN/topic.ts
@@ -24,6 +24,7 @@ export default {
   'topic.aggregator': '聚合规则',
   'topic.publicUrl': '订阅地址',
   'topic.copyLink': '复制链接',
+  'topic.copyLinkFailed': '复制链接失败',
   'topic.viewFeed': '查看订阅',
   'topic.viewDetails': '查看详情',
   'topic.editAction': '编辑',

--- a/web/admin/src/views/dashboard/topic_feed/detail.vue
+++ b/web/admin/src/views/dashboard/topic_feed/detail.vue
@@ -268,8 +268,13 @@
 
   const copyPublicUrl = async () => {
     if (!detail.value) return;
-    await navigator.clipboard.writeText(publicUrl.value);
-    Message.success(t('topic.copyLink'));
+    try {
+      await navigator.clipboard.writeText(publicUrl.value);
+      Message.success(t('topic.copyLink'));
+    } catch (err) {
+      console.error(err);
+      Message.error(t('topic.copyLinkFailed'));
+    }
   };
 
   const buildExecutionDetails = (


### PR DESCRIPTION
Fixes the issue where `navigator.clipboard.writeText` fails silently (e.g. permission denied) when copying the TopicFeed public URL by wrapping it in a try/catch block and showing a localized error message.

---
*PR created automatically by Jules for task [10064598643467360082](https://jules.google.com/task/10064598643467360082) started by @Colin-XKL*

## Summary by Sourcery

Handle failures when copying the TopicFeed public URL and provide user feedback.

Bug Fixes:
- Prevent silent failures when copying the TopicFeed public URL by showing an error message on clipboard write errors.

Enhancements:
- Add localized copy-failure messages for TopicFeed link copying in both English and Chinese locales.