### PR TITLE
fix(recipe): prevent panic on nil feed in ProcessRecipeByIDWithTrigger

### DIFF
--- a/internal/recipe/custom_recipe.go
+++ b/internal/recipe/custom_recipe.go
@@ -59,6 +59,11 @@ func ProcessRecipeByIDWithTrigger(ctx context.Context, recipeId string, trigger 
 		})
 		return nil, err
 	}
+
+	if processedCraftFeed == nil {
+		return &feeds.Feed{}, nil
+	}
+
 	processedFeed := processedCraftFeed.ToFeedsFeed()
 
 	observability.Report(observability.ExecutionEvent{


### PR DESCRIPTION
Added a nil-check for `processedCraftFeed` in `ProcessRecipeByIDWithTrigger` after `recipeRuntime.Fetch(ctx)`. If nil, it returns an empty feed value without calling `ToFeedsFeed()`, which prevents a potential panic and addresses the issue of handling `nil, nil` safely.

---
*PR created automatically by Jules for task [8431976134297913256](https://jules.google.com/task/8431976134297913256) started by @Colin-XKL*

## Summary by Sourcery

Bug Fixes:
- Add a nil check for processed craft feeds in ProcessRecipeByIDWithTrigger to avoid calling ToFeedsFeed on a nil value.