### PR TITLE
fix(frontend): properly normalize relative API base URLs

### DIFF
--- a/web/admin/src/utils/publicFeedUrl.ts
+++ b/web/admin/src/utils/publicFeedUrl.ts
@@ -9,7 +9,9 @@ function normalizeBaseUrl(): string {
     return apiBaseUrl.replace(/\/$/, '');
   }
 
-  const normalizedApiBaseUrl = apiBaseUrl.startsWith('/') ? apiBaseUrl : `/${apiBaseUrl}`;
+  const normalizedApiBaseUrl = apiBaseUrl.startsWith('/')
+    ? apiBaseUrl
+    : `/${apiBaseUrl}`;
   return `${window.location.origin}${normalizedApiBaseUrl}`.replace(/\/$/, '');
 }
 

--- a/web/admin/src/utils/publicFeedUrl.ts
+++ b/web/admin/src/utils/publicFeedUrl.ts
@@ -9,7 +9,8 @@ function normalizeBaseUrl(): string {
     return apiBaseUrl.replace(/\/$/, '');
   }
 
-  return `${window.location.origin}${apiBaseUrl}`.replace(/\/$/, '');
+  const normalizedApiBaseUrl = apiBaseUrl.startsWith('/') ? apiBaseUrl : `/${apiBaseUrl}`;
+  return `${window.location.origin}${normalizedApiBaseUrl}`.replace(/\/$/, '');
 }
 
 export default function buildPublicFeedUrl(path: string): string {

--- a/web/admin/src/utils/publicFeedUrl.ts
+++ b/web/admin/src/utils/publicFeedUrl.ts
@@ -5,14 +5,7 @@ function normalizeBaseUrl(): string {
     return window.location.origin;
   }
 
-  if (/^https?:\/\//.test(apiBaseUrl)) {
-    return apiBaseUrl.replace(/\/$/, '');
-  }
-
-  const normalizedApiBaseUrl = apiBaseUrl.startsWith('/')
-    ? apiBaseUrl
-    : `/${apiBaseUrl}`;
-  return `${window.location.origin}${normalizedApiBaseUrl}`.replace(/\/$/, '');
+  return new URL(apiBaseUrl, window.location.origin).href.replace(/\/$/, '');
 }
 
 export default function buildPublicFeedUrl(path: string): string {


### PR DESCRIPTION
Fixes a bug where relative `VITE_API_BASE_URL` strings lacking a leading slash (like `"api"`) resulted in malformed concatenated URLs (like `https://example.comapi`) within the frontend.

**Changes:**
- Updated `normalizeBaseUrl()` in `web/admin/src/utils/publicFeedUrl.ts` to explicitly prepend a `/` to `apiBaseUrl` if it doesn't already start with one, right before prepending the window origin. Empty string behavior and absolute URLs remain unaffected.
- Tested compilation and verified the fix correctly resolves relative API URL concatenation.

---
*PR created automatically by Jules for task [2912472243618420888](https://jules.google.com/task/2912472243618420888) started by @Colin-XKL*

## Summary by Sourcery

Bug Fixes:
- Fix malformed frontend API URLs when VITE_API_BASE_URL is a relative path without a leading slash.