### PR TITLE
fix(parser): prevent clearing fallback content on HTML extraction failure

### DIFF
--- a/internal/controller/html_to_rss.go
+++ b/internal/controller/html_to_rss.go
@@ -212,13 +212,13 @@ func HtmlParse(c *gin.Context) {
 		}
 		if req.ContentSelector != "" {
 			sel := getSelection(req.ContentSelector)
-			html, err := sel.Html()
+			htmlStr, err := sel.Html()
 			if err != nil {
 				logrus.Infof("Warning: Failed to extract content using selector '%s' for item %d in feed %s: %v",
 					req.ContentSelector, i, req.URL, err)
-				item.Content = ""
-			} else {
-				item.Content = html
+			}
+			if err == nil && htmlStr != "" {
+				item.Content = htmlStr
 			}
 		}
 

--- a/internal/source/parser/html_parser.go
+++ b/internal/source/parser/html_parser.go
@@ -84,13 +84,9 @@ func (p *HtmlParser) Parse(data []byte) (*model.CraftFeed, error) {
 		// Content (rich HTML)
 		if p.Config.Content != "" {
 			sel := getSelection(p.Config.Content)
-			html, err := sel.Html()
-			if err != nil {
-				// Log error but don't fail, just leave content empty
-				// logrus.Warnf("Failed to extract content for item: %v", err)
-				item.Content = ""
-			} else {
-				item.Content = html
+			htmlStr, err := sel.Html()
+			if err == nil && htmlStr != "" {
+				item.Content = htmlStr
 			}
 		}
 


### PR DESCRIPTION
- Replaced `html, err := sel.Html()` with `htmlStr, err := sel.Html()` in `html_parser.go` and `html_to_rss.go` and added a condition `if err == nil && htmlStr != ""` before assigning to `item.Content`.
- This ensures that if HTML extraction fails or yields an empty string, any fallback content already assigned to `item.Content` (e.g., from `item.Description`) is preserved rather than being overwritten with `""`.
- Ran `go test ./...` which executed successfully.

---
*PR created automatically by Jules for task [10887822075477162212](https://jules.google.com/task/10887822075477162212) started by @Colin-XKL*

## Summary by Sourcery

Bug Fixes:
- Avoid overwriting previously set item content with an empty value when HTML parsing fails or yields no HTML in both the HTML parser and HTML-to-RSS controller.