### PR TITLE
Fix Custom Recipe preview and link generation

### DIFF
--- a/web/admin/config/vite.config.dev.ts
+++ b/web/admin/config/vite.config.dev.ts
@@ -16,6 +16,18 @@ export default mergeConfig(
           target: 'http://localhost:8080',
           changeOrigin: true,
         },
+        '/craft': {
+          target: 'http://localhost:8080',
+          changeOrigin: true,
+        },
+        '/recipe': {
+          target: 'http://localhost:8080',
+          changeOrigin: true,
+        },
+        '/topic': {
+          target: 'http://localhost:8080',
+          changeOrigin: true,
+        },
       },
     },
     plugins: [

--- a/web/admin/src/utils/publicFeedUrl.ts
+++ b/web/admin/src/utils/publicFeedUrl.ts
@@ -1,11 +1,22 @@
 const apiBaseUrl = import.meta.env.VITE_API_BASE_URL ?? '';
 
-function normalizeBaseUrl(): string {
+export function normalizeBaseUrl(): string {
   if (!apiBaseUrl) {
     return window.location.origin;
   }
 
-  return new URL(apiBaseUrl, window.location.origin).href.replace(/\/$/, '');
+  let base = apiBaseUrl;
+  if (base.endsWith('/api')) {
+    base = base.substring(0, base.length - 4);
+  } else if (base.endsWith('/api/')) {
+    base = base.substring(0, base.length - 5);
+  }
+
+  if (!base) {
+    base = window.location.origin;
+  }
+
+  return new URL(base, window.location.origin).href.replace(/\/$/, '');
 }
 
 export default function buildPublicFeedUrl(path: string): string {

--- a/web/admin/src/views/dashboard/feed_viewer/feed_viewer.vue
+++ b/web/admin/src/views/dashboard/feed_viewer/feed_viewer.vue
@@ -83,12 +83,16 @@
       if (!isInternal) {
         // If it's an external URL, wrap it in our proxy
         const prefix = normalizeBaseUrl();
-        requestUrl = `${prefix}/craft/proxy?input_url=${encodeURIComponent(feedUrl.value)}`;
+        requestUrl = `${prefix}/craft/proxy?input_url=${encodeURIComponent(
+          feedUrl.value
+        )}`;
       }
     } catch (e) {
       // Invalid URL format, default to using proxy
       const prefix = normalizeBaseUrl();
-      requestUrl = `${prefix}/craft/proxy?input_url=${encodeURIComponent(feedUrl.value)}`;
+      requestUrl = `${prefix}/craft/proxy?input_url=${encodeURIComponent(
+        feedUrl.value
+      )}`;
     }
 
     try {

--- a/web/admin/src/views/dashboard/feed_viewer/feed_viewer.vue
+++ b/web/admin/src/views/dashboard/feed_viewer/feed_viewer.vue
@@ -45,6 +45,7 @@
   import XHeader from '@/components/header/x-header.vue';
   import { useI18n } from 'vue-i18n';
   import { useRoute } from 'vue-router';
+  import { normalizeBaseUrl } from '@/utils/publicFeedUrl';
 
   const { t } = useI18n();
   const route = useRoute();
@@ -52,14 +53,44 @@
   const feedUrl = ref('');
   const feedContent = ref<any>(null);
   const isLoading = ref(false);
-  const baseUrl = import.meta.env.VITE_API_BASE_URL ?? '';
 
   async function fetchFeed() {
     if (!feedUrl.value) return;
     isLoading.value = true;
-    const requestUrl = `${baseUrl}/craft/proxy?input_url=${encodeURIComponent(
-      feedUrl.value
-    )}`;
+
+    let requestUrl = feedUrl.value;
+
+    try {
+      let isInternal = false;
+      if (feedUrl.value.startsWith('/')) {
+        isInternal = true;
+      } else {
+        const urlObj = new URL(feedUrl.value, window.location.origin);
+        if (urlObj.origin === window.location.origin) {
+          isInternal = true;
+        } else {
+          // If the API base URL is fully qualified and matches the input URL origin, consider it internal
+          const apiBase = normalizeBaseUrl();
+          if (apiBase) {
+            const apiBaseObj = new URL(apiBase, window.location.origin);
+            if (urlObj.origin === apiBaseObj.origin) {
+              isInternal = true;
+            }
+          }
+        }
+      }
+
+      if (!isInternal) {
+        // If it's an external URL, wrap it in our proxy
+        const prefix = normalizeBaseUrl();
+        requestUrl = `${prefix}/craft/proxy?input_url=${encodeURIComponent(feedUrl.value)}`;
+      }
+    } catch (e) {
+      // Invalid URL format, default to using proxy
+      const prefix = normalizeBaseUrl();
+      requestUrl = `${prefix}/craft/proxy?input_url=${encodeURIComponent(feedUrl.value)}`;
+    }
+
     try {
       const parser = new Parser();
       const resp = await fetch(requestUrl);


### PR DESCRIPTION
Fixes the issue where previewing custom recipes failed. When previewing an internal FeedCraft URL (like `/recipe/...`), the frontend now correctly fetches it directly without wrapping it in `/craft/proxy?input_url=...`, avoiding resolution issues. It also corrects the generated public URLs so they don't contain the `/api` prefix, and updates the local dev vite config to proxy the necessary frontend routes to the backend.

---
*PR created automatically by Jules for task [5715429760044885457](https://jules.google.com/task/5715429760044885457) started by @Colin-XKL*

## Summary by Sourcery

Fix feed viewer custom recipe preview handling and public URL generation while aligning dev proxy configuration with backend routes.

Bug Fixes:
- Ensure the feed viewer only proxies external recipe URLs and fetches internal FeedCraft URLs directly.
- Correct public feed URL generation to strip any trailing /api segment from the configured API base URL.

Build:
- Update the dev Vite proxy configuration to forward /craft, /recipe, and /topic routes to the backend.