### PR TITLE
feat: enhance LLM filters to use title and format payload in markdown codeblocks

### DIFF
--- a/internal/adapter/llm.go
+++ b/internal/adapter/llm.go
@@ -3,11 +3,15 @@ package adapter
 import (
 	"FeedCraft/internal/util"
 	"fmt"
+	"strings"
 )
 
 // CallLLMUsingContext using openai compatible api
 func CallLLMUsingContext(prompt, context string, option util.ContentProcessOption) (string, error) {
 	processedContext := util.ProcessContent(context, option)
+	// Remove backticks to avoid breaking the markdown code block
+	processedContext = strings.ReplaceAll(processedContext, "`", "")
+
 	finalPrompt := fmt.Sprintf("%s \n```\n%s\n```", prompt, processedContext)
 	cacheKey := fmt.Sprintf("llm_call_%s", util.GetMD5Hash(finalPrompt))
 	valFunc := func() (string, error) {

--- a/internal/craft/advertorial.go
+++ b/internal/craft/advertorial.go
@@ -37,8 +37,8 @@ const judgePrompt = `
 const promptCheckIfAdvertorial = "请阅读下面的文章, 并判断是不是广告推销软文. 如果非常确信这篇文章是营销推广文章, 请返回 'true', 不要包括其他内容. 如果不是或者没有把握确定,请返回 'false'"
 
 // CheckIfAdvertorial 判断是否为软文, 非常有把握则返回true, 如果不是或者不确定或是发生错误则返回false
-func CheckIfAdvertorial(content string, prompt string) bool {
-	res, _ := CheckConditionWithLLM(content, prompt)
+func CheckIfAdvertorial(title string, content string, prompt string) bool {
+	res, _ := CheckConditionWithLLM(title, content, prompt)
 	return res
 }
 
@@ -63,7 +63,7 @@ func OptionIgnoreAdvertorial(prompt string) CraftOption {
 			if len(content) == 0 {
 				content = itm.Description
 			}
-			return CheckIfAdvertorial(content, prompt)
+			return CheckIfAdvertorial(itm.Title, content, prompt)
 		})
 
 		// 2. 同步过滤
@@ -128,7 +128,7 @@ func DebugCheckIfAdvertorial(c *gin.Context) {
 	}
 	prompt := fmt.Sprintf("%s\n%s\n", judgePrompt, promptCheckIfAdvertorial)
 
-	result := CheckIfAdvertorial(webContent, prompt)
+	result := CheckIfAdvertorial("", webContent, prompt)
 	ret := CheckIfAdvertorialDebugResp{
 		Url:            reqBody.Url,
 		IsAdvertorial:  result,

--- a/internal/craft/common_llm_logic.go
+++ b/internal/craft/common_llm_logic.go
@@ -11,11 +11,12 @@ import (
 
 // CheckConditionWithLLM 检查文章内容是否符合特定条件
 // prompt: 用户提供的 prompt 模板，必须明确要求返回 'true' 或 'false'
+// title: 文章标题
 // content: 文章内容
 // 返回值: (bool, error)
 // true: 表示符合条件
 // false: 表示不符合条件或无法判断
-func CheckConditionWithLLM(content string, conditionPrompt string) (bool, error) {
+func CheckConditionWithLLM(title string, content string, conditionPrompt string) (bool, error) {
 	const MinContentLength = 20
 	if len(strings.TrimSpace(content)) < MinContentLength {
 		return false, nil
@@ -28,7 +29,12 @@ func CheckConditionWithLLM(content string, conditionPrompt string) (bool, error)
 	// 如果 prompt 没有明确包含 true/false 的指令，建议调用者在传入前拼接好。
 	// 但为了通用性，我们这里假设传入的 prompt 已经包含了判断逻辑。
 
-	result, err := adapter.CallLLMUsingContext(conditionPrompt, content, option)
+	contextData := content
+	if title != "" {
+		contextData = fmt.Sprintf("Title: %s\n\nContent:\n%s", title, content)
+	}
+
+	result, err := adapter.CallLLMUsingContext(conditionPrompt, contextData, option)
 	if err != nil {
 		logrus.Errorf("Error checking condition with LLM: %v", err)
 		return false, err
@@ -49,7 +55,7 @@ func CheckConditionWithLLM(content string, conditionPrompt string) (bool, error)
 
 // CheckConditionWithGenericPrompt 使用通用模板构造 prompt 并调用 LLM
 // userPrompt: 用户提供的判断标准，例如 "Is this regarding politics?"
-func CheckConditionWithGenericPrompt(content string, userPrompt string) (bool, error) {
+func CheckConditionWithGenericPrompt(title string, content string, userPrompt string) (bool, error) {
 	// 构造强制要求 true/false 的完整 prompt
 	fullPrompt := fmt.Sprintf(`
 Evaluate the following content based on this criterion:
@@ -60,5 +66,5 @@ Otherwise return 'false'.
 Do not include any other text.
 `, userPrompt)
 
-	return CheckConditionWithLLM(content, fullPrompt)
+	return CheckConditionWithLLM(title, content, fullPrompt)
 }

--- a/internal/craft/llm_filter.go
+++ b/internal/craft/llm_filter.go
@@ -43,7 +43,7 @@ func OptionLLMFilterGeneric(condition string) CraftOption {
 			if len(content) == 0 {
 				content = itm.Description
 			}
-			match, err := CheckConditionWithGenericPrompt(content, condition)
+			match, err := CheckConditionWithGenericPrompt(itm.Title, content, condition)
 			if err != nil {
 				return false
 			}


### PR DESCRIPTION
This PR implements enhancements to the `ignore-advertorial` and `llm filter` Atom Crafts. 
- It updates the LLM prompt construction to include the article's `Title` logically combined with the `Content` when passing data to the LLM filters. 
- Additionally, it ensures the final article content structure sent in the payload is wrapped within Markdown codeblocks for structural clarity. Any existing backticks (`` ` ``) in the article text are preprocessed and removed to prevent unintended breaks in the markdown wrapper.

---
*PR created automatically by Jules for task [4326235499979391914](https://jules.google.com/task/4326235499979391914) started by @Colin-XKL*

## Summary by Sourcery

Incorporate article titles into LLM-based filtering and wrap processed content in markdown code blocks for LLM calls.

New Features:
- Augment LLM condition checks and generic filters to use both article title and content as context.

Enhancements:
- Normalize LLM request payloads by wrapping processed article content in markdown code blocks and stripping backticks to avoid breaking the structure.