### PR TITLE
feat: optimize LLM token usage by cleaning HTML before markdown conversion

### DIFF
--- a/internal/util/content_processor.go
+++ b/internal/util/content_processor.go
@@ -2,8 +2,10 @@ package util
 
 import (
 	"regexp"
+	"strings"
 
 	htmltomarkdown "github.com/JohannesKaufmann/html-to-markdown/v2"
+	"github.com/PuerkitoBio/goquery"
 	"github.com/sirupsen/logrus"
 )
 
@@ -26,6 +28,42 @@ func ProcessContent(content string, option ContentProcessOption) string {
 		content = imgRegex.ReplaceAllString(content, "")
 	}
 	if option.ConvertToMd {
+		doc, err := goquery.NewDocumentFromReader(strings.NewReader(content))
+		if err == nil {
+			doc.Find("script, style, svg").Remove()
+
+			// Remove tags with data URI base64 images
+			doc.Find("img").Each(func(i int, s *goquery.Selection) {
+				src, exists := s.Attr("src")
+				if exists && strings.HasPrefix(strings.ToLower(src), "data:image") {
+					s.Remove()
+				}
+			})
+
+			doc.Find("a").Each(func(i int, s *goquery.Selection) {
+				href, exists := s.Attr("href")
+				if exists && strings.HasPrefix(strings.ToLower(href), "data:image") {
+					s.Remove()
+				}
+			})
+
+			doc.Find("*").Each(func(i int, s *goquery.Selection) {
+				for _, node := range s.Nodes {
+					var attrsToRemove []string
+					for _, attr := range node.Attr {
+						if strings.HasPrefix(attr.Key, "aria-") || strings.HasPrefix(attr.Key, "data-") {
+							attrsToRemove = append(attrsToRemove, attr.Key)
+						}
+					}
+					for _, key := range attrsToRemove {
+						s.RemoveAttr(key)
+					}
+				}
+			})
+
+			content, _ = doc.Html()
+		}
+
 		markdown, err := htmltomarkdown.ConvertString(content)
 		if err != nil {
 			logrus.Errorf("Error converting HTML to Markdown: %v", err)

--- a/internal/util/content_processor_test.go
+++ b/internal/util/content_processor_test.go
@@ -1,0 +1,54 @@
+package util
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestProcessContent(t *testing.T) {
+	htmlContent := `
+<html>
+<body>
+<h1>Title</h1>
+<p>Hello <a href="http://example.com">link</a></p>
+<img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=" alt="image" />
+<img src="http://example.com/image.jpg" alt="image" />
+<script>alert("hello");</script>
+<style>.css { color: red; }</style>
+<div aria-label="hello" data-custom="value">world</div>
+<custom-tag>custom</custom-tag>
+
+<!-- Some other image tags -->
+<img
+  src="data:image/jpeg;base64,/9j/4AAQSkZJRgABAQEASABIAAD/2wBD..."
+  alt="Base64 Image"
+/>
+<IMG SRC="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7">
+
+<a href="data:image/jpeg;base64,/9j/4AAQSkZJRgABAQEASABIAAD/2wBD...">base64 link</a>
+
+<svg width="100" height="100">
+  <circle cx="50" cy="50" r="40" stroke="green" stroke-width="4" fill="yellow" />
+</svg>
+</body>
+</html>`
+
+	option := ContentProcessOption{
+		RemoveLinks: true,
+		RemoveImage: true,
+		ConvertToMd: true,
+	}
+
+	result := ProcessContent(htmlContent, option)
+	t.Logf("Result:\n%s", result)
+
+	if strings.Contains(result, "alert(\"hello\")") {
+		t.Errorf("script tag not removed")
+	}
+	if strings.Contains(result, ".css") {
+		t.Errorf("style tag not removed")
+	}
+	if strings.Contains(result, "base64") {
+		t.Errorf("base64 not removed")
+	}
+}


### PR DESCRIPTION
This PR optimizes token usage when sending article content to an LLM by stripping out unnecessary HTML elements before converting the content to markdown.

Specifically, `ProcessContent` now uses `goquery` to perform the following cleanup operations:
- Removes `<script>`, `<style>`, and `<svg>` tags.
- Removes base64-encoded images from both `<img>` and `<a>` tags.
- Strips custom `aria-*` and `data-*` attributes from all remaining tags.

A new test case `TestProcessContent` has also been added to verify these modifications function correctly.

---
*PR created automatically by Jules for task [3633908395912584267](https://jules.google.com/task/3633908395912584267) started by @Colin-XKL*

## Summary by Sourcery

Optimize HTML content preprocessing before markdown conversion to reduce unnecessary data sent to LLMs.

New Features:
- Clean HTML content with goquery before markdown conversion by stripping scripts, styles, SVGs, base64-encoded images, and custom aria/data attributes.

Tests:
- Add TestProcessContent to validate HTML cleanup behavior during content processing.