### PR TITLE
ci: use setup-task action in lint workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -36,8 +36,8 @@ jobs:
           cache: "pnpm"
           cache-dependency-path: web/admin/pnpm-lock.yaml
 
-      - name: Install Task
-        run: sudo sh -c "$(curl --location https://taskfile.dev/install.sh)" -- -d -b /usr/local/bin
+      - name: Install task
+        uses: arduino/setup-task@v2
 
       - name: Install frontend dependencies
         run: pnpm --dir web/admin install --frozen-lockfile


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Replace the custom curl-based Task installation step in the lint workflow with the arduino/setup-task@v2 GitHub Action.