### PR TITLE
fix: restore description fallback before content-based crafts run

### DIFF
--- a/internal/model/feed.go
+++ b/internal/model/feed.go
@@ -107,10 +107,15 @@ func ArticleFromGofeed(item *gofeed.Item) *CraftArticle {
 		content = item.Description
 	}
 
+	description := item.Description
+	if len(description) == 0 {
+		description = item.Content
+	}
+
 	article := &CraftArticle{
 		Title:       item.Title,
 		Link:        item.Link,
-		Description: item.Description,
+		Description: description,
 		Id:          item.GUID,
 		Updated:     updatedTime,
 		Created:     publishedTime,


### PR DESCRIPTION
This change restores the fallback behavior for the `Description` field in `ArticleFromGofeed` during the `gofeed.Item` to `CraftArticle` conversion. By ensuring `Description` is populated from `Content` when empty, we fix a regression where content-only feeds would result in an empty `Description`, leading to identically hashed cache keys (`""`) for all articles. This ensures subsequent crafts (e.g., translation, cleanup, beautify) correctly process and cache each distinct article.

---
*PR created automatically by Jules for task [649913329586295049](https://jules.google.com/task/649913329586295049) started by @Colin-XKL*

## Summary by Sourcery

Bug Fixes:
- Ensure CraftArticle.Description falls back to item.Content when item.Description is empty to avoid empty descriptions and identical cache keys for content-only feeds.