### PR TITLE
fix: return 404 on deleting non-existent topic feed

### DIFF
--- a/internal/controller/topic_feed.go
+++ b/internal/controller/topic_feed.go
@@ -138,6 +138,10 @@ func DeleteTopicFeed(c *gin.Context) {
 	db := util.GetDatabase()
 
 	if err := dao.DeleteTopicFeed(db, id); err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			c.JSON(http.StatusNotFound, util.APIResponse[any]{Msg: "Topic feed not found"})
+			return
+		}
 		c.JSON(http.StatusInternalServerError, util.APIResponse[any]{Msg: err.Error()})
 		return
 	}

--- a/internal/dao/topic.go
+++ b/internal/dao/topic.go
@@ -57,7 +57,14 @@ func UpdateTopicFeed(db *gorm.DB, topic *TopicFeed) error {
 // DeleteTopicFeed deletes a TopicFeed record by its ID.
 func DeleteTopicFeed(db *gorm.DB, id string) error {
 	var topic TopicFeed
-	return db.Where("id = ?", id).Delete(&topic).Error
+	result := db.Where("id = ?", id).Delete(&topic)
+	if result.Error != nil {
+		return result.Error
+	}
+	if result.RowsAffected == 0 {
+		return gorm.ErrRecordNotFound
+	}
+	return nil
 }
 
 // ListTopicFeeds retrieves all TopicFeed records.


### PR DESCRIPTION
Updated `DeleteTopicFeed` in the DAO to check `RowsAffected` and return `gorm.ErrRecordNotFound` if no rows were deleted. Updated the controller to catch this error and return a 404 status, adhering to REST principles.

---
*PR created automatically by Jules for task [13486734116414914333](https://jules.google.com/task/13486734116414914333) started by @Colin-XKL*

## Summary by Sourcery

Ensure deleting a topic feed returns appropriate errors and HTTP status codes when the record does not exist.

Bug Fixes:
- Return gorm.ErrRecordNotFound from DeleteTopicFeed DAO when no topic feed rows are deleted.
- Return HTTP 404 with a clear message when attempting to delete a non-existent topic feed.