### PR TITLE
fix(model): fall back to `Author` field when converting `gofeed.Feed`

### DIFF
--- a/internal/model/feed.go
+++ b/internal/model/feed.go
@@ -74,6 +74,9 @@ func FromGofeed(parsedFeed *gofeed.Feed) *CraftFeed {
 	if len(parsedFeed.Authors) > 0 && parsedFeed.Authors[0] != nil {
 		cf.AuthorName = parsedFeed.Authors[0].Name
 		cf.AuthorEmail = parsedFeed.Authors[0].Email
+	} else if parsedFeed.Author != nil {
+		cf.AuthorName = parsedFeed.Author.Name
+		cf.AuthorEmail = parsedFeed.Author.Email
 	}
 	if parsedFeed.Image != nil {
 		cf.ImageURL = parsedFeed.Image.URL
@@ -121,6 +124,9 @@ func ArticleFromGofeed(item *gofeed.Item) *CraftArticle {
 	if authorItem != nil {
 		article.AuthorName = authorItem.Name
 		article.AuthorEmail = authorItem.Email
+	} else if item.Author != nil {
+		article.AuthorName = item.Author.Name
+		article.AuthorEmail = item.Author.Email
 	}
 
 	return article


### PR DESCRIPTION
`model.FromGofeed` currently copies author info only from `parsedFeed.Authors[0]`. However, the Source pipeline applies FeedMeta author overrides into `feed.Author`, so the author is lost after converting to `CraftFeed`.

This pull request implements the suggested fix in `internal/model/feed.go` to fall back to `parsedFeed.Author` for both the feed and its items if the `Authors` list is empty, preventing metadata loss.

---
*PR created automatically by Jules for task [9961919893557724383](https://jules.google.com/task/9961919893557724383) started by @Colin-XKL*

## Summary by Sourcery

Preserve author metadata when converting gofeed feeds and items to Craft models by adding a fallback from the primary Authors list to the single Author field.

Bug Fixes:
- Fix loss of author information when converting gofeed.Feed to CraftFeed by falling back to the feed's Author field when Authors is empty.
- Fix loss of item author information when converting gofeed.Item to CraftArticle by falling back to the item's Author field when no Authors-derived author is found.