### PR TITLE
fix(dao): return nil on TopicFeed query failure

### DIFF
--- a/internal/dao/topic.go
+++ b/internal/dao/topic.go
@@ -46,7 +46,10 @@ func GetTopicFeedByID(db *gorm.DB, id string) (*TopicFeed, error) {
 		return nil, gorm.ErrRecordNotFound
 	}
 	result := db.Where("id = ?", id).First(&topic)
-	return &topic, result.Error
+	if result.Error != nil {
+		return nil, result.Error
+	}
+	return &topic, nil
 }
 
 // UpdateTopicFeed updates an existing TopicFeed record.
@@ -64,7 +67,7 @@ func DeleteTopicFeed(db *gorm.DB, id string) error {
 func ListTopicFeeds(db *gorm.DB) ([]*TopicFeed, error) {
 	var topics []*TopicFeed
 	if err := db.Find(&topics).Error; err != nil {
-		return topics, err
+		return nil, err
 	}
 	return topics, nil
 }


### PR DESCRIPTION
Modified `GetTopicFeedByID` and `ListTopicFeeds` in `internal/dao/topic.go` to explicitly return a nil pointer/slice on database query failure, rather than returning a zero-valued struct pointer or slice. This prevents callers from accidentally using invalid data if they fail to check the returned error.

---
*PR created automatically by Jules for task [12440596948572411349](https://jules.google.com/task/12440596948572411349) started by @Colin-XKL*

## Summary by Sourcery

Ensure topic feed DAO methods return nil results when database queries fail to avoid exposing partially populated data.

Bug Fixes:
- Return nil from GetTopicFeedByID when the underlying query returns an error instead of a non-nil pointer with an error set.
- Return nil from ListTopicFeeds when the database query fails instead of returning a partially filled slice.