### PR TITLE
Fix metadata corruption in UpdateTopicFeed and UpdateCustomRecipe

### DIFF
--- a/internal/controller/custom_recipe.go
+++ b/internal/controller/custom_recipe.go
@@ -88,7 +88,7 @@ func UpdateCustomRecipe(c *gin.Context) {
 	}
 	db := util.GetDatabase()
 
-	_, err := dao.GetCustomRecipeByIDV2(db, id)
+	existingRecipe, err := dao.GetCustomRecipeByIDV2(db, id)
 	if err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			c.JSON(http.StatusNotFound, util.APIResponse[any]{Msg: "Recipe not found"})
@@ -98,12 +98,17 @@ func UpdateCustomRecipe(c *gin.Context) {
 		return
 	}
 
-	if err := dao.UpdateCustomRecipeV2(db, &recipeData); err != nil {
+	existingRecipe.Description = recipeData.Description
+	existingRecipe.Craft = recipeData.Craft
+	existingRecipe.SourceType = recipeData.SourceType
+	existingRecipe.SourceConfig = recipeData.SourceConfig
+
+	if err := dao.UpdateCustomRecipeV2(db, existingRecipe); err != nil {
 		c.JSON(http.StatusInternalServerError, util.APIResponse[any]{Msg: err.Error()})
 		return
 	}
 
-	c.JSON(http.StatusOK, util.APIResponse[any]{Data: recipeData})
+	c.JSON(http.StatusOK, util.APIResponse[any]{Data: existingRecipe})
 }
 
 func DeleteCustomRecipe(c *gin.Context) {

--- a/internal/controller/topic_feed.go
+++ b/internal/controller/topic_feed.go
@@ -115,7 +115,7 @@ func UpdateTopicFeed(c *gin.Context) {
 
 	db := util.GetDatabase()
 
-	_, err := dao.GetTopicFeedByID(db, id)
+	existingTopic, err := dao.GetTopicFeedByID(db, id)
 	if err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			c.JSON(http.StatusNotFound, util.APIResponse[any]{Msg: "Topic feed not found"})
@@ -125,12 +125,17 @@ func UpdateTopicFeed(c *gin.Context) {
 		return
 	}
 
-	if err := dao.UpdateTopicFeed(db, &topicData); err != nil {
+	existingTopic.Title = topicData.Title
+	existingTopic.Description = topicData.Description
+	existingTopic.InputURIs = topicData.InputURIs
+	existingTopic.AggregatorConfig = topicData.AggregatorConfig
+
+	if err := dao.UpdateTopicFeed(db, existingTopic); err != nil {
 		c.JSON(http.StatusInternalServerError, util.APIResponse[any]{Msg: err.Error()})
 		return
 	}
 
-	c.JSON(http.StatusOK, util.APIResponse[any]{Data: topicData})
+	c.JSON(http.StatusOK, util.APIResponse[any]{Data: existingTopic})
 }
 
 func DeleteTopicFeed(c *gin.Context) {


### PR DESCRIPTION
Fixed an issue where updating topic feeds and custom recipes via the admin interface would overwrite non-editable metadata columns (like `created_at` and `deleted_at`) with their zero values. The controllers now fetch the existing record first and only copy the modified fields before saving.

---
*PR created automatically by Jules for task [8638583650656038343](https://jules.google.com/task/8638583650656038343) started by @Colin-XKL*

## Summary by Sourcery

Preserve non-editable metadata when updating topic feeds and custom recipes via the admin API by applying updates only to mutable fields on the existing records.

Bug Fixes:
- Prevent UpdateCustomRecipe from overwriting existing metadata fields by updating only the editable attributes of the fetched recipe record.
- Prevent UpdateTopicFeed from overwriting existing metadata fields by updating only the editable attributes of the fetched topic record.