### PR TITLE
fix: prevent panics from nil article dereferences in aggregator

### DIFF
--- a/internal/engine/aggregator.go
+++ b/internal/engine/aggregator.go
@@ -23,6 +23,10 @@ func (p *DeduplicateProcessor) Process(ctx context.Context, feed *model.CraftFee
 	var uniqueArticles []*model.CraftArticle
 
 	for _, article := range feed.Articles {
+		if article == nil {
+			continue
+		}
+
 		var key string
 		switch strings.ToLower(p.Strategy) {
 		case "by_id":

--- a/internal/model/feed.go
+++ b/internal/model/feed.go
@@ -80,8 +80,9 @@ func FromGofeed(parsedFeed *gofeed.Feed) *CraftFeed {
 		cf.ImageTitle = parsedFeed.Image.Title
 	}
 
-	cf.Articles = lo.Map(parsedFeed.Items, func(item *gofeed.Item, _ int) *CraftArticle {
-		return ArticleFromGofeed(item)
+	cf.Articles = lo.FilterMap(parsedFeed.Items, func(item *gofeed.Item, _ int) (*CraftArticle, bool) {
+		article := ArticleFromGofeed(item)
+		return article, article != nil
 	})
 
 	return cf


### PR DESCRIPTION
Fixes an issue where `cf.Articles` could contain `nil` entries, causing panics when downstream processors (such as `DeduplicateProcessor`) attempted to dereference `article.Id` or `article.Link`.

Replaced `lo.Map` with `lo.FilterMap` in `internal/model/feed.go` to filter out any `nil` items early. Also added a defensive nil check directly inside the `DeduplicateProcessor` loop in `internal/engine/aggregator.go` for robust execution against legacy structures or alternative pipeline sources.

---
*PR created automatically by Jules for task [6629047830495080181](https://jules.google.com/task/6629047830495080181) started by @Colin-XKL*

## Summary by Sourcery

Prevent panics caused by nil articles in feed processing by filtering them out during feed construction and defensively skipping nil entries during aggregation.

Bug Fixes:
- Filter out nil articles when converting parsed feeds to internal CraftFeed structures to avoid downstream nil dereferences.
- Skip nil articles in the DeduplicateProcessor to ensure robust handling of legacy or malformed feeds.