### PR TITLE
fix: resolve relative feed links properly against base URL

### DIFF
--- a/internal/craft/common.go
+++ b/internal/craft/common.go
@@ -222,6 +222,9 @@ func getAbsFeedLink(feedUrl, feedLinkAttr string) string {
 	if err != nil {
 		logrus.Errorf("invalid feed url [%s]. err: %v", feedUrl, err)
 	} else {
+		if feedLinkAttr != "" && feedLinkUrl != nil {
+			return parsedFeedUrl.ResolveReference(feedLinkUrl).String()
+		}
 		return fmt.Sprintf("%s://%s", parsedFeedUrl.Scheme, parsedFeedUrl.Host)
 	}
 	return feedLinkAttr

--- a/internal/source/adapter.go
+++ b/internal/source/adapter.go
@@ -48,6 +48,9 @@ func getAbsFeedLink(feedUrl, feedLinkAttr string) string {
 	if err != nil {
 		logrus.Errorf("invalid feed url [%s]. err: %v", feedUrl, err)
 	} else {
+		if feedLinkAttr != "" && feedLinkUrl != nil {
+			return parsedFeedUrl.ResolveReference(feedLinkUrl).String()
+		}
 		return fmt.Sprintf("%s://%s", parsedFeedUrl.Scheme, parsedFeedUrl.Host)
 	}
 	return feedLinkAttr


### PR DESCRIPTION
When a parsed feedLinkAttr is a relative URL (e.g. `/feed.xml`), the current implementation in `getAbsFeedLink` truncates it to just the scheme and host of the origin URL. This incorrectly creates URLs like `https://example.com` instead of `https://example.com/feed.xml`.

This PR fixes this issue by resolving the relative URL against the parsed base URL using `ResolveReference()` from the standard `net/url` package.

Changes:
- Modified `getAbsFeedLink` in `internal/craft/common.go`
- Modified `getAbsFeedLink` in `internal/source/adapter.go`

Tests passed.

---
*PR created automatically by Jules for task [13018316294110480581](https://jules.google.com/task/13018316294110480581) started by @Colin-XKL*

## Summary by Sourcery

Bug Fixes:
- Resolve relative feed link attributes against the base feed URL instead of truncating them to only scheme and host in both craft and source adapters.