### PR TITLE
Add GitHub link to doc-site header

### DIFF
--- a/doc-site/astro.config.mjs
+++ b/doc-site/astro.config.mjs
@@ -9,6 +9,9 @@ export default defineConfig({
     starlight({
       title: "FeedCraft",
       defaultLocale: "en",
+      social: [
+        { icon: "github", label: "GitHub", href: "https://github.com/Colin-XKL/FeedCraft" }
+      ],
       plugins: [
         starlightCatppuccin({
           dark: { flavor: "mocha", accent: "sapphire" },


### PR DESCRIPTION
Added a GitHub social link to the Astro Starlight documentation site configuration, updating the schema format to an array of objects to align with Starlight v0.33.0 changes.

---
*PR created automatically by Jules for task [13468310601917799908](https://jules.google.com/task/13468310601917799908) started by @Colin-XKL*

## Summary by Sourcery

New Features:
- Expose a GitHub link in the documentation site's header via Starlight social configuration.