### PR TITLE
fix(log): reduce language detection log noise and add LOG_LEVEL env var

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,7 @@
 # Server Configuration
 LISTEN_ADDR=:8080
 ENV=dev
+# LOG_LEVEL=info
 
 # Sentry (optional)
 SENTRY_DSN=

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -103,9 +103,20 @@ func startServer() {
 		env = "prod"
 	}
 	isProd := env == "prod"
+
 	if !isProd {
 		logrus.SetLevel(logrus.DebugLevel)
 	}
+
+	logLevelStr := os.Getenv("LOG_LEVEL")
+	if logLevelStr != "" {
+		if level, err := logrus.ParseLevel(logLevelStr); err == nil {
+			logrus.SetLevel(level)
+		} else {
+			logrus.Warnf("Invalid LOG_LEVEL '%s': %v. Using default.", logLevelStr, err)
+		}
+	}
+
 	if len(sentryDsn) > 0 {
 		logrus.Info("Initializing Sentry...")
 		sampledRate := 1.0

--- a/internal/util/language.go
+++ b/internal/util/language.go
@@ -75,7 +75,7 @@ func IsSameLanguage(text string, targetLangCode string) bool {
 	base, _ := targetTag.Base()
 	targetIso := base.String()
 
-	logrus.Debugf("Language detection: text_len=%d, detected=%s, target=%s", len(text), detectedIso, targetIso)
+	logrus.Tracef("Language detection: text_len=%d, detected=%s, target=%s", len(text), detectedIso, targetIso)
 
 	// whatlanggo returns "zh" for Mandarin (Cmn) when calling Iso6391()
 	return detectedIso == targetIso


### PR DESCRIPTION
- Added support for the `LOG_LEVEL` environment variable, enabling finer control over the application's log output.
- Demoted the "Language detection" log statement in `internal/util/language.go` from `logrus.Debugf` to `logrus.Tracef`. This prevents excessive log spam when running the application in non-production environments (where the default log level is `debug`), as requested.
- Updated `.env.example` to include the new `LOG_LEVEL` variable.

---
*PR created automatically by Jules for task [3236977184923523435](https://jules.google.com/task/3236977184923523435) started by @Colin-XKL*

## Summary by Sourcery

Introduce configurable log level via environment variable and reduce verbosity of language detection logging.

New Features:
- Allow configuring the application log level via a LOG_LEVEL environment variable, overriding the default in non-production environments.

Enhancements:
- Lower the language detection log message from debug to trace to reduce default log noise.
- Document the LOG_LEVEL environment variable in .env.example for easier configuration.