### PR TITLE
fix: improve language detection for texts mixed with HTML/URLs/English

### DIFF
--- a/internal/util/language.go
+++ b/internal/util/language.go
@@ -1,12 +1,20 @@
 package util
 
 import (
+	"regexp"
 	"strings"
 
 	"github.com/abadojack/whatlanggo"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/text/language"
 	"golang.org/x/text/language/display"
+)
+
+var (
+	htmlTagRegex = regexp.MustCompile(`(?i)<[^>]*>`)
+	urlRegex     = regexp.MustCompile(`(?i)https?://[^\s]+`)
+	uuidRegex    = regexp.MustCompile(`(?i)[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}`)
+	enWordRegex  = regexp.MustCompile(`(?i)\b[a-z]+\b`)
 )
 
 // GetDefaultTargetLang returns the default target language code (e.g. "zh-CN", "en")
@@ -57,7 +65,12 @@ func IsSameLanguage(text string, targetLangCode string) bool {
 		return false
 	}
 
-	info := whatlanggo.Detect(text)
+	// Clean text from noise (HTML tags, URLs, UUIDs) that distorts trigram-based language detection
+	cleanText := uuidRegex.ReplaceAllString(text, " ")
+	cleanText = htmlTagRegex.ReplaceAllString(cleanText, " ")
+	cleanText = urlRegex.ReplaceAllString(cleanText, " ")
+
+	info := whatlanggo.Detect(cleanText)
 	detectedIso := info.Lang.Iso6391()
 
 	// Normalize targetLangCode to ISO 639-1 for comparison
@@ -69,13 +82,40 @@ func IsSameLanguage(text string, targetLangCode string) bool {
 		if len(targetLangCode) > 2 && strings.Contains(targetLangCode, "-") {
 			targetIso = strings.Split(targetLangCode, "-")[0]
 		}
-		return detectedIso == targetIso
+
+		return checkLanguageMatchFallback(cleanText, detectedIso, targetIso)
 	}
 
 	base, _ := targetTag.Base()
 	targetIso := base.String()
 
 	logrus.Debugf("Language detection: text_len=%d, detected=%s, target=%s", len(text), detectedIso, targetIso)
+
+	return checkLanguageMatchFallback(cleanText, detectedIso, targetIso)
+}
+
+// checkLanguageMatchFallback applies additional CJK-specific language detection fallback.
+// English words in short texts can heavily sway the whatlanggo trigram models, causing
+// Japanese/Chinese texts to be detected as English, Danish, Portuguese, etc.
+func checkLanguageMatchFallback(cleanText string, detectedIso string, targetIso string) bool {
+	if detectedIso == targetIso {
+		return true
+	}
+
+	// For CJK languages, strip English alphabetical words and try detection again
+	if targetIso == "ja" || targetIso == "zh" || targetIso == "ko" {
+		cleanTextCJK := enWordRegex.ReplaceAllString(cleanText, " ")
+		if strings.TrimSpace(cleanTextCJK) != "" {
+			infoCJK := whatlanggo.Detect(cleanTextCJK)
+			detectedIsoCJK := infoCJK.Lang.Iso6391()
+
+			// If whatlanggo successfully detects the target CJK language after stripping English text
+			if detectedIsoCJK == targetIso {
+				logrus.Debugf("Language detection fallback triggered: original=%s, corrected=%s", detectedIso, detectedIsoCJK)
+				return true
+			}
+		}
+	}
 
 	// whatlanggo returns "zh" for Mandarin (Cmn) when calling Iso6391()
 	return detectedIso == targetIso

--- a/internal/util/language_test.go
+++ b/internal/util/language_test.go
@@ -45,6 +45,14 @@ func TestIsSameLanguage(t *testing.T) {
 		{"Hello 这是一个中文句子。", "zh", true},
 		// Short text might be hard to detect, but let's see
 		{"你好", "zh", true},
+
+		// Test texts with noise (HTML tags, URLs, UUIDs)
+		{"<div id=\"12345678-1234-1234-1234-123456789012\">这是一个中文句子。</div>", "zh", true},
+		{"<a href=\"https://example.com/some/long/url/with/english/words\">这是一个带有链接的中文句子。</a>", "zh", true},
+		{"<p>Some English intro text here.</p> <p>然后是大量的中文内容，以确保中文被正确识别。</p>", "zh", true},
+		{"<div>[128/365]Thought as a Medium: Sculpting the Mind with Multi-Agent Systems 【128/365】2026年4月3日このところAI Agent（Tochikoma Multi Agent System）作品の制作にかかりっきりです。続きをみる</div>", "ja", true},
+		{"Gemma 4 の概要 「Gemma 4」の概要をまとめました。・Gemma 4: Byte for byte, the most capable open models 続きをみる", "ja", true},
+		{"<a href=\"https://example.com\">Hello World</a> これは日本語のテキストです。", "ja", true},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
The `IsSameLanguage` function in `internal/util/language.go` was misidentifying CJK texts (specifically Japanese and Chinese) as various Latin-based languages (like `fr`, `es`, `da`, `pt`, `ak`) when the text contained HTML tags, URLs, UUIDs, or English words (e.g., "LLM", "Agent"). This happens because `whatlanggo` uses character trigrams, and the English characters overwhelm the scoring model for short strings.

This PR introduces robust regex-based preprocessing that safely strips common sources of Latin-character noise (HTML tags, URLs, UUIDs) before invoking `whatlanggo.Detect`. 

Additionally, a fallback is implemented specifically for `ja`, `zh`, and `ko` target languages. If the initial detection fails to match the target language, it strips all remaining English words (`[a-zA-Z]+`) from the text and re-attempts detection on the CJK characters. 

Tests have been added to verify detection against noisy inputs.

---
*PR created automatically by Jules for task [15969281205250605297](https://jules.google.com/task/15969281205250605297) started by @Colin-XKL*

## Summary by Sourcery

Improve robustness of language detection by preprocessing noisy text and adding CJK-specific fallbacks.

Bug Fixes:
- Prevent CJK texts mixed with HTML, URLs, UUIDs, or English words from being misclassified as Latin-based languages during detection.

Enhancements:
- Strip HTML tags, URLs, and UUIDs before language detection and add a CJK-focused fallback that retries detection after removing English words from the text.

Tests:
- Extend language detection tests to cover noisy mixed-language inputs for Chinese and Japanese text.