### PR TITLE
feat: add cache status to craft log output

### DIFF
--- a/internal/craft/common.go
+++ b/internal/craft/common.go
@@ -155,7 +155,6 @@ type RawTransformer func(item *feeds.Item) (string, error)
 func GetCommonCachedTransformer(cacheKeyGenerator ContentCacheKeyGenerator, rawTransformer TransFunc, craftName string) TransFunc {
 	ret := func(item *feeds.Item) (string, error) {
 		originalTitle := item.Title
-		logrus.Infof("applying craft [%s] to article [%s]", craftName, originalTitle)
 
 		hashVal, _ := cacheKeyGenerator(item)
 		cacheKey := getCraftCacheKey(craftName, hashVal)
@@ -168,7 +167,9 @@ func GetCommonCachedTransformer(cacheKeyGenerator ContentCacheKeyGenerator, rawT
 			return ret, err
 		}
 
-		return util.CachedFunc(cacheKey, valFunc)
+		return util.CachedFuncWithPreLog(cacheKey, valFunc, func(isCached bool) {
+			logrus.Infof("applying craft [%s] to article [%s], cached: %v", craftName, originalTitle, isCached)
+		})
 	}
 	return ret
 }

--- a/internal/craft/content_processors.go
+++ b/internal/craft/content_processors.go
@@ -180,8 +180,10 @@ func GetCommonCachedArticleTransformer(cacheKeyGenerator ArticleCacheKeyGenerato
 			return "", err
 		}
 		cacheKey := getCraftCacheKey(craftName, hashVal)
-		return util.CachedFunc(cacheKey, func() (string, error) {
+		return util.CachedFuncWithPreLog(cacheKey, func() (string, error) {
 			return rawTransformer(ctx, article)
+		}, func(isCached bool) {
+			logrus.Infof("applying craft [%s] to article [%s], cached: %v", craftName, article.Title, isCached)
 		})
 	}
 }

--- a/internal/util/cache.go
+++ b/internal/util/cache.go
@@ -38,11 +38,17 @@ func CacheGetString(key string) (string, error) {
 	return rdb.Get(context.Background(), key).Result()
 }
 
-// CachedFunc 先尝试取缓存, 如不存在, 则调用valFunc 获取值并写入缓存
-func CachedFunc(cacheKey string, valFunc func() (string, error)) (string, error) {
+// CachedFuncWithPreLog tries to get from cache, invokes preLog if provided, and if absent, calls valFunc and saves to cache
+func CachedFuncWithPreLog(cacheKey string, valFunc func() (string, error), preLog func(isCached bool)) (string, error) {
 	final := ""
 	cached, err := CacheGetString(cacheKey)
-	if err != nil || cached == "" {
+	isCached := err == nil && cached != ""
+
+	if preLog != nil {
+		preLog(isCached)
+	}
+
+	if !isCached {
 		processedContent, getValErr := valFunc()
 		if getValErr != nil {
 			return "", getValErr
@@ -51,8 +57,6 @@ func CachedFunc(cacheKey string, valFunc func() (string, error)) (string, error)
 			cacheErr := CacheSetString(cacheKey, processedContent, constant.WebContentExpire)
 			if cacheErr != nil {
 				logrus.Warn("failed to cache result")
-				//logrus.Warnf("failed to cache result of craft [%s] for article [%s], %v\n", craftName,
-				//	originalTitle, cacheErr)
 			}
 		}
 	} else {
@@ -60,4 +64,9 @@ func CachedFunc(cacheKey string, valFunc func() (string, error)) (string, error)
 	}
 
 	return final, nil
+}
+
+// CachedFunc 先尝试取缓存, 如不存在, 则调用valFunc 获取值并写入缓存
+func CachedFunc(cacheKey string, valFunc func() (string, error)) (string, error) {
+	return CachedFuncWithPreLog(cacheKey, valFunc, nil)
 }


### PR DESCRIPTION
- Introduced `CachedFuncWithPreLog` in `internal/util/cache.go` to provide cache hit/miss status cleanly before the actual logic execution without duplicate database calls.
- Refactored `CachedFunc` to use `CachedFuncWithPreLog`.
- Updated `GetCommonCachedTransformer` in `internal/craft/common.go` and `GetCommonCachedArticleTransformer` in `internal/craft/content_processors.go` to use `CachedFuncWithPreLog` and output `cached: true/false` in their standard log statements.

---
*PR created automatically by Jules for task [10305086030394241027](https://jules.google.com/task/10305086030394241027) started by @Colin-XKL*

## Summary by Sourcery

Add cache-aware logging around craft transformations while introducing a reusable cached function helper with optional pre-execution logging.

New Features:
- Introduce CachedFuncWithPreLog utility to report cache hit or miss before executing value computations.

Enhancements:
- Refactor existing CachedFunc to delegate to CachedFuncWithPreLog for consistent cache handling.
- Update craft transformers to include cache hit status in their log output when applying crafts to items and articles.