### PR TITLE
Fix Docker semver tag generation in GitHub Actions workflow

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -74,8 +74,9 @@ jobs:
             type=raw,value=latest,enable={{is_default_branch}}
             # set dev tag for dev branch
             type=raw,value=dev,enable=${{ github.ref == 'refs/heads/dev' }}
-            type=pep440,pattern={{major}}.{{minor}},enable={{is_default_branch}}
-            type=pep440,pattern={{version}},enable={{is_default_branch}}
+            type=semver,pattern=v{{version}}
+            type=semver,pattern=v{{major}}.{{minor}}
+            type=semver,pattern=v{{major}}
             # tag with branch name for other branches
             type=ref,event=branch
           flavor: latest=false


### PR DESCRIPTION
Fix Docker semver tag generation in GitHub Actions workflow

Replace the `pep440` tag configuration (which was restricted to the default branch)
with `type=semver` rules explicitly preserving the `v` prefix in `.github/workflows/docker-publish.yml`.
This ensures that creating a GitHub Release via a git tag like `v3.1.0` correctly builds and publishes
images tagged as `v3.1.0`, `v3.1`, and `v3` to the registry.

---
*PR created automatically by Jules for task [7506795202610087225](https://jules.google.com/task/7506795202610087225) started by @Colin-XKL*

## Summary by Sourcery

Build:
- Adjust Docker metadata action configuration to use semver-based tag rules instead of pep440, ensuring tags like vX.Y.Z, vX.Y, and vX are produced from release tags.