### PR TITLE
fix(html-to-rss): use descendant combinator in generated CSS selectors

### DIFF
--- a/web/admin/src/views/dashboard/html_to_rss/utils/selector.ts
+++ b/web/admin/src/views/dashboard/html_to_rss/utils/selector.ts
@@ -75,5 +75,5 @@ export const getCssSelector = (
     if (!currentEl || currentEl === body || currentEl === html) break;
   }
 
-  return path.join(' > ');
+  return path.join(' ');
 };


### PR DESCRIPTION
Fixes an issue where the HTML-to-RSS wizard correctly showed matched items in the frontend preview, but the backend returned empty content when fetching the actual feed due to mismatching direct child selectors.

---
*PR created automatically by Jules for task [2767013045760520773](https://jules.google.com/task/2767013045760520773) started by @Colin-XKL*

## Summary by Sourcery

Bug Fixes:
- Fix incorrect feed extraction in HTML-to-RSS where backend selectors failed to match elements despite correct matches in the frontend preview.