### PR TITLE
feat: custom ua

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,10 @@ FC_DB_SQLITE_PATH=./db
 # Cache Configuration
 FC_REDIS_URI=redis://localhost:6379/
 
+# Outbound HTTP User-Agent defaults
+FC_HTTP_USER_AGENT_FEED=FeedCraft/2.0
+FC_HTTP_USER_AGENT_HTML=Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/135.0.0.0 Safari/537.36
+
 # LLM Configuration
 FC_LLM_API_BASE=https://api.openai.com/v1
 FC_LLM_API_KEY=sk-your-api-key-here

--- a/doc-site/src/content/docs/en/guides/advanced/customization.md
+++ b/doc-site/src/content/docs/en/guides/advanced/customization.md
@@ -65,6 +65,8 @@ You can configure FeedCraft using environment variables in `docker-compose.yml`.
 
 - **FC_PUPPETEER_HTTP_ENDPOINT**: Address of the Browserless/Chrome instance. Required for `fulltext-plus`.
 - **FC_REDIS_URI**: Redis connection address. Used for caching to speed up processing and reduce AI token consumption.
+- **FC_HTTP_USER_AGENT_FEED**: (Optional) Default `User-Agent` for feed-style outbound requests, such as fetching RSS/XML resources. Search provider requests are temporarily grouped into this same rule.
+- **FC_HTTP_USER_AGENT_HTML**: (Optional) Default `User-Agent` for HTML page fetches, such as fulltext extraction and the HTML-to-RSS tooling.
 - **FC_LLM_API_KEY**: API Key for OpenAI or compatible services (like DeepSeek, Gemini, etc.).
 - **FC_LLM_API_MODEL**: Default model to use (e.g., `gemini-pro`, `gpt-3.5-turbo`). **Multiple Models Support:** You can provide a comma-separated list of models (e.g., `gpt-3.5-turbo,gpt-4`). FeedCraft will randomly select a model for each request and automatically retry with others if a call fails.
 - **FC_LLM_API_BASE**: API endpoint address. For OpenAI-compatible APIs, usually ends with `/v1`.

--- a/doc-site/src/content/docs/zh-tw/guides/advanced/customization.md
+++ b/doc-site/src/content/docs/zh-tw/guides/advanced/customization.md
@@ -65,6 +65,8 @@ sidebar:
 
 - **FC_PUPPETEER_HTTP_ENDPOINT**: Browserless/Chrome 實例的地址。`fulltext-plus` 功能必須。
 - **FC_REDIS_URI**: Redis 連線地址。用於快取，加快處理速度並減少 AI Token 消耗。
+- **FC_HTTP_USER_AGENT_FEED**: （可選）feed 類外部請求的預設 `User-Agent`，例如抓取 RSS/XML 資源時使用。搜尋提供方請求目前也暫時歸入這一規則。
+- **FC_HTTP_USER_AGENT_HTML**: （可選）HTML 頁面抓取的預設 `User-Agent`，例如全文提取和 HTML 轉 RSS 工具使用。
 - **FC_LLM_API_KEY**: OpenAI 或相容服務（如 DeepSeek, Gemini 等）的 API Key。
 - **FC_LLM_API_MODEL**: 預設使用的模型（如 `gemini-pro`, `gpt-3.5-turbo`）。**支援多個模型：** 你可以提供一個逗號分隔的模型列表（例如 `gpt-3.5-turbo,gpt-4`）。FeedCraft 會為每個請求隨機選擇一個模型，如果調用失敗，會自動重試列表中的其他模型。
 - **FC_LLM_API_BASE**: API 介面地址。如果是相容 OpenAI 的 API，通常以 `/v1` 結尾。

--- a/doc-site/src/content/docs/zh/guides/advanced/customization.md
+++ b/doc-site/src/content/docs/zh/guides/advanced/customization.md
@@ -65,6 +65,8 @@ sidebar:
 
 - **FC_PUPPETEER_HTTP_ENDPOINT**: Browserless/Chrome 实例的地址。`fulltext-plus` 功能必须。
 - **FC_REDIS_URI**: Redis 连接地址。用于缓存，加快处理速度并减少 AI Token 消耗。
+- **FC_HTTP_USER_AGENT_FEED**: （可选）feed 类外部请求的默认 `User-Agent`，例如抓取 RSS/XML 资源时使用。搜索提供方请求目前也临时归入这一规则。
+- **FC_HTTP_USER_AGENT_HTML**: （可选）HTML 页面抓取的默认 `User-Agent`，例如全文提取和 HTML 转 RSS 工具使用。
 - **FC_LLM_API_KEY**: OpenAI 或兼容服务（如 DeepSeek, Gemini 等）的 API Key。
 - **FC_LLM_API_MODEL**: 默认使用的模型（如 `gemini-pro`, `gpt-3.5-turbo`）。**支持多个模型：** 你可以提供一个逗号分隔的模型列表（例如 `gpt-3.5-turbo,gpt-4`）。FeedCraft 会为每个请求随机选择一个模型，如果调用失败，会自动重试列表中的其他模型。
 - **FC_LLM_API_BASE**: API 接口地址。如果是兼容 OpenAI 的 API，通常以 `/v1` 结尾。

--- a/internal/config/source_config.go
+++ b/internal/config/source_config.go
@@ -4,6 +4,11 @@ import (
 	"FeedCraft/internal/constant"
 )
 
+const (
+	HttpFetcherPurposeFeed = "feed"
+	HttpFetcherPurposeHTML = "html"
+)
+
 // --- Fetcher-specific Configurations ---
 
 // HttpFetcherConfig holds the configuration for an HTTP fetcher.
@@ -14,6 +19,7 @@ type HttpFetcherConfig struct {
 	Headers        map[string]string `json:"headers,omitempty"`
 	Body           string            `json:"body,omitempty"`
 	UseBrowserless bool              `json:"use_browserless,omitempty"`
+	Purpose        string            `json:"purpose,omitempty"`
 }
 
 // SearchFetcherConfig holds the configuration for search-based fetching.

--- a/internal/controller/html_to_rss.go
+++ b/internal/controller/html_to_rss.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"FeedCraft/internal/craft"
+	fetcherpkg "FeedCraft/internal/source/fetcher"
 	"FeedCraft/internal/util"
 	"fmt"
 	"net"
@@ -67,19 +68,13 @@ func fetchHTML(targetURL string, useBrowserless bool) (string, error) {
 		})
 	}
 
-	// Try standard HTTP request (simulating a browser user agent)
 	client := resty.New()
 	client.SetTimeout(craft.DefaultExtractFulltextTimeout)
-	resp, err := client.R().
-		SetHeader("User-Agent", "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36").
-		SetHeader("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7").
-		SetHeader("Accept-Language", "en-US,en;q=0.9").
-		SetHeader("Upgrade-Insecure-Requests", "1").
-		SetHeader("Sec-Fetch-Dest", "document").
-		SetHeader("Sec-Fetch-Mode", "navigate").
-		SetHeader("Sec-Fetch-Site", "none").
-		SetHeader("Sec-Fetch-User", "?1").
-		Get(targetURL)
+	req := client.R()
+	for key, value := range fetcherpkg.HTMLDefaultHeaders() {
+		req.SetHeader(key, value)
+	}
+	resp, err := req.Get(targetURL)
 
 	if err != nil {
 		return "", fmt.Errorf("fetch failed: %w", err)

--- a/internal/craft/option.go
+++ b/internal/craft/option.go
@@ -1,13 +1,16 @@
 package craft
 
 import (
+	"FeedCraft/internal/config"
+	"FeedCraft/internal/source/fetcher"
+	"bytes"
+	"context"
 	"fmt"
 	"github.com/gorilla/feeds"
 	"github.com/mmcdole/gofeed"
 	"github.com/samber/lo"
 	"github.com/samber/lo/parallel"
 	"github.com/sirupsen/logrus"
-
 	"strings"
 )
 
@@ -26,8 +29,16 @@ type CraftOption func(*feeds.Feed, ExtraPayload) error
 func NewCraftedFeedFromUrl(feedUrl string, options ...CraftOption) (CraftedFeed, error) {
 	ingredient := CraftedFeed{originalFeedUrl: feedUrl}
 
+	raw, err := (&fetcher.HttpFetcher{Config: &config.HttpFetcherConfig{
+		URL:     feedUrl,
+		Purpose: config.HttpFetcherPurposeFeed,
+	}}).Fetch(context.Background())
+	if err != nil {
+		return ingredient, err
+	}
+
 	fp := gofeed.NewParser()
-	parsedFeed, err := fp.ParseURL(feedUrl)
+	parsedFeed, err := fp.Parse(bytes.NewReader(raw))
 	if err != nil {
 		return ingredient, err
 	}

--- a/internal/craft/option_fetch_test.go
+++ b/internal/craft/option_fetch_test.go
@@ -1,0 +1,40 @@
+package craft
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestNewCraftedFeedFromUrlUsesFeedFetcherUserAgent(t *testing.T) {
+	var gotUA string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotUA = r.Header.Get("User-Agent")
+		w.Header().Set("Content-Type", "application/rss+xml")
+		_, _ = w.Write([]byte(`<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+  <channel>
+    <title>Feed</title>
+    <link>https://example.com/</link>
+    <description>Test feed</description>
+    <item>
+      <title>Item 1</title>
+      <link>https://example.com/item-1</link>
+      <description>Hello</description>
+    </item>
+  </channel>
+</rss>`))
+	}))
+	defer server.Close()
+
+	crafted, err := NewCraftedFeedFromUrl(server.URL)
+	if err != nil {
+		t.Fatalf("NewCraftedFeedFromUrl returned error: %v", err)
+	}
+	if crafted.OutputFeed == nil {
+		t.Fatal("expected output feed")
+	}
+	if gotUA != "FeedCraft/2.0" {
+		t.Fatalf("expected feed fetcher user agent, got %q", gotUA)
+	}
+}

--- a/internal/feedruntime/builder.go
+++ b/internal/feedruntime/builder.go
@@ -173,7 +173,6 @@ func (b *Builder) BuildRecipe(ctx context.Context, recipeData *dao.CustomRecipeV
 	if err != nil {
 		return nil, err
 	}
-
 	provider, err := b.BuildProviderFromInput(ctx, inputSpec, nil)
 	if err != nil {
 		return nil, err

--- a/internal/feedruntime/builder_test.go
+++ b/internal/feedruntime/builder_test.go
@@ -146,7 +146,6 @@ func TestBuildRecipe_UsesSourceInputSpecCompatibility(t *testing.T) {
 	assert.Equal(t, "stub-feed", feed.Title)
 }
 
-
 func TestProxyRecipeFetch_UsesDefaultUserAgent(t *testing.T) {
 	var gotUA string
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/feedruntime/builder_test.go
+++ b/internal/feedruntime/builder_test.go
@@ -3,6 +3,9 @@ package feedruntime
 import (
 	"context"
 	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
@@ -143,14 +146,47 @@ func TestBuildRecipe_UsesSourceInputSpecCompatibility(t *testing.T) {
 	assert.Equal(t, "stub-feed", feed.Title)
 }
 
-func TestBuildProviderFromInput_InvalidURI(t *testing.T) {
-	builder := NewBuilder(newTestDB(t))
-	_, err := builder.BuildProviderFromInput(context.Background(), InputSpec{
-		Kind: InputKindURI,
-		URI:  "feedcraft://recipe",
-	}, nil)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "missing resource id")
+
+func TestProxyRecipeFetch_UsesDefaultUserAgent(t *testing.T) {
+	var gotUA string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotUA = r.Header.Get("User-Agent")
+		w.Header().Set("Content-Type", "application/rss+xml")
+		_, _ = io.WriteString(w, `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+  <channel>
+    <title>Proxy Feed</title>
+    <link>https://example.com/</link>
+    <description>Proxy test feed</description>
+    <item>
+      <title>Item 1</title>
+      <link>https://example.com/item-1</link>
+      <description>Hello</description>
+    </item>
+  </channel>
+</rss>`)
+	}))
+	defer server.Close()
+
+	db := newTestDB(t)
+	require.NoError(t, db.Create(&dao.CustomRecipeV2{
+		ID:         "proxy-runtime-default-ua",
+		Craft:      "proxy",
+		SourceType: string(constant.SourceRSS),
+		SourceConfig: `{
+			"type":"rss",
+			"http_fetcher":{"url":"` + server.URL + `"}
+		}`,
+	}).Error)
+
+	builder := NewBuilder(db)
+	provider, err := builder.BuildRecipeProvider(context.Background(), "proxy-runtime-default-ua")
+	require.NoError(t, err)
+
+	feed, err := provider.Fetch(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, feed)
+	assert.Equal(t, "FeedCraft/2.0", gotUA)
 }
 
 func TestBuildAggregator(t *testing.T) {
@@ -235,7 +271,7 @@ func newTestDB(t *testing.T) *gorm.DB {
 	dsn := "file:" + t.Name() + "?mode=memory&cache=shared"
 	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
 	require.NoError(t, err)
-	require.NoError(t, db.AutoMigrate(&dao.CustomRecipeV2{}, &dao.TopicFeed{}))
+	require.NoError(t, db.AutoMigrate(&dao.CustomRecipeV2{}, &dao.TopicFeed{}, &dao.CraftAtom{}))
 	return db
 }
 

--- a/internal/router/registry.go
+++ b/internal/router/registry.go
@@ -35,6 +35,7 @@ func RegisterRouters(router *gin.Engine) {
 	router.LoadHTMLFiles("web/index.html")
 	router.LoadHTMLFiles("web/start.html")
 	router.StaticFile("/start.html", "web/start.html")
+	router.StaticFile("/favicon.ico", "web/favicon.ico")
 	//router.GET("/start.html", func(c *gin.Context) {
 	//	c.HTML(http.StatusOK, "start.html", gin.H{
 	//		"SiteBaseUrl": siteBaseUrl,

--- a/internal/source/fetcher/http_fetcher.go
+++ b/internal/source/fetcher/http_fetcher.go
@@ -4,12 +4,20 @@ import (
 	"FeedCraft/internal/config"
 	"FeedCraft/internal/util"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"strings"
 	"time"
+
+	retry "github.com/avast/retry-go/v4"
 )
+
+type requestProfile struct {
+	defaultHeaders map[string]string
+	retryAttempts  uint
+}
 
 // HttpFetcher is a simple fetcher based on http.Get.
 type HttpFetcher struct {
@@ -31,9 +39,34 @@ func (f *HttpFetcher) Fetch(ctx context.Context) ([]byte, error) {
 		return []byte(content), nil
 	}
 
+	profile := resolveRequestProfile(f.Config)
+	var body []byte
+	err := retry.Do(
+		func() error {
+			result, err := f.doRequest(ctx, profile)
+			if err != nil {
+				return err
+			}
+			body = result
+			return nil
+		},
+		retry.Attempts(profile.retryAttempts),
+		retry.Delay(300*time.Millisecond),
+		retry.DelayType(retry.FixedDelay),
+		retry.RetryIf(isRetryableFetchError),
+		retry.LastErrorOnly(true),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return body, nil
+}
+
+func (f *HttpFetcher) doRequest(ctx context.Context, profile requestProfile) ([]byte, error) {
 	method := f.Config.Method
 	if method == "" {
-		method = "GET"
+		method = http.MethodGet
 	}
 
 	var bodyReader io.Reader
@@ -46,27 +79,29 @@ func (f *HttpFetcher) Fetch(ctx context.Context) ([]byte, error) {
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
 
-	// It is good practice to set a user-agent.
-	req.Header.Set("User-Agent", "FeedCraft/2.0")
-
-	// Set custom headers from config
+	for key, value := range profile.defaultHeaders {
+		req.Header.Set(key, value)
+	}
 	for key, value := range f.Config.Headers {
 		req.Header.Set(key, value)
 	}
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("http get failed: %w", err)
+		return nil, &fetchError{err: fmt.Errorf("http get failed: %w", err), retryable: true}
 	}
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("http status not ok: %s", resp.Status)
+		return nil, &fetchError{
+			err:       fmt.Errorf("http status not ok: %s", resp.Status),
+			retryable: isRetryableStatus(resp.StatusCode),
+		}
 	}
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read response body: %w", err)
+		return nil, &fetchError{err: fmt.Errorf("failed to read response body: %w", err), retryable: true}
 	}
 
 	return body, nil
@@ -77,4 +112,58 @@ func (f *HttpFetcher) BaseURL() string {
 		return ""
 	}
 	return f.Config.URL
+}
+
+func resolveRequestProfile(cfg *config.HttpFetcherConfig) requestProfile {
+	if cfg != nil && cfg.Purpose == config.HttpFetcherPurposeHTML {
+		return requestProfile{
+			defaultHeaders: HTMLDefaultHeaders(),
+			retryAttempts:  3,
+		}
+	}
+
+	return requestProfile{
+		defaultHeaders: map[string]string{
+			"User-Agent": util.DefaultFeedUserAgent(),
+		},
+		retryAttempts: 1,
+	}
+}
+
+func HTMLDefaultHeaders() map[string]string {
+	return map[string]string{
+		"User-Agent":                util.DefaultHTMLUserAgent(),
+		"Accept":                    "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7",
+		"Accept-Language":           "en-US,en;q=0.9",
+		"Upgrade-Insecure-Requests": "1",
+		"Sec-Fetch-Dest":            "document",
+		"Sec-Fetch-Mode":            "navigate",
+		"Sec-Fetch-Site":            "none",
+		"Sec-Fetch-User":            "?1",
+	}
+}
+
+type fetchError struct {
+	err       error
+	retryable bool
+}
+
+func (e *fetchError) Error() string {
+	return e.err.Error()
+}
+
+func (e *fetchError) Unwrap() error {
+	return e.err
+}
+
+func isRetryableFetchError(err error) bool {
+	var fetchErr *fetchError
+	if !errors.As(err, &fetchErr) {
+		return false
+	}
+	return fetchErr.retryable
+}
+
+func isRetryableStatus(statusCode int) bool {
+	return statusCode == http.StatusTooManyRequests || statusCode >= http.StatusInternalServerError
 }

--- a/internal/source/fetcher/http_fetcher_test.go
+++ b/internal/source/fetcher/http_fetcher_test.go
@@ -1,0 +1,123 @@
+package fetcher
+
+import (
+	"FeedCraft/internal/config"
+	"FeedCraft/internal/util"
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestHttpFetcherUsesDefaultFeedUserAgent(t *testing.T) {
+	var gotUA string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotUA = r.Header.Get("User-Agent")
+		_, _ = io.WriteString(w, "ok")
+	}))
+	defer server.Close()
+
+	fetcher := &HttpFetcher{Config: &config.HttpFetcherConfig{URL: server.URL}}
+	_, err := fetcher.Fetch(context.Background())
+	if err != nil {
+		t.Fatalf("Fetch returned error: %v", err)
+	}
+	if gotUA != util.DefaultFeedUserAgent() {
+		t.Fatalf("expected default feed user agent, got %q", gotUA)
+	}
+}
+
+func TestHttpFetcherAllowsHeaderOverride(t *testing.T) {
+	var gotUA string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotUA = r.Header.Get("User-Agent")
+		_, _ = io.WriteString(w, "ok")
+	}))
+	defer server.Close()
+
+	fetcher := &HttpFetcher{Config: &config.HttpFetcherConfig{
+		URL: server.URL,
+		Headers: map[string]string{
+			"User-Agent": "SourceSpecific/1.2.3",
+		},
+	}}
+	_, err := fetcher.Fetch(context.Background())
+	if err != nil {
+		t.Fatalf("Fetch returned error: %v", err)
+	}
+	if gotUA != "SourceSpecific/1.2.3" {
+		t.Fatalf("expected source header override, got %q", gotUA)
+	}
+}
+
+func TestHttpFetcherHTMLPurposeUsesDefaultHTMLUserAgent(t *testing.T) {
+	var gotUA, gotAccept string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotUA = r.Header.Get("User-Agent")
+		gotAccept = r.Header.Get("Accept")
+		_, _ = io.WriteString(w, "ok")
+	}))
+	defer server.Close()
+
+	fetcher := &HttpFetcher{Config: &config.HttpFetcherConfig{
+		URL:     server.URL,
+		Purpose: config.HttpFetcherPurposeHTML,
+	}}
+	_, err := fetcher.Fetch(context.Background())
+	if err != nil {
+		t.Fatalf("Fetch returned error: %v", err)
+	}
+	if gotUA != util.DefaultHTMLUserAgent() {
+		t.Fatalf("expected html default user agent, got %q", gotUA)
+	}
+	if gotAccept == "" {
+		t.Fatal("expected html accept header to be set")
+	}
+}
+
+func TestHttpFetcherHTMLPurposeRetriesRetryableStatus(t *testing.T) {
+	attempts := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempts++
+		if attempts < 3 {
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		_, _ = io.WriteString(w, "ok")
+	}))
+	defer server.Close()
+
+	fetcher := &HttpFetcher{Config: &config.HttpFetcherConfig{
+		URL:     server.URL,
+		Purpose: config.HttpFetcherPurposeHTML,
+	}}
+	_, err := fetcher.Fetch(context.Background())
+	if err != nil {
+		t.Fatalf("Fetch returned error: %v", err)
+	}
+	if attempts != 3 {
+		t.Fatalf("expected 3 attempts, got %d", attempts)
+	}
+}
+
+func TestHttpFetcherFeedPurposeDoesNotRetryOnRetryableStatus(t *testing.T) {
+	attempts := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempts++
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	fetcher := &HttpFetcher{Config: &config.HttpFetcherConfig{
+		URL:     server.URL,
+		Purpose: config.HttpFetcherPurposeFeed,
+	}}
+	_, err := fetcher.Fetch(context.Background())
+	if err == nil {
+		t.Fatal("expected fetch to fail")
+	}
+	if attempts != 1 {
+		t.Fatalf("expected 1 attempt, got %d", attempts)
+	}
+}

--- a/internal/source/fetcher/provider/litellm.go
+++ b/internal/source/fetcher/provider/litellm.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"FeedCraft/internal/config"
+	"FeedCraft/internal/util"
 	"context"
 	"fmt"
 	"strings"
@@ -55,6 +56,8 @@ func (p *LiteLLMProvider) Fetch(ctx context.Context, query string) ([]byte, erro
 
 	req := p.Client.R().
 		SetContext(ctx).
+		// NOTE: search provider requests are temporarily grouped under feed UA rules.
+		SetHeader("User-Agent", util.DefaultFeedUserAgent()).
 		SetBody(reqBody)
 
 	if p.Config.APIKey != "" {

--- a/internal/source/fetcher/provider/litellm_test.go
+++ b/internal/source/fetcher/provider/litellm_test.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"FeedCraft/internal/config"
 	"FeedCraft/internal/source/parser"
+	"FeedCraft/internal/util"
 	"context"
 	"net/http"
 	"net/http/httptest"
@@ -12,7 +13,6 @@ import (
 )
 
 func TestLiteLLMProvider_EndToEnd(t *testing.T) {
-	// Standard API response from LiteLLM (often similar to OpenAI/Bing search results)
 	mockResponse := `{
   "results": [
     {
@@ -31,6 +31,7 @@ func TestLiteLLMProvider_EndToEnd(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, "/", r.URL.Path)
 		assert.Equal(t, "POST", r.Method)
+		assert.Equal(t, util.DefaultFeedUserAgent(), r.Header.Get("User-Agent"))
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(mockResponse))
 	}))
@@ -41,29 +42,20 @@ func TestLiteLLMProvider_EndToEnd(t *testing.T) {
 	}
 
 	provider := NewLiteLLMProvider(cfg)
-
-	// 1. Fetch the data
 	data, err := provider.Fetch(context.Background(), "test litellm query")
 	assert.NoError(t, err)
 	assert.NotNil(t, data)
 
-	// 2. Parse the data using the default parser configuration
 	parserConfig := provider.GetDefaultParserConfig()
 	jsonParser := &parser.JsonParser{Config: parserConfig}
 
 	feed, err := jsonParser.Parse(data)
 	assert.NoError(t, err)
 	assert.NotNil(t, feed)
-
-	// 3. Verify the parsed feed items
 	assert.Len(t, feed.Articles, 2)
-
-	// First item verification
 	assert.Equal(t, "LiteLLM Title 1", feed.Articles[0].Title)
 	assert.Equal(t, "https://example.com/litellm1", feed.Articles[0].Link)
 	assert.Equal(t, "This is a snippet for the first result.", feed.Articles[0].Description)
-
-	// Second item verification
 	assert.Equal(t, "LiteLLM Title 2", feed.Articles[1].Title)
 	assert.Equal(t, "https://example.com/litellm2", feed.Articles[1].Link)
 	assert.Equal(t, "Snippet for the second LiteLLM search result.", feed.Articles[1].Description)

--- a/internal/source/fetcher/provider/searxng.go
+++ b/internal/source/fetcher/provider/searxng.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"FeedCraft/internal/config"
+	"FeedCraft/internal/util"
 	"context"
 	"fmt"
 	"net/url"
@@ -53,7 +54,10 @@ func (p *SearXNGProvider) Fetch(ctx context.Context, query string) ([]byte, erro
 		p.Client = resty.New().SetTimeout(10 * time.Second)
 	}
 
-	req := p.Client.R().SetContext(ctx)
+	req := p.Client.R().
+		SetContext(ctx).
+		// NOTE: search provider requests are temporarily grouped under feed UA rules.
+		SetHeader("User-Agent", util.DefaultFeedUserAgent())
 
 	// Add Authorization header if API Key is present (useful for private instances with Basic/Bearer auth)
 	if p.Config.APIKey != "" {

--- a/internal/source/fetcher/provider/searxng_test.go
+++ b/internal/source/fetcher/provider/searxng_test.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"FeedCraft/internal/config"
 	"FeedCraft/internal/source/parser"
+	"FeedCraft/internal/util"
 	"context"
 	"net/http"
 	"net/http/httptest"
@@ -12,7 +13,6 @@ import (
 )
 
 func TestSearXNGProvider_EndToEnd(t *testing.T) {
-	// Standard API response from SearXNG
 	mockResponse := `{
   "query": "test query",
   "number_of_results": 2,
@@ -41,6 +41,7 @@ func TestSearXNGProvider_EndToEnd(t *testing.T) {
 		assert.Equal(t, "/search", r.URL.Path)
 		assert.Equal(t, "test query", r.URL.Query().Get("q"))
 		assert.Equal(t, "json", r.URL.Query().Get("format"))
+		assert.Equal(t, util.DefaultFeedUserAgent(), r.Header.Get("User-Agent"))
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(mockResponse))
 	}))
@@ -54,30 +55,21 @@ func TestSearXNGProvider_EndToEnd(t *testing.T) {
 	}
 
 	provider := NewSearXNGProvider(cfg)
-
-	// 1. Fetch the data
 	data, err := provider.Fetch(context.Background(), "test query")
 	assert.NoError(t, err)
 	assert.NotNil(t, data)
 
-	// 2. Parse the data using the default parser configuration
 	parserConfig := provider.GetDefaultParserConfig()
 	jsonParser := &parser.JsonParser{Config: parserConfig}
 
 	feed, err := jsonParser.Parse(data)
 	assert.NoError(t, err)
 	assert.NotNil(t, feed)
-
-	// 3. Verify the parsed feed items
 	assert.Len(t, feed.Articles, 2)
-
-	// First item verification
 	assert.Equal(t, "Example Domain 1", feed.Articles[0].Title)
 	assert.Equal(t, "https://example.com/1", feed.Articles[0].Link)
 	assert.Equal(t, "This domain is for use in illustrative examples.", feed.Articles[0].Description)
 	assert.False(t, feed.Articles[0].Created.IsZero())
-
-	// Second item verification (missing publishedDate)
 	assert.Equal(t, "Example Domain 2", feed.Articles[1].Title)
 	assert.Equal(t, "https://example.com/2", feed.Articles[1].Link)
 	assert.Equal(t, "More illustrative examples here.", feed.Articles[1].Description)

--- a/internal/source/html.go
+++ b/internal/source/html.go
@@ -19,6 +19,9 @@ func htmlSourceFactory(cfg *config.SourceConfig) (Source, error) {
 	if cfg.HtmlParser == nil {
 		return nil, fmt.Errorf("html_parser config is required for html source")
 	}
+	if cfg.HttpFetcher.Purpose == "" {
+		cfg.HttpFetcher.Purpose = config.HttpFetcherPurposeHTML
+	}
 
 	return &PipelineSource{
 		Config:  cfg,

--- a/internal/source/json.go
+++ b/internal/source/json.go
@@ -19,6 +19,9 @@ func jsonSourceFactory(cfg *config.SourceConfig) (Source, error) {
 	if cfg.JsonParser == nil {
 		return nil, fmt.Errorf("json_parser config is required for json source")
 	}
+	if cfg.HttpFetcher.Purpose == "" {
+		cfg.HttpFetcher.Purpose = config.HttpFetcherPurposeHTML
+	}
 
 	return &PipelineSource{
 		Config:  cfg,

--- a/internal/source/rss.go
+++ b/internal/source/rss.go
@@ -16,6 +16,9 @@ func rssSourceFactory(cfg *config.SourceConfig) (Source, error) {
 	if cfg.HttpFetcher == nil {
 		return nil, fmt.Errorf("http_fetcher config is required for rss source")
 	}
+	if cfg.HttpFetcher.Purpose == "" {
+		cfg.HttpFetcher.Purpose = config.HttpFetcherPurposeFeed
+	}
 
 	return &PipelineSource{
 		Config:  cfg, // Inject the full config

--- a/internal/source/source_factory_test.go
+++ b/internal/source/source_factory_test.go
@@ -1,0 +1,68 @@
+package source
+
+import (
+	"FeedCraft/internal/config"
+	"FeedCraft/internal/constant"
+	"testing"
+)
+
+func TestRSSSourceFactorySetsFeedPurposeByDefault(t *testing.T) {
+	cfg := &config.SourceConfig{
+		Type: constant.SourceRSS,
+		HttpFetcher: &config.HttpFetcherConfig{
+			URL: "https://example.com/feed.xml",
+		},
+	}
+
+	_, err := rssSourceFactory(cfg)
+	if err != nil {
+		t.Fatalf("rssSourceFactory returned error: %v", err)
+	}
+	if cfg.HttpFetcher.Purpose != config.HttpFetcherPurposeFeed {
+		t.Fatalf("expected purpose %q, got %q", config.HttpFetcherPurposeFeed, cfg.HttpFetcher.Purpose)
+	}
+}
+
+func TestHTMLSourceFactorySetsHTMLPurposeByDefault(t *testing.T) {
+	cfg := &config.SourceConfig{
+		Type: constant.SourceHTML,
+		HttpFetcher: &config.HttpFetcherConfig{
+			URL: "https://example.com/page",
+		},
+		HtmlParser: &config.HtmlParserConfig{
+			ItemSelector: ".item",
+			Title:        ".title",
+			Link:         ".link",
+		},
+	}
+
+	_, err := htmlSourceFactory(cfg)
+	if err != nil {
+		t.Fatalf("htmlSourceFactory returned error: %v", err)
+	}
+	if cfg.HttpFetcher.Purpose != config.HttpFetcherPurposeHTML {
+		t.Fatalf("expected purpose %q, got %q", config.HttpFetcherPurposeHTML, cfg.HttpFetcher.Purpose)
+	}
+}
+
+func TestJSONSourceFactorySetsHTMLPurposeByDefault(t *testing.T) {
+	cfg := &config.SourceConfig{
+		Type: constant.SourceJSON,
+		HttpFetcher: &config.HttpFetcherConfig{
+			URL: "https://example.com/api/items",
+		},
+		JsonParser: &config.JsonParserConfig{
+			ItemsIterator: ".items",
+			Title:         ".title",
+			Link:          ".link",
+		},
+	}
+
+	_, err := jsonSourceFactory(cfg)
+	if err != nil {
+		t.Fatalf("jsonSourceFactory returned error: %v", err)
+	}
+	if cfg.HttpFetcher.Purpose != config.HttpFetcherPurposeHTML {
+		t.Fatalf("expected purpose %q, got %q", config.HttpFetcherPurposeHTML, cfg.HttpFetcher.Purpose)
+	}
+}

--- a/internal/util/env_var.go
+++ b/internal/util/env_var.go
@@ -1,8 +1,31 @@
 package util
 
 import (
+	"strings"
+
 	"github.com/spf13/viper"
 )
+
+const (
+	defaultFeedUserAgent = "FeedCraft/2.0"
+	htmlDefaultUserAgent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/135.0.0.0 Safari/537.36"
+)
+
+func DefaultFeedUserAgent() string {
+	value := strings.TrimSpace(GetEnvClient().GetString("HTTP_USER_AGENT_FEED"))
+	if value == "" {
+		return defaultFeedUserAgent
+	}
+	return value
+}
+
+func DefaultHTMLUserAgent() string {
+	value := strings.TrimSpace(GetEnvClient().GetString("HTTP_USER_AGENT_HTML"))
+	if value == "" {
+		return htmlDefaultUserAgent
+	}
+	return value
+}
 
 func GetEnvClient() *viper.Viper {
 	v := viper.New()

--- a/internal/util/env_var_test.go
+++ b/internal/util/env_var_test.go
@@ -1,0 +1,29 @@
+package util
+
+import (
+	"testing"
+)
+
+func TestDefaultFeedUserAgent(t *testing.T) {
+	t.Setenv("FC_HTTP_USER_AGENT_FEED", "")
+	if got := DefaultFeedUserAgent(); got != defaultFeedUserAgent {
+		t.Fatalf("expected default feed user agent %q, got %q", defaultFeedUserAgent, got)
+	}
+
+	t.Setenv("FC_HTTP_USER_AGENT_FEED", "CustomFeedUA/1.0")
+	if got := DefaultFeedUserAgent(); got != "CustomFeedUA/1.0" {
+		t.Fatalf("expected custom feed user agent, got %q", got)
+	}
+}
+
+func TestDefaultHTMLUserAgent(t *testing.T) {
+	t.Setenv("FC_HTTP_USER_AGENT_HTML", "")
+	if got := DefaultHTMLUserAgent(); got != htmlDefaultUserAgent {
+		t.Fatalf("expected default html user agent %q, got %q", htmlDefaultUserAgent, got)
+	}
+
+	t.Setenv("FC_HTTP_USER_AGENT_HTML", "CustomHTMLUA/2.0")
+	if got := DefaultHTMLUserAgent(); got != "CustomHTMLUA/2.0" {
+		t.Fatalf("expected custom html user agent, got %q", got)
+	}
+}

--- a/web/admin/index.html
+++ b/web/admin/index.html
@@ -2,11 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link
-      rel="shortcut icon"
-      type="image/x-icon"
-      href="https://unpkg.byted-static.com/latest/byted/arco-config/assets/favicon.ico"
-    />
+    <link rel="shortcut icon" type="image/x-icon" href="/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>FeedCraft Admin Panel</title>
   </head>


### PR DESCRIPTION
## Summary by Sourcery

Introduce configurable default User-Agent profiles and retry behavior for HTTP fetching, and wire them through feed, HTML, and search-related flows.

New Features:
- Add environment-configurable default User-Agent strings for feed and HTML HTTP requests with separate profiles.
- Introduce HTTP fetcher request purposes (feed vs HTML) to apply appropriate headers and retry strategies.
- Add default User-Agent headers to search providers and crafted feed fetching, aligning them with feed-style requests.
- Serve a favicon from the backend and update the admin panel to reference a local favicon asset.

Enhancements:
- Refine HTTP fetching to wrap errors with retryability metadata and selectively retry HTML-purpose requests on transient failures.
- Refactor HTML fetching in the HTML-to-RSS controller to reuse shared HTML header defaults.
- Ensure source factories automatically set sensible HttpFetcher purposes for RSS, HTML, and JSON sources.
- Extend database test setup to include CraftAtom schema migration.

Documentation:
- Document new environment variables for configuring default feed and HTML User-Agent headers in English and Chinese customization guides.

Tests:
- Add unit tests covering HTTP fetcher User-Agent behavior, header overrides, purpose-specific retries, and source factory defaults.
- Add tests to verify crafted feed fetching and search providers use the correct default User-Agent.
- Add tests for environment-based User-Agent overrides for feed and HTML profiles.