### PR TITLE
feat(admin): highlight missing crafts on health dashboard

### DIFF
--- a/web/admin/package-lock.json
+++ b/web/admin/package-lock.json
@@ -17,6 +17,7 @@
         "echarts": "^5.5.1",
         "events": "^3.3.0",
         "js-md5": "^0.8.3",
+        "limax": "^4.2.2",
         "lodash": "^4.17.21",
         "mitt": "^3.0.0",
         "nprogress": "^0.2.0",
@@ -110,7 +111,6 @@
       "resolved": "https://registry.npmjs.org/@arco-design/web-vue/-/web-vue-2.57.0.tgz",
       "integrity": "sha512-R5YReC3C2sG3Jv0+YuR3B7kzkq2KdhhQNCGXD8T11xAoa0zMt6SWTP1xJQOdZcM9du+q3z6tk5mRvh4qkieRJw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@arco-design/color": "^0.4.0",
         "b-tween": "^0.3.3",
@@ -182,7 +182,6 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -1131,7 +1130,6 @@
       "integrity": "sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "5.62.0",
         "@typescript-eslint/types": "5.62.0",
@@ -1802,7 +1800,6 @@
       "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.25.tgz",
       "integrity": "sha512-Z751v203YWwYzy460bzsYQISDfPjHTl+6Zzwo/a3CsAf+0ccEjQ8c+0CdX1WsumRTHeywvyUFtW6KvNukT/smA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vue/reactivity": "3.5.25",
         "@vue/shared": "3.5.25"
@@ -1881,7 +1878,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2319,7 +2315,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.25",
         "caniuse-lite": "^1.0.30001754",
@@ -3196,7 +3191,6 @@
       "resolved": "https://registry.npmjs.org/echarts/-/echarts-5.6.0.tgz",
       "integrity": "sha512-oTbVTsXfKuEhxftHqL5xprgLoc0k7uScAwtryCgWF6hPYFLRwOUHiFmHGCBKP5NPFNkDVopOieyUqYGH8Fa3kA==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "tslib": "2.3.0",
         "zrender": "5.6.1"
@@ -3805,7 +3799,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -3990,7 +3983,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -4882,6 +4874,15 @@
         "he": "bin/he"
       }
     },
+    "node_modules/hepburn": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/hepburn/-/hepburn-1.2.2.tgz",
+      "integrity": "sha512-DeykBc4XmfAWsnN+Y1Svi9uaQnnz21Q/ARuGWvIBxP1iUFeMIWL41DfVkgTh7tU23LFIbmIBO2Bk17BTPu0kVA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/htmlparser2": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.2.tgz",
@@ -5524,7 +5525,6 @@
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -5618,7 +5618,6 @@
       "integrity": "sha512-j1n1IuTX1VQjIy3tT7cyGbX7nvQOsFLoIqobZv4ttI5axP923gA44zUj6miiA6R5Aoms4sEGVIIcucXUbRI14g==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "copy-anything": "^2.0.1",
         "parse-node-version": "^1.0.1",
@@ -5662,6 +5661,20 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/limax": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/limax/-/limax-4.2.3.tgz",
+      "integrity": "sha512-KJ41cc23/i9rGgFjpLpz4LVFuVHIVUoQX3zJs8qCY+Eo1KReIPD8QTahSErdWuO1Zt7CyjuLdo4vtsH60qau8Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "hepburn": "^1.2.2",
+        "pinyin-pro": "^3.27.0",
+        "speakingurl": "^14.0.1"
+      },
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/lines-and-columns": {
@@ -6609,6 +6622,12 @@
         }
       }
     },
+    "node_modules/pinyin-pro": {
+      "version": "3.28.1",
+      "resolved": "https://registry.npmjs.org/pinyin-pro/-/pinyin-pro-3.28.1.tgz",
+      "integrity": "sha512-oqz8ulwRgtUXRi0vbqEfGNly19zpyCxYrjhkk5TibGcgSW6eNwS5woajCXRwqURi8Ehc2yOFTiB4uNoZ+NJOnA==",
+      "license": "MIT"
+    },
     "node_modules/pirates": {
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
@@ -6662,7 +6681,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -6819,7 +6837,6 @@
       "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin-prettier.js"
       },
@@ -7129,7 +7146,6 @@
       "integrity": "sha512-fS6iqSPZDs3dr/y7Od6y5nha8dW1YnbgtsyotCVvoFGKbERG++CVRFv1meyGDE1SNItQA8BrnCw7ScdAhRJ3XQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "rollup": "dist/bin/rollup"
       },
@@ -7552,6 +7568,15 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/speakingurl": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/speakingurl/-/speakingurl-14.0.1.tgz",
+      "integrity": "sha512-1POYv7uv2gXoyGFpBCmpDVSNV74IfsWlDW216UPjbWufNf+bSU6GdbDsxdcxtfwb4xlI3yxzOTKClUosxARYrQ==",
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -8019,7 +8044,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -8212,7 +8236,6 @@
       "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -8407,7 +8430,6 @@
       "integrity": "sha512-K/jGKL/PgbIgKCiJo5QbASQhFiV02X9Jh+Qq0AKCRCRKZtOTVi4t6wh75FDpGf2N9rYOnzH87OEFQNaFy6pdxQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.15.9",
         "postcss": "^8.4.18",
@@ -8508,7 +8530,6 @@
       "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.25.tgz",
       "integrity": "sha512-YLVdgv2K13WJ6n+kD5owehKtEXwdwXuj2TTyJMsO7pSeKw2bfRNZGjhB7YzrpbMYj5b5QsUebHpOqR3R3ziy/g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vue/compiler-dom": "3.5.25",
         "@vue/compiler-sfc": "3.5.25",

--- a/web/admin/src/locale/en-US/health.ts
+++ b/web/admin/src/locale/en-US/health.ts
@@ -6,4 +6,5 @@ export default {
   'health.missing': 'Missing',
   'health.noData': 'No analysis data. Click Analyze to start.',
   'health.fetchError': 'Failed to fetch dependency health data',
+  'health.missingCrafts': 'Missing Crafts',
 };

--- a/web/admin/src/locale/zh-CN/health.ts
+++ b/web/admin/src/locale/zh-CN/health.ts
@@ -6,4 +6,5 @@ export default {
   'health.missing': '缺失',
   'health.noData': '暂无分析数据，请点击分析按钮开始。',
   'health.fetchError': '获取依赖健康状态失败',
+  'health.missingCrafts': '缺失的 Crafts',
 };

--- a/web/admin/src/views/dashboard/health/index.vue
+++ b/web/admin/src/views/dashboard/health/index.vue
@@ -24,7 +24,7 @@
             </a-alert>
             <a-card
               class="mb-4 border-red-200"
-              style="background-color: var(--color-danger-light-1);"
+              style="background-color: var(--color-danger-light-1)"
             >
               <template #title>
                 <span class="font-medium" style="color: rgb(var(--danger-6))">{{

--- a/web/admin/src/views/dashboard/health/index.vue
+++ b/web/admin/src/views/dashboard/health/index.vue
@@ -7,25 +7,49 @@
     </x-header>
 
     <a-card class="general-card" :title="t('menu.systemHealth')">
-      <a-row style="margin-bottom: 16px">
-        <a-col :span="24">
-          <a-space>
-            <a-button type="primary" :loading="loading" @click="fetchData">
-              {{ t('health.analyze') }}
-            </a-button>
-          </a-space>
-        </a-col>
-      </a-row>
+      <template #extra>
+        <a-button type="primary" :loading="loading" @click="fetchData">
+          <template #icon>
+            <icon-refresh />
+          </template>
+          {{ t('health.analyze') }}
+        </a-button>
+      </template>
 
       <a-spin :loading="loading" style="width: 100%">
         <div v-if="treeData.length > 0">
-          <a-alert
-            v-if="missingCount > 0"
-            type="error"
-            style="margin-bottom: 16px"
-          >
-            {{ t('health.issuesFound', { count: missingCount }) }}
-          </a-alert>
+          <div v-if="missingCount > 0" class="mb-4">
+            <a-alert type="error" style="margin-bottom: 16px">
+              {{ t('health.issuesFound', { count: missingCount }) }}
+            </a-alert>
+            <a-card
+              class="mb-4 border-red-200"
+              style="background-color: var(--color-danger-light-1);"
+            >
+              <template #title>
+                <span class="font-medium" style="color: rgb(var(--danger-6))">{{
+                  t('health.missingCrafts')
+                }}</span>
+              </template>
+              <div class="flex flex-wrap gap-2">
+                <a-tag
+                  v-for="node in missingNodes"
+                  :key="node.key"
+                  color="red"
+                  size="large"
+                  class="font-medium px-3 py-1"
+                >
+                  <template #icon>
+                    <icon-exclamation-circle-fill />
+                  </template>
+                  {{ node.name }}
+                  <span v-if="node.details" class="ml-2 text-xs opacity-80"
+                    >({{ node.details }})</span
+                  >
+                </a-tag>
+              </div>
+            </a-card>
+          </div>
           <a-alert v-else type="success" style="margin-bottom: 16px">
             {{ t('health.allHealthy') }}
           </a-alert>
@@ -38,19 +62,32 @@
           >
             <template #title="node">
               <a-space>
-                <span style="font-weight: bold">{{ node.name }}</span>
+                <span
+                  :class="{
+                    'font-bold': true,
+                    'text-red-500': !node.exists || node.type === 'missing',
+                  }"
+                  >{{ node.name }}</span
+                >
                 <a-tag
                   v-if="node.type"
                   :color="getTypeColor(node.type)"
                   size="small"
                   >{{ node.type }}</a-tag
                 >
-                <a-tag v-if="!node.exists" color="red" size="small">{{
-                  t('health.missing')
-                }}</a-tag>
+                <a-tag
+                  v-if="!node.exists || node.type === 'missing'"
+                  color="red"
+                  size="small"
+                  >{{ t('health.missing') }}</a-tag
+                >
                 <span
                   v-if="node.details"
-                  style="color: #86909c; font-size: 12px"
+                  :class="{
+                    'text-xs': true,
+                    'text-gray-400': node.exists && node.type !== 'missing',
+                    'text-red-400': !node.exists || node.type === 'missing',
+                  }"
                   >{{ node.details }}</span
                 >
               </a-space>
@@ -69,11 +106,16 @@
   import { Message } from '@arco-design/web-vue';
   import { fetchDependencyHealth, DependencyNode } from '@/api/health';
   import XHeader from '@/components/header/x-header.vue';
+  import {
+    IconRefresh,
+    IconExclamationCircleFill,
+  } from '@arco-design/web-vue/es/icon';
 
   const { t } = useI18n();
   const loading = ref(false);
   const treeData = ref<DependencyNode[]>([]);
   const missingCount = ref(0);
+  const missingNodes = ref<DependencyNode[]>([]);
 
   const getTypeColor = (type: string) => {
     switch (type) {
@@ -94,6 +136,23 @@
     }
   };
 
+  const collectMissingNodes = (
+    nodes: DependencyNode[],
+    missingList: DependencyNode[]
+  ) => {
+    nodes.forEach((node) => {
+      if (!node.exists || node.type === 'missing') {
+        // Prevent duplicates
+        if (!missingList.some((n) => n.name === node.name)) {
+          missingList.push(node);
+        }
+      }
+      if (node.children) {
+        collectMissingNodes(node.children, missingList);
+      }
+    });
+  };
+
   const countMissing = (nodes: DependencyNode[]) => {
     let count = 0;
     nodes.forEach((node) => {
@@ -112,9 +171,14 @@
       const data = res.data ?? [];
       treeData.value = data;
       missingCount.value = countMissing(data);
+
+      const missingList: DependencyNode[] = [];
+      collectMissingNodes(data, missingList);
+      missingNodes.value = missingList;
     } catch (err: any) {
       treeData.value = [];
       missingCount.value = 0;
+      missingNodes.value = [];
       Message.error(err.message || t('health.fetchError'));
     } finally {
       loading.value = false;


### PR DESCRIPTION
Extract missing nodes and prominently display them at the top of the Dependency Check page using a styled warning card with red tags, improving UX/UI visibility of missing crafts. Additionally, updates missing craft labels within the main dependency tree to be styled with a bold, red font weight to highlight errors inline. Also moved the analyze button to the upper right card actions slot for better layout hierarchy and added i18n support in EN/ZH-CN.

---
*PR created automatically by Jules for task [9687030616519962460](https://jules.google.com/task/9687030616519962460) started by @Colin-XKL*

## Summary by Sourcery

Highlight missing crafts in the health dashboard and surface them more prominently for admins.

New Features:
- Display a dedicated warning card listing missing crafts at the top of the dependency health view with prominent styling.
- Add inline highlighting for missing or non-existent dependency nodes within the dependency tree.

Enhancements:
- Move the Analyze action button into the card header actions area and add an icon for clearer hierarchy and affordance.