### PR TITLE
fix(parser): prevent large numerical IDs from formatting into scientific notation

### DIFF
--- a/internal/controller/curl_to_rss.go
+++ b/internal/controller/curl_to_rss.go
@@ -175,7 +175,9 @@ func CurlParse(c *gin.Context) {
 	}
 
 	var input interface{}
-	if err := json.Unmarshal([]byte(req.JsonContent), &input); err != nil {
+	decoder := json.NewDecoder(strings.NewReader(req.JsonContent))
+	decoder.UseNumber()
+	if err := decoder.Decode(&input); err != nil {
 		c.JSON(http.StatusBadRequest, util.APIResponse[any]{StatusCode: -1, Msg: "Invalid JSON content: " + err.Error()})
 		return
 	}

--- a/internal/source/parser/json_parser.go
+++ b/internal/source/parser/json_parser.go
@@ -3,6 +3,7 @@ package parser
 import (
 	"FeedCraft/internal/config"
 	"FeedCraft/internal/model"
+	"bytes"
 	"encoding/json"
 	"fmt"
 )
@@ -17,7 +18,9 @@ func (p *JsonParser) Parse(data []byte) (*model.CraftFeed, error) {
 	}
 
 	var rawData interface{}
-	if err := json.Unmarshal(data, &rawData); err != nil {
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.UseNumber()
+	if err := decoder.Decode(&rawData); err != nil {
 		return nil, fmt.Errorf("invalid json data: %w", err)
 	}
 

--- a/internal/source/parser/json_parser_test.go
+++ b/internal/source/parser/json_parser_test.go
@@ -111,6 +111,31 @@ func TestJsonParser_Parse_WithItemTemplateOnly(t *testing.T) {
 	}
 }
 
+func TestJsonParser_Parse_LargeNumberID(t *testing.T) {
+	jsonContent := `{
+	  "items": [
+	    {
+	      "id": 2658732,
+	      "title": "Entry"
+	    }
+	  ]
+	}`
+
+	cfg := &config.JsonParserConfig{
+		ItemsIterator: ".items[]",
+		Title:         ".title",
+		LinkTemplate:  "https://example.com/article/{{ .Item.id }}",
+	}
+
+	parser := &JsonParser{Config: cfg}
+	feed, err := parser.Parse([]byte(jsonContent))
+
+	assert.NoError(t, err)
+	if assert.NotNil(t, feed) && assert.Len(t, feed.Articles, 1) {
+		assert.Equal(t, "https://example.com/article/2658732", feed.Articles[0].Link)
+	}
+}
+
 func TestJsonParser_Parse_Error(t *testing.T) {
 	// Test case where field selector causes a runtime error in jq
 	// e.g. trying to iterate a string


### PR DESCRIPTION
Fix large numeric IDs being formatted to scientific notation when evaluating link templates.

---
*PR created automatically by Jules for task [12047220006203345272](https://jules.google.com/task/12047220006203345272) started by @Colin-XKL*

## Summary by Sourcery

Ensure JSON parsing preserves large numeric IDs when building article links from templates.

Bug Fixes:
- Prevent large numeric item IDs from being converted to scientific notation during JSON parsing for link template evaluation.

Enhancements:
- Switch JSON parsing in both the curl controller and JSON parser to use json.Decoder with UseNumber to retain exact numeric representations.

Tests:
- Add a JSON parser test verifying that large numeric IDs are rendered verbatim in generated article links.