### PR TITLE
docs: add detailed template guide to curl-to-rss docs

### DIFF
--- a/doc-site/src/content/docs/en/guides/advanced/curl-to-rss.md
+++ b/doc-site/src/content/docs/en/guides/advanced/curl-to-rss.md
@@ -55,15 +55,18 @@ The tool uses **[jq](https://jqlang.github.io/jq/)** syntax for querying JSON, a
 You can use [Go Templates](https://pkg.go.dev/text/template) to further process extracted values.
 
 **Available Variables:**
+
 - `.Fields`: The parsed field values (e.g., `.Fields.Title`, `.Fields.Link`, `.Fields.Date`, `.Fields.Description`).
 - `.Item`: The raw JSON item object (e.g., `.Item.id`, `.Item.author.name`).
 
 **Built-in Functions:**
+
 - `trimSpace`: Removes leading and trailing whitespace.
 - `trim`: Removes specified leading and trailing characters.
 - `default`: Provides a fallback value if the field is empty.
 
 **Examples:**
+
 - **Clean up whitespace in title**: `{{ .Fields.Title | trimSpace }}`
 - **Build absolute URLs**: `https://example.com/article/{{ .Item.id }}`
 - **Remove specific prefixes**: `{{ .Fields.Description | trim "Prefix: " }}`

--- a/doc-site/src/content/docs/en/guides/advanced/curl-to-rss.md
+++ b/doc-site/src/content/docs/en/guides/advanced/curl-to-rss.md
@@ -50,6 +50,25 @@ The tool uses **[jq](https://jqlang.github.io/jq/)** syntax for querying JSON, a
 - **Date Selector**: (Optional) Path to the publication date.
 - **Content Selector**: (Optional) Path to the full content or summary.
 
+#### Using Templates (Optional)
+
+You can use [Go Templates](https://pkg.go.dev/text/template) to further process extracted values.
+
+**Available Variables:**
+- `.Fields`: The parsed field values (e.g., `.Fields.Title`, `.Fields.Link`, `.Fields.Date`, `.Fields.Description`).
+- `.Item`: The raw JSON item object (e.g., `.Item.id`, `.Item.author.name`).
+
+**Built-in Functions:**
+- `trimSpace`: Removes leading and trailing whitespace.
+- `trim`: Removes specified leading and trailing characters.
+- `default`: Provides a fallback value if the field is empty.
+
+**Examples:**
+- **Clean up whitespace in title**: `{{ .Fields.Title | trimSpace }}`
+- **Build absolute URLs**: `https://example.com/article/{{ .Item.id }}`
+- **Remove specific prefixes**: `{{ .Fields.Description | trim "Prefix: " }}`
+- **Fallback values**: `{{ default .Fields.Description "No summary available" }}`
+
 Click **Run Preview** to verify your selectors, then click **Next Step**.
 
 ### Step 3: Feed Metadata

--- a/doc-site/src/content/docs/zh-tw/guides/advanced/curl-to-rss.md
+++ b/doc-site/src/content/docs/zh-tw/guides/advanced/curl-to-rss.md
@@ -50,6 +50,25 @@ JSON RSS 生成器可以幫助你：
 - **日期選取器 (Date Selector)**：（可選）發布日期的路徑。
 - **內容選取器 (Content Selector)**：（可選）完整內容或摘要的路徑。
 
+#### 使用模板 (可選)
+
+你可以使用 [Go Templates](https://pkg.go.dev/text/template) 語法對提取的值進行進一步處理。
+
+**可用變數：**
+- `.Fields`：已解析的欄位值（例如 `.Fields.Title`, `.Fields.Link`, `.Fields.Date`, `.Fields.Description`）。
+- `.Item`：原始 JSON 列表項物件（例如 `.Item.id`, `.Item.author.name`）。
+
+**內建函數：**
+- `trimSpace`：移除首尾的空白字元。
+- `trim`：移除首尾指定的字元。
+- `default`：如果欄位為空，提供一個預設值。
+
+**範例：**
+- **清理標題空白字元**：`{{ .Fields.Title | trimSpace }}`
+- **拼接完整連結**：`https://example.com/article/{{ .Item.id }}`
+- **移除特定前缀**：`{{ .Fields.Description | trim "Prefix: " }}`
+- **預設值兜底**：`{{ default .Fields.Description "暫無摘要" }}`
+
 點擊 **執行預覽 (Run Preview)** 驗證你的選取器，然後點擊 **下一步 (Next Step)**。
 
 ### 第三步：訂閱源元數據 (Feed Metadata)

--- a/doc-site/src/content/docs/zh-tw/guides/advanced/curl-to-rss.md
+++ b/doc-site/src/content/docs/zh-tw/guides/advanced/curl-to-rss.md
@@ -55,15 +55,18 @@ JSON RSS 生成器可以幫助你：
 你可以使用 [Go Templates](https://pkg.go.dev/text/template) 語法對提取的值進行進一步處理。
 
 **可用變數：**
+
 - `.Fields`：已解析的欄位值（例如 `.Fields.Title`, `.Fields.Link`, `.Fields.Date`, `.Fields.Description`）。
 - `.Item`：原始 JSON 列表項物件（例如 `.Item.id`, `.Item.author.name`）。
 
 **內建函數：**
+
 - `trimSpace`：移除首尾的空白字元。
 - `trim`：移除首尾指定的字元。
 - `default`：如果欄位為空，提供一個預設值。
 
 **範例：**
+
 - **清理標題空白字元**：`{{ .Fields.Title | trimSpace }}`
 - **拼接完整連結**：`https://example.com/article/{{ .Item.id }}`
 - **移除特定前缀**：`{{ .Fields.Description | trim "Prefix: " }}`

--- a/doc-site/src/content/docs/zh/guides/advanced/curl-to-rss.md
+++ b/doc-site/src/content/docs/zh/guides/advanced/curl-to-rss.md
@@ -50,6 +50,25 @@ JSON RSS 生成器可以帮助你：
 - **日期选择器 (Date Selector)**：（可选）发布日期的路径。
 - **内容选择器 (Content Selector)**：（可选）完整内容或摘要的路径。
 
+#### 使用模板 (可选)
+
+你可以使用 [Go Templates](https://pkg.go.dev/text/template) 语法对提取的值进行进一步处理。
+
+**可用变量：**
+- `.Fields`：已解析的字段值（例如 `.Fields.Title`, `.Fields.Link`, `.Fields.Date`, `.Fields.Description`）。
+- `.Item`：原始 JSON 列表项对象（例如 `.Item.id`, `.Item.author.name`）。
+
+**内置函数：**
+- `trimSpace`：移除首尾的空白字符。
+- `trim`：移除首尾指定的字符。
+- `default`：如果字段为空，提供一个默认值。
+
+**示例：**
+- **清理标题空白字符**：`{{ .Fields.Title | trimSpace }}`
+- **拼接完整链接**：`https://example.com/article/{{ .Item.id }}`
+- **移除特定前缀**：`{{ .Fields.Description | trim "Prefix: " }}`
+- **默认值兜底**：`{{ default .Fields.Description "暂无摘要" }}`
+
 点击 **运行预览 (Run Preview)** 验证你的选择器，然后点击 **下一步 (Next Step)**。
 
 ### 第三步：订阅源元数据 (Feed Metadata)

--- a/doc-site/src/content/docs/zh/guides/advanced/curl-to-rss.md
+++ b/doc-site/src/content/docs/zh/guides/advanced/curl-to-rss.md
@@ -55,15 +55,18 @@ JSON RSS 生成器可以帮助你：
 你可以使用 [Go Templates](https://pkg.go.dev/text/template) 语法对提取的值进行进一步处理。
 
 **可用变量：**
+
 - `.Fields`：已解析的字段值（例如 `.Fields.Title`, `.Fields.Link`, `.Fields.Date`, `.Fields.Description`）。
 - `.Item`：原始 JSON 列表项对象（例如 `.Item.id`, `.Item.author.name`）。
 
 **内置函数：**
+
 - `trimSpace`：移除首尾的空白字符。
 - `trim`：移除首尾指定的字符。
 - `default`：如果字段为空，提供一个默认值。
 
 **示例：**
+
 - **清理标题空白字符**：`{{ .Fields.Title | trimSpace }}`
 - **拼接完整链接**：`https://example.com/article/{{ .Item.id }}`
 - **移除特定前缀**：`{{ .Fields.Description | trim "Prefix: " }}`


### PR DESCRIPTION
This PR adds a dedicated "Using Templates (Optional)" section to the `curl-to-rss.md` documentation guides in English, Simplified Chinese, and Traditional Chinese.

It aims to make the template functionality clearer and more actionable for users by explaining:
*   The Go Templates syntax.
*   The available variables (`.Fields`, `.Item`).
*   The built-in functions provided by the parser (`trimSpace`, `trim`, `default`).
*   Common, practical examples (building absolute URLs, stripping prefixes, and setting defaults).

---
*PR created automatically by Jules for task [9657083057889188699](https://jules.google.com/task/9657083057889188699) started by @Colin-XKL*

## Summary by Sourcery

Document template support in the curl-to-rss advanced guide across all supported languages.

Documentation:
- Add a "Using Templates" section to the English curl-to-rss guide explaining available variables, built-in functions, and usage examples for Go Templates.
- Localize the new template usage documentation into Traditional Chinese in the zh-tw curl-to-rss guide.
- Localize the new template usage documentation into Simplified Chinese in the zh curl-to-rss guide.