### PR TITLE
fix: improve browserless error handling and feed viewer presentation

### DIFF
--- a/internal/controller/feed_viewer.go
+++ b/internal/controller/feed_viewer.go
@@ -216,8 +216,13 @@ func validateFeedViewerURL(rawURL string) error {
 
 func classifyFeedViewerError(err error) (int, string) {
 	msg := err.Error()
+	if strings.HasPrefix(msg, "all items failed to process. last error: ") {
+		msg = strings.TrimPrefix(msg, "all items failed to process. last error: ")
+	}
 
 	switch {
+	case strings.Contains(msg, "browserless service returned status"):
+		return http.StatusOK, humanizeBrowserlessStatus(msg)
 	case strings.Contains(msg, "http status not ok:"):
 		return http.StatusOK, humanizeFeedViewerHTTPStatus(msg)
 	case strings.Contains(msg, "http get failed:"), strings.Contains(msg, "browserless fetch failed:"), strings.Contains(msg, "failed to read response body:"), strings.Contains(msg, "Unable to resolve this URL"):
@@ -229,6 +234,14 @@ func classifyFeedViewerError(err error) (int, string) {
 	default:
 		return http.StatusInternalServerError, "Failed to preview this feed due to an internal error."
 	}
+}
+
+func humanizeBrowserlessStatus(msg string) string {
+	status := strings.TrimSpace(strings.TrimPrefix(msg, "browserless service returned status"))
+	if status == "" {
+		return "Browserless service failed to render the URL."
+	}
+	return fmt.Sprintf("Browserless service failed to render the URL (returned status %s). Please check the address or the browserless service.", status)
 }
 
 func humanizeFeedViewerHTTPStatus(msg string) string {

--- a/internal/controller/feed_viewer.go
+++ b/internal/controller/feed_viewer.go
@@ -216,9 +216,7 @@ func validateFeedViewerURL(rawURL string) error {
 
 func classifyFeedViewerError(err error) (int, string) {
 	msg := err.Error()
-	if strings.HasPrefix(msg, "all items failed to process. last error: ") {
-		msg = strings.TrimPrefix(msg, "all items failed to process. last error: ")
-	}
+	msg = strings.TrimPrefix(msg, "all items failed to process. last error: ")
 
 	switch {
 	case strings.Contains(msg, "browserless service returned status"):

--- a/internal/util/browserless.go
+++ b/internal/util/browserless.go
@@ -78,7 +78,14 @@ func GetBrowserlessContent(websiteUrl string, options BrowserlessOptions) (strin
 	}
 
 	if response.StatusCode() != http.StatusOK {
-		return "", fmt.Errorf("browserless service returned status %d: %s", response.StatusCode(), response.String())
+		respStr := response.String()
+		logrus.Errorf("browserless service returned status %d. URL: %s, response body: %s", response.StatusCode(), websiteUrl, respStr)
+
+		truncLen := 200
+		if len(respStr) > truncLen {
+			respStr = respStr[:truncLen] + "..."
+		}
+		return "", fmt.Errorf("browserless service returned status %d: %s", response.StatusCode(), respStr)
 	}
 
 	return response.String(), nil


### PR DESCRIPTION
This PR addresses an issue where `fulltext-plus` failures resulted in vague "500 Internal Server Error" responses without sufficient debugging logs.

Changes include:
- `internal/util/browserless.go`: `GetBrowserlessContent` now explicitly logs the full response body using `logrus` and truncates the string passed to `fmt.Errorf` to ensure it remains manageable.
- `internal/controller/feed_viewer.go`: `classifyFeedViewerError` was updated to unwrap the `"all items failed to process. last error: "` wrapper. It now properly maps the browserless status error string to a new `humanizeBrowserlessStatus` helper, returning an HTTP 200 OK with the formatted error message inside the generated RSS error item, matching the behavior of HTTP fetch failures.

---
*PR created automatically by Jules for task [17075266474162865405](https://jules.google.com/task/17075266474162865405) started by @Colin-XKL*

## Summary by Sourcery

Improve browserless error handling and feed viewer error presentation for failed full-text rendering requests.

Bug Fixes:
- Ensure feed viewer correctly unwraps aggregated processing errors so underlying browserless failures are surfaced to clients.
- Handle non-200 responses from the browserless service with clearer, human-readable messages instead of generic 500 errors.

Enhancements:
- Log full browserless response bodies on non-OK status codes while truncating error messages to keep them manageable.
- Map browserless status errors to descriptive HTTP 200 feed responses consistent with other fetch failure handling.