### PR TITLE
Fix humanizeBrowserlessStatus to handle wrapped error messages

### DIFF
--- a/internal/controller/feed_viewer.go
+++ b/internal/controller/feed_viewer.go
@@ -235,7 +235,12 @@ func classifyFeedViewerError(err error) (int, string) {
 }
 
 func humanizeBrowserlessStatus(msg string) string {
-	status := strings.TrimSpace(strings.TrimPrefix(msg, "browserless service returned status"))
+	prefix := "browserless service returned status"
+	idx := strings.Index(msg, prefix)
+	status := ""
+	if idx != -1 {
+		status = strings.TrimSpace(msg[idx+len(prefix):])
+	}
 	if status == "" {
 		return "Browserless service failed to render the URL."
 	}


### PR DESCRIPTION
The current implementation of `humanizeBrowserlessStatus` uses `strings.TrimPrefix`, which only works if the error message starts exactly with the specified prefix. However, error messages are often wrapped (e.g., with "browserless fetch failed: ..." in `http_fetcher.go`), which would cause `TrimPrefix` to do nothing. This resulted in redundant and messy humanized messages like "... (returned status browserless fetch failed: browserless service returned status 500: ...)".

This fix changes the implementation to use `strings.Index` to find the status information within the message. It correctly extracts the status regardless of any wrapping prefixes, creating a more robust extraction.

---
*PR created automatically by Jules for task [7276889589446579442](https://jules.google.com/task/7276889589446579442) started by @Colin-XKL*

## Summary by Sourcery

Bug Fixes:
- Fix browserless status extraction so wrapped error messages still yield a clean, human-readable message instead of including redundant prefixes.