### PR TITLE
feat: add io.LimitReader to prevent OOM in HTTP fetcher

### DIFF
--- a/internal/source/fetcher/http_fetcher.go
+++ b/internal/source/fetcher/http_fetcher.go
@@ -101,9 +101,12 @@ func (f *HttpFetcher) doRequest(ctx context.Context, profile requestProfile) ([]
 		}
 	}
 
-	body, err := io.ReadAll(io.LimitReader(resp.Body, MaxResponseBodySize))
+	body, err := io.ReadAll(io.LimitReader(resp.Body, MaxResponseBodySize+1))
 	if err != nil {
 		return nil, &fetchError{err: fmt.Errorf("failed to read response body: %w", err), retryable: true}
+	}
+	if len(body) > MaxResponseBodySize {
+		return nil, &fetchError{err: fmt.Errorf("response body exceeds the maximum size limit of %d bytes", MaxResponseBodySize), retryable: false}
 	}
 
 	return body, nil

--- a/internal/source/fetcher/http_fetcher.go
+++ b/internal/source/fetcher/http_fetcher.go
@@ -14,6 +14,8 @@ import (
 	retry "github.com/avast/retry-go/v4"
 )
 
+const MaxResponseBodySize = 10 * 1024 * 1024 // 10MB
+
 type requestProfile struct {
 	defaultHeaders map[string]string
 	retryAttempts  uint
@@ -99,7 +101,7 @@ func (f *HttpFetcher) doRequest(ctx context.Context, profile requestProfile) ([]
 		}
 	}
 
-	body, err := io.ReadAll(resp.Body)
+	body, err := io.ReadAll(io.LimitReader(resp.Body, MaxResponseBodySize))
 	if err != nil {
 		return nil, &fetchError{err: fmt.Errorf("failed to read response body: %w", err), retryable: true}
 	}


### PR DESCRIPTION
Limits the maximum amount of data read into memory during an HTTP fetch
to a fixed size of 10MB to mitigate Out-Of-Memory (OOM) risks from
unbounded or maliciously large response bodies.

---
*PR created automatically by Jules for task [8174899968658621879](https://jules.google.com/task/8174899968658621879) started by @Colin-XKL*

## Summary by Sourcery

Bug Fixes:
- Prevent potential out-of-memory errors by capping the in-memory HTTP response body size at 10MB.