### PR TITLE
test: use truly large number in json parser test

### DIFF
--- a/internal/source/parser/json_parser_test.go
+++ b/internal/source/parser/json_parser_test.go
@@ -115,7 +115,7 @@ func TestJsonParser_Parse_LargeNumberID(t *testing.T) {
 	jsonContent := `{
 	  "items": [
 	    {
-	      "id": 2658732,
+	      "id": 12345678901234567890,
 	      "title": "Entry"
 	    }
 	  ]
@@ -132,7 +132,7 @@ func TestJsonParser_Parse_LargeNumberID(t *testing.T) {
 
 	assert.NoError(t, err)
 	if assert.NotNil(t, feed) && assert.Len(t, feed.Articles, 1) {
-		assert.Equal(t, "https://example.com/article/2658732", feed.Articles[0].Link)
+		assert.Equal(t, "https://example.com/article/12345678901234567890", feed.Articles[0].Link)
 	}
 }
 


### PR DESCRIPTION
This commit updates the `TestJsonParser_Parse_LargeNumberID` test to use a truly large numeric ID (`12345678901234567890`) that exceeds `float64` precision (2^53 - 1). This ensures the test properly exercises the scientific-notation / precision bug fix implemented via `decoder.UseNumber()`.

---
*PR created automatically by Jules for task [18005921651672273223](https://jules.google.com/task/18005921651672273223) started by @Colin-XKL*

## Summary by Sourcery

Tests:
- Adjust the large-number JSON parsing test to use a significantly larger numeric ID and verify the resulting article link reflects the full-precision value.