### PR TITLE
Fix potential indefinite hangs in feed fetching and retries

### DIFF
--- a/internal/craft/option.go
+++ b/internal/craft/option.go
@@ -12,6 +12,7 @@ import (
 	"github.com/samber/lo/parallel"
 	"github.com/sirupsen/logrus"
 	"strings"
+	"time"
 )
 
 type CraftedFeed struct {
@@ -29,10 +30,13 @@ type CraftOption func(*feeds.Feed, ExtraPayload) error
 func NewCraftedFeedFromUrl(feedUrl string, options ...CraftOption) (CraftedFeed, error) {
 	ingredient := CraftedFeed{originalFeedUrl: feedUrl}
 
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
 	raw, err := (&fetcher.HttpFetcher{Config: &config.HttpFetcherConfig{
 		URL:     feedUrl,
 		Purpose: config.HttpFetcherPurposeFeed,
-	}}).Fetch(context.Background())
+	}}).Fetch(ctx)
 	if err != nil {
 		return ingredient, err
 	}

--- a/internal/source/fetcher/http_fetcher.go
+++ b/internal/source/fetcher/http_fetcher.go
@@ -50,6 +50,7 @@ func (f *HttpFetcher) Fetch(ctx context.Context) ([]byte, error) {
 			body = result
 			return nil
 		},
+		retry.Context(ctx),
 		retry.Attempts(profile.retryAttempts),
 		retry.Delay(300*time.Millisecond),
 		retry.DelayType(retry.FixedDelay),


### PR DESCRIPTION
Adds a 30-second context timeout to `HttpFetcher` to prevent potential indefinite hangs caused by slow or unresponsive target URLs, and ensures the `retry.Do` loop correctly respects context cancellations.

---
*PR created automatically by Jules for task [11514031547719464378](https://jules.google.com/task/11514031547719464378) started by @Colin-XKL*

## Summary by Sourcery

Add a timeout-bound context to feed fetching and ensure HTTP fetch retries honor caller cancellation.

Bug Fixes:
- Prevent potential indefinite hangs when fetching feeds by bounding the HTTP fetch operation with a 30-second context timeout.
- Ensure the HTTP fetch retry loop stops when the caller’s context is canceled instead of continuing indefinitely.