### PR TITLE
fix: correctly handle logout action and provide feedback

### DIFF
--- a/web/admin/src/api/user.ts
+++ b/web/admin/src/api/user.ts
@@ -24,9 +24,7 @@ export function login(data: LoginData): Promise<APIResponse<LoginRes>> {
 }
 
 export function logout(): Promise<APIResponse<LoginRes>> {
-  return axios
-    .post<APIResponse<LoginRes>>('/api/user/logout')
-    .then((res) => res.data);
+  return Promise.resolve({ data: { token: '' } } as any);
 }
 
 export function getUserInfo(): Promise<APIResponse<UserState>> {

--- a/web/admin/src/components/message-box/locale/en-US.ts
+++ b/web/admin/src/components/message-box/locale/en-US.ts
@@ -10,4 +10,5 @@ export default {
   'messageBox.userCenter': 'User Center',
   'messageBox.userSettings': 'User Settings',
   'messageBox.logout': 'Logout',
+  'messageBox.logoutSuccess': 'Logout Successful',
 };

--- a/web/admin/src/components/message-box/locale/zh-CN.ts
+++ b/web/admin/src/components/message-box/locale/zh-CN.ts
@@ -10,4 +10,5 @@ export default {
   'messageBox.userCenter': '用户中心',
   'messageBox.userSettings': '用户设置',
   'messageBox.logout': '退出登录',
+  'messageBox.logoutSuccess': '登出成功',
 };

--- a/web/admin/src/components/navbar/index.vue
+++ b/web/admin/src/components/navbar/index.vue
@@ -154,6 +154,15 @@
   import useUser from '@/hooks/user';
   import Menu from '@/components/menu/index.vue';
   import logo from '@/assets/logo.png';
+  // const setPopoverVisible = () => {
+  //   const event = new MouseEvent('click', {
+  //     view: window,
+  //     bubbles: true,
+  //     cancelable: true,
+  //   });
+  //   refBtn.value.dispatchEvent(event);
+  // };
+  import { useI18n } from 'vue-i18n';
   // import user from '@/store/modules/user';
 
   const appStore = useAppStore();
@@ -191,15 +200,6 @@
   // };
   // const refBtn = ref();
   const triggerBtn = ref();
-  // const setPopoverVisible = () => {
-  //   const event = new MouseEvent('click', {
-  //     view: window,
-  //     bubbles: true,
-  //     cancelable: true,
-  //   });
-  //   refBtn.value.dispatchEvent(event);
-  // };
-  import { useI18n } from 'vue-i18n';
 
   const { t } = useI18n();
 

--- a/web/admin/src/components/navbar/index.vue
+++ b/web/admin/src/components/navbar/index.vue
@@ -81,6 +81,21 @@
       </li>
 
       <li>
+        <a-tooltip :content="$t('messageBox.logout')">
+          <a-button
+            class="nav-btn"
+            type="outline"
+            :shape="'circle'"
+            @click="handleLogout"
+          >
+            <template #icon>
+              <icon-export />
+            </template>
+          </a-button>
+        </a-tooltip>
+      </li>
+
+      <li>
         <a-dropdown trigger="click">
           <a-avatar
             :size="32"
@@ -184,8 +199,12 @@
   //   });
   //   refBtn.value.dispatchEvent(event);
   // };
+  import { useI18n } from 'vue-i18n';
+
+  const { t } = useI18n();
+
   const handleLogout = () => {
-    logout();
+    logout(undefined, t('messageBox.logoutSuccess'));
   };
   const setDropDownVisible = () => {
     const event = new MouseEvent('click', {

--- a/web/admin/src/hooks/user.ts
+++ b/web/admin/src/hooks/user.ts
@@ -6,10 +6,10 @@ import { useUserStore } from '@/store';
 export default function useUser() {
   const router = useRouter();
   const userStore = useUserStore();
-  const logout = async (logoutTo?: string) => {
+  const logout = async (logoutTo?: string, msg?: string) => {
     await userStore.logout();
     const currentRoute = router.currentRoute.value;
-    Message.success('登出成功');
+    Message.success(msg || '登出成功');
     router.push({
       name: logoutTo && typeof logoutTo === 'string' ? logoutTo : 'login',
       query: {


### PR DESCRIPTION
- The logout function failed silently because the frontend attempted to call a non-existent `/api/user/logout` endpoint in the backend. Since the backend uses stateless JWT, the logout is purely a client-side action (clearing the token). I mocked the API promise resolution.
- The user feedback is improved by ensuring the `Message.success` toast displays when logging out successfully, using proper i18n variables.
- The UX issue "Logout button is not easily discoverable" is resolved by placing a dedicated Logout `<icon-export />` button directly in the main top-right navbar tools.

---
*PR created automatically by Jules for task [7287679719412846665](https://jules.google.com/task/7287679719412846665) started by @Colin-XKL*

## Summary by Sourcery

Handle logout purely on the client while improving logout visibility and feedback in the admin UI.

New Features:
- Add a dedicated logout icon button to the top-right navbar for easier access.

Bug Fixes:
- Stop calling a non-existent /api/user/logout backend endpoint by mocking a resolved logout response on the client.

Enhancements:
- Allow the logout helper to accept an optional custom success message and use i18n-based text for logout success toasts.