### PR TITLE
fix: Ensure valid JSON string in jsonToRss placeholder

### DIFF
--- a/web/admin/src/locale/en-US/jsonToRss.ts
+++ b/web/admin/src/locale/en-US/jsonToRss.ts
@@ -88,7 +88,7 @@ export default {
   'jsonToRss.placeholder.recipeId': 'my-json-feed',
   'jsonToRss.placeholder.internalDesc': 'Notes for yourself about this recipe',
   'jsonToRss.placeholder.url': 'https://api.example.com/v1/posts',
-  'jsonToRss.placeholder.body': "{ 'foo': 'bar' }",
+  'jsonToRss.placeholder.body': '{"foo": "bar"}',
   'jsonToRss.placeholder.curl': 'curl -X POST ...',
   'jsonToRss.placeholder.items': '.items',
   'jsonToRss.placeholder.title': '.title',

--- a/web/admin/src/locale/zh-CN/jsonToRss.ts
+++ b/web/admin/src/locale/zh-CN/jsonToRss.ts
@@ -82,7 +82,7 @@ export default {
   'jsonToRss.placeholder.recipeId': 'my-json-feed',
   'jsonToRss.placeholder.internalDesc': '关于此配方的备注',
   'jsonToRss.placeholder.url': 'https://api.example.com/v1/posts',
-  'jsonToRss.placeholder.body': "{ 'foo': 'bar' }",
+  'jsonToRss.placeholder.body': '{"foo": "bar"}',
   'jsonToRss.placeholder.curl': 'curl -X POST ...',
   'jsonToRss.placeholder.items': '.items',
   'jsonToRss.placeholder.title': '.title',


### PR DESCRIPTION
Fixes an issue where the `jsonToRss` placeholder displayed an invalid JSON string due to the use of single quotes for keys and values instead of double quotes.

Changed:
*   `web/admin/src/locale/en-US/jsonToRss.ts`
*   `web/admin/src/locale/zh-CN/jsonToRss.ts`

---
*PR created automatically by Jules for task [6275650260582133362](https://jules.google.com/task/6275650260582133362) started by @Colin-XKL*

## Summary by Sourcery

Bug Fixes:
- Fix jsonToRss body placeholder text to use valid JSON quoting in English and Chinese locales.