### PR TITLE
feat(fetcher): configure http client with timeout instead of using DefaultClient

### DIFF
--- a/internal/config/source_config.go
+++ b/internal/config/source_config.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"FeedCraft/internal/constant"
+	"time"
 )
 
 const (
@@ -14,12 +15,13 @@ const (
 // HttpFetcherConfig holds the configuration for an HTTP fetcher.
 // It supports some HTTP methods, headers, and request bodies.
 type HttpFetcherConfig struct {
-	URL            string            `json:"url"`
-	Method         string            `json:"method,omitempty"`
-	Headers        map[string]string `json:"headers,omitempty"`
-	Body           string            `json:"body,omitempty"`
-	UseBrowserless bool              `json:"use_browserless,omitempty"`
-	Purpose        string            `json:"purpose,omitempty"`
+	URL               string            `json:"url"`
+	Method            string            `json:"method,omitempty"`
+	Headers           map[string]string `json:"headers,omitempty"`
+	Body              string            `json:"body,omitempty"`
+	UseBrowserless    bool              `json:"use_browserless,omitempty"`
+	Purpose           string            `json:"purpose,omitempty"`
+	HttpClientTimeout time.Duration     `json:"http_client_timeout,omitempty"`
 }
 
 // SearchFetcherConfig holds the configuration for search-based fetching.

--- a/internal/source/fetcher/http_fetcher.go
+++ b/internal/source/fetcher/http_fetcher.go
@@ -89,7 +89,13 @@ func (f *HttpFetcher) doRequest(ctx context.Context, profile requestProfile) ([]
 		req.Header.Set(key, value)
 	}
 
-	resp, err := http.DefaultClient.Do(req)
+	timeout := 30 * time.Second
+	if f.Config.HttpClientTimeout > 0 {
+		timeout = f.Config.HttpClientTimeout
+	}
+	client := &http.Client{Timeout: timeout}
+
+	resp, err := client.Do(req)
 	if err != nil {
 		return nil, &fetchError{err: fmt.Errorf("http get failed: %w", err), retryable: true}
 	}


### PR DESCRIPTION
Resolves the issue where `HttpFetcher` executes HTTP requests without bounded timeout using `http.DefaultClient`. Adds a `HttpClientTimeout` field to `HttpFetcherConfig` and uses a localized `*http.Client` for request execution in `doRequest`.

---
*PR created automatically by Jules for task [11913687849931482701](https://jules.google.com/task/11913687849931482701) started by @Colin-XKL*

## Summary by Sourcery

New Features:
- Add an HttpClientTimeout field to HttpFetcherConfig to allow per-source HTTP client timeout configuration.