### PR TITLE
feat: add legacy ai filter atom craft

### DIFF
--- a/internal/craft/ai_filter.go
+++ b/internal/craft/ai_filter.go
@@ -37,8 +37,8 @@ const (
 
 var aiFilterCraftParamTmpl = []ParamTemplate{
 	{
-		Key:         "filter-content",
-		Description: "Describe which articles should be kept. Example: 只保留科技有关的文章",
+		Key:         "rule",
+		Description: "Rule for deciding which articles should be kept. Example: 只保留科技有关的文章",
 		Default:     "",
 	},
 	{
@@ -49,21 +49,21 @@ var aiFilterCraftParamTmpl = []ParamTemplate{
 }
 
 func aiFilterCraftLoadParam(m map[string]string) []CraftOption {
-	return GetAIFilterCraftOptions(m["filter-content"], m["extra-payload"])
+	return GetAIFilterCraftOptions(m["rule"], m["extra-payload"])
 }
 
-func GetAIFilterCraftOptions(filterContent string, extraPayloadRaw string) []CraftOption {
+func GetAIFilterCraftOptions(rule string, extraPayloadRaw string) []CraftOption {
 	return []CraftOption{
-		OptionAIFilter(filterContent, extraPayloadRaw),
+		OptionAIFilter(rule, extraPayloadRaw),
 	}
 }
 
-func OptionAIFilter(filterContent string, extraPayloadRaw string) CraftOption {
-	filterContent = strings.TrimSpace(filterContent)
+func OptionAIFilter(rule string, extraPayloadRaw string) CraftOption {
+	rule = strings.TrimSpace(rule)
 	payloadTypes := parseAIFilterExtraPayload(extraPayloadRaw)
 	return func(feed *feeds.Feed, payload ExtraPayload) error {
-		if filterContent == "" {
-			return fmt.Errorf("ai-filter requires filter-content param")
+		if rule == "" {
+			return fmt.Errorf("ai-filter requires rule param")
 		}
 		items := feed.Items
 		if len(items) == 0 {
@@ -71,7 +71,7 @@ func OptionAIFilter(filterContent string, extraPayloadRaw string) CraftOption {
 		}
 
 		drops := parallel.Map(items, func(item *feeds.Item, _ int) bool {
-			decision, err := evaluateAIFilterItem(item, filterContent, payloadTypes)
+			decision, err := evaluateAIFilterItem(item, rule, payloadTypes)
 			if err != nil {
 				logrus.Warnf("failed to evaluate ai-filter for article [%s], err: %v", item.Title, err)
 				return false
@@ -86,7 +86,7 @@ func OptionAIFilter(filterContent string, extraPayloadRaw string) CraftOption {
 	}
 }
 
-func evaluateAIFilterItem(item *feeds.Item, filterContent string, payloadTypes []aiFilterExtraPayloadType) (aiFilterDecision, error) {
+func evaluateAIFilterItem(item *feeds.Item, rule string, payloadTypes []aiFilterExtraPayloadType) (aiFilterDecision, error) {
 	summary := ""
 	if lo.Contains(payloadTypes, aiFilterExtraPayloadArticleSummary) {
 		generated, err := generateAIFilterArticleSummary(item)
@@ -101,7 +101,7 @@ func evaluateAIFilterItem(item *feeds.Item, filterContent string, payloadTypes [
 		return aiFilterDecision{}, err
 	}
 
-	result, err := llmContextCaller(buildAIFilterPrompt(filterContent), context, util.ContentProcessOption{
+	result, err := llmContextCaller(buildAIFilterPrompt(rule), context, util.ContentProcessOption{
 		RemoveImage: true,
 		ConvertToMd: true,
 	})
@@ -141,10 +141,10 @@ func parseAIFilterExtraPayload(raw string) []aiFilterExtraPayloadType {
 	return payloadTypes
 }
 
-func buildAIFilterPrompt(filterContent string) string {
+func buildAIFilterPrompt(rule string) string {
 	return fmt.Sprintf(`You are an RSS article filtering assistant.
 
-Filtering rule from user:
+Rule from user:
 %s
 
 Decide whether the article should be kept in the RSS feed or dropped from the RSS feed.
@@ -157,7 +157,7 @@ Output requirements:
 
 Examples:
 {"reason":"The article is about semiconductor technology and matches the rule.","result":"keep"}
-{"reason":"The article is unrelated to the requested topic.","result":"drop"}`, filterContent)
+{"reason":"The article is unrelated to the requested topic.","result":"drop"}`, rule)
 }
 
 func buildAIFilterArticlePayload(item *feeds.Item, payloadTypes []aiFilterExtraPayloadType, articleSummary string) (string, error) {

--- a/internal/craft/ai_filter.go
+++ b/internal/craft/ai_filter.go
@@ -179,10 +179,10 @@ func buildAIFilterArticlePayload(item *feeds.Item, payloadTypes []aiFilterExtraP
 		case aiFilterExtraPayloadArticleDate:
 			builder.WriteString("\n\nArticle Date:\n```text\n")
 			if !item.Created.IsZero() {
-				builder.WriteString(fmt.Sprintf("Created: %s\n", item.Created.Format("2006-01-02T15:04:05Z07:00")))
+				fmt.Fprintf(&builder, "Created: %s\n", item.Created.Format("2006-01-02T15:04:05Z07:00"))
 			}
 			if !item.Updated.IsZero() {
-				builder.WriteString(fmt.Sprintf("Updated: %s\n", item.Updated.Format("2006-01-02T15:04:05Z07:00")))
+				fmt.Fprintf(&builder, "Updated: %s\n", item.Updated.Format("2006-01-02T15:04:05Z07:00"))
 			}
 			builder.WriteString("```")
 		case aiFilterExtraPayloadRawRSSItem:
@@ -190,7 +190,7 @@ func buildAIFilterArticlePayload(item *feeds.Item, payloadTypes []aiFilterExtraP
 			if err != nil {
 				return "", err
 			}
-			builder.WriteString(fmt.Sprintf("\n\nRaw RSS Item JSON:\n```json\n%s\n```", rawJSON))
+			fmt.Fprintf(&builder, "\n\nRaw RSS Item JSON:\n```json\n%s\n```", rawJSON)
 		}
 	}
 

--- a/internal/craft/ai_filter.go
+++ b/internal/craft/ai_filter.go
@@ -1,0 +1,307 @@
+package craft
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"FeedCraft/internal/constant"
+	"FeedCraft/internal/util"
+
+	"github.com/gorilla/feeds"
+	"github.com/samber/lo"
+	"github.com/samber/lo/parallel"
+	"github.com/sirupsen/logrus"
+)
+
+type aiFilterResult string
+
+const (
+	aiFilterResultKeep aiFilterResult = "keep"
+	aiFilterResultDrop aiFilterResult = "drop"
+)
+
+type aiFilterDecision struct {
+	Reason string         `json:"reason"`
+	Result aiFilterResult `json:"result"`
+}
+
+type aiFilterExtraPayloadType string
+
+const (
+	aiFilterExtraPayloadArticleSummary aiFilterExtraPayloadType = "article_summary"
+	aiFilterExtraPayloadArticleContent aiFilterExtraPayloadType = "article_content"
+	aiFilterExtraPayloadArticleDate    aiFilterExtraPayloadType = "article_date"
+	aiFilterExtraPayloadRawRSSItem     aiFilterExtraPayloadType = "raw_rss_item"
+)
+
+var aiFilterCraftParamTmpl = []ParamTemplate{
+	{
+		Key:         "filter-content",
+		Description: "Describe which articles should be kept. Example: 只保留科技有关的文章",
+		Default:     "",
+	},
+	{
+		Key:         "extra-payload",
+		Description: "Comma-separated extra payload list. Supported: article_summary, article_content, article_date, raw_rss_item",
+		Default:     string(aiFilterExtraPayloadArticleSummary),
+	},
+}
+
+func aiFilterCraftLoadParam(m map[string]string) []CraftOption {
+	return GetAIFilterCraftOptions(m["filter-content"], m["extra-payload"])
+}
+
+func GetAIFilterCraftOptions(filterContent string, extraPayloadRaw string) []CraftOption {
+	return []CraftOption{
+		OptionAIFilter(filterContent, extraPayloadRaw),
+	}
+}
+
+func OptionAIFilter(filterContent string, extraPayloadRaw string) CraftOption {
+	filterContent = strings.TrimSpace(filterContent)
+	payloadTypes := parseAIFilterExtraPayload(extraPayloadRaw)
+	return func(feed *feeds.Feed, payload ExtraPayload) error {
+		if filterContent == "" {
+			return fmt.Errorf("ai-filter requires filter-content param")
+		}
+		items := feed.Items
+		if len(items) == 0 {
+			return nil
+		}
+
+		drops := parallel.Map(items, func(item *feeds.Item, _ int) bool {
+			decision, err := evaluateAIFilterItem(item, filterContent, payloadTypes)
+			if err != nil {
+				logrus.Warnf("failed to evaluate ai-filter for article [%s], err: %v", item.Title, err)
+				return false
+			}
+			return decision.Result == aiFilterResultDrop
+		})
+
+		feed.Items = lo.Filter(items, func(_ *feeds.Item, index int) bool {
+			return !drops[index]
+		})
+		return nil
+	}
+}
+
+func evaluateAIFilterItem(item *feeds.Item, filterContent string, payloadTypes []aiFilterExtraPayloadType) (aiFilterDecision, error) {
+	summary := ""
+	if lo.Contains(payloadTypes, aiFilterExtraPayloadArticleSummary) {
+		generated, err := generateAIFilterArticleSummary(item)
+		if err != nil {
+			return aiFilterDecision{}, err
+		}
+		summary = generated
+	}
+
+	context, err := buildAIFilterArticlePayload(item, payloadTypes, summary)
+	if err != nil {
+		return aiFilterDecision{}, err
+	}
+
+	result, err := llmContextCaller(buildAIFilterPrompt(filterContent), context, util.ContentProcessOption{
+		RemoveImage: true,
+		ConvertToMd: true,
+	})
+	if err != nil {
+		return aiFilterDecision{}, err
+	}
+	return parseAIFilterDecision(result)
+}
+
+func parseAIFilterExtraPayload(raw string) []aiFilterExtraPayloadType {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return []aiFilterExtraPayloadType{aiFilterExtraPayloadArticleSummary}
+	}
+
+	normalized := strings.NewReplacer("|", ",", "\n", ",", "\t", ",").Replace(raw)
+	parts := strings.Split(normalized, ",")
+	seen := map[aiFilterExtraPayloadType]bool{}
+	payloadTypes := make([]aiFilterExtraPayloadType, 0, len(parts))
+	for _, part := range parts {
+		payloadType := aiFilterExtraPayloadType(strings.TrimSpace(part))
+		switch payloadType {
+		case aiFilterExtraPayloadArticleSummary, aiFilterExtraPayloadArticleContent, aiFilterExtraPayloadArticleDate, aiFilterExtraPayloadRawRSSItem:
+			if !seen[payloadType] {
+				seen[payloadType] = true
+				payloadTypes = append(payloadTypes, payloadType)
+			}
+		case "":
+			continue
+		default:
+			logrus.Warnf("unknown ai-filter extra-payload value [%s], ignored", payloadType)
+		}
+	}
+	if len(payloadTypes) == 0 {
+		return []aiFilterExtraPayloadType{aiFilterExtraPayloadArticleSummary}
+	}
+	return payloadTypes
+}
+
+func buildAIFilterPrompt(filterContent string) string {
+	return fmt.Sprintf(`You are an RSS article filtering assistant.
+
+Filtering rule from user:
+%s
+
+Decide whether the article should be kept in the RSS feed or dropped from the RSS feed.
+
+Output requirements:
+- Return JSON only. Do not include markdown fences or any other text.
+- JSON schema: {"reason":"short reason","result":"keep|drop"}
+- Use result="keep" when the article should remain visible to the user.
+- Use result="drop" when the article should be excluded from the RSS output.
+
+Examples:
+{"reason":"The article is about semiconductor technology and matches the rule.","result":"keep"}
+{"reason":"The article is unrelated to the requested topic.","result":"drop"}`, filterContent)
+}
+
+func buildAIFilterArticlePayload(item *feeds.Item, payloadTypes []aiFilterExtraPayloadType, articleSummary string) (string, error) {
+	if item == nil {
+		return "", fmt.Errorf("nil rss item")
+	}
+
+	var builder strings.Builder
+	builder.WriteString(fmt.Sprintf("Article Title:\n```text\n%s\n```", strings.TrimSpace(item.Title)))
+
+	for _, payloadType := range payloadTypes {
+		switch payloadType {
+		case aiFilterExtraPayloadArticleSummary:
+			if strings.TrimSpace(articleSummary) != "" {
+				builder.WriteString(fmt.Sprintf("\n\nArticle Summary:\n```markdown\n%s\n```", strings.TrimSpace(articleSummary)))
+			}
+		case aiFilterExtraPayloadArticleContent:
+			builder.WriteString(fmt.Sprintf("\n\nArticle Content:\n```markdown\n%s\n```", strings.TrimSpace(getPrimaryFeedItemContent(item))))
+		case aiFilterExtraPayloadArticleDate:
+			builder.WriteString("\n\nArticle Date:\n```text\n")
+			if !item.Created.IsZero() {
+				builder.WriteString(fmt.Sprintf("Created: %s\n", item.Created.Format("2006-01-02T15:04:05Z07:00")))
+			}
+			if !item.Updated.IsZero() {
+				builder.WriteString(fmt.Sprintf("Updated: %s\n", item.Updated.Format("2006-01-02T15:04:05Z07:00")))
+			}
+			builder.WriteString("```")
+		case aiFilterExtraPayloadRawRSSItem:
+			rawJSON, err := buildRawRSSItemJSON(item)
+			if err != nil {
+				return "", err
+			}
+			builder.WriteString(fmt.Sprintf("\n\nRaw RSS Item JSON:\n```json\n%s\n```", rawJSON))
+		}
+	}
+
+	return builder.String(), nil
+}
+
+func generateAIFilterArticleSummary(item *feeds.Item) (string, error) {
+	content := getPrimaryFeedItemContent(item)
+	if strings.TrimSpace(content) == "" {
+		return "", nil
+	}
+
+	summaryPrompt := renderTargetLangPrompt("", constant.DefaultPrompts[constant.ProcessorTypeSummary])
+	hashVal := util.GetTextContentHash(strings.Join([]string{
+		util.GetTextContentHash(summaryPrompt),
+		strings.TrimSpace(item.Title),
+		util.GetTextContentHash(content),
+	}, "|"))
+	cacheKey := getCraftCacheKey("ai-filter-article-summary", hashVal)
+
+	return util.CachedFuncWithPreLog(cacheKey, func() (string, error) {
+		processedContent := content
+		domain := ""
+		if item.Link != nil {
+			domain, _ = util.ParseDomainFromUrl(item.Link.Href)
+		}
+		cleanedContent := util.Html2Markdown(content, &domain)
+		if strings.TrimSpace(cleanedContent) != "" {
+			processedContent = cleanedContent
+		}
+		return llmContextCaller(summaryPrompt, processedContent, util.ContentProcessOption{})
+	}, func(isCached bool) {
+		logrus.Infof("generating ai-filter article summary for article [%s], cached: %v", item.Title, isCached)
+	})
+}
+
+func parseAIFilterDecision(raw string) (aiFilterDecision, error) {
+	jsonText, err := extractAIFilterJSON(raw)
+	if err != nil {
+		return aiFilterDecision{}, err
+	}
+
+	var decision aiFilterDecision
+	if err := json.Unmarshal([]byte(jsonText), &decision); err != nil {
+		return aiFilterDecision{}, err
+	}
+	decision.Result = aiFilterResult(strings.ToLower(strings.TrimSpace(string(decision.Result))))
+	decision.Reason = strings.TrimSpace(decision.Reason)
+	switch decision.Result {
+	case aiFilterResultKeep, aiFilterResultDrop:
+		return decision, nil
+	default:
+		return aiFilterDecision{}, fmt.Errorf("unexpected ai-filter result [%s]", decision.Result)
+	}
+}
+
+func extractAIFilterJSON(raw string) (string, error) {
+	trimmed := strings.TrimSpace(raw)
+	if strings.HasPrefix(trimmed, "```") {
+		lines := strings.Split(trimmed, "\n")
+		if len(lines) >= 3 {
+			trimmed = strings.Join(lines[1:len(lines)-1], "\n")
+		}
+	}
+
+	start := strings.Index(trimmed, "{")
+	end := strings.LastIndex(trimmed, "}")
+	if start < 0 || end < start {
+		return "", fmt.Errorf("ai-filter response does not contain json object: [%s]", raw)
+	}
+	return strings.TrimSpace(trimmed[start : end+1]), nil
+}
+
+func getPrimaryFeedItemContent(item *feeds.Item) string {
+	if item == nil {
+		return ""
+	}
+	content := item.Content
+	if strings.TrimSpace(content) == "" {
+		content = item.Description
+	}
+	return content
+}
+
+func buildRawRSSItemJSON(item *feeds.Item) (string, error) {
+	raw := map[string]string{
+		"title":       item.Title,
+		"description": item.Description,
+		"content":     item.Content,
+		"id":          item.Id,
+	}
+	if item.Link != nil {
+		raw["link"] = item.Link.Href
+	}
+	if item.Source != nil {
+		raw["source"] = item.Source.Href
+	}
+	if item.Author != nil {
+		raw["author_name"] = item.Author.Name
+		raw["author_email"] = item.Author.Email
+	}
+	if !item.Created.IsZero() {
+		raw["created"] = item.Created.Format("2006-01-02T15:04:05Z07:00")
+	}
+	if !item.Updated.IsZero() {
+		raw["updated"] = item.Updated.Format("2006-01-02T15:04:05Z07:00")
+	}
+
+	encoded, err := json.Marshal(raw)
+	if err != nil {
+		return "", err
+	}
+	return string(encoded), nil
+}

--- a/internal/craft/ai_filter.go
+++ b/internal/craft/ai_filter.go
@@ -166,16 +166,16 @@ func buildAIFilterArticlePayload(item *feeds.Item, payloadTypes []aiFilterExtraP
 	}
 
 	var builder strings.Builder
-	builder.WriteString(fmt.Sprintf("Article Title:\n```text\n%s\n```", strings.TrimSpace(item.Title)))
+	fmt.Fprintf(&builder, "Article Title:\n```text\n%s\n```", strings.TrimSpace(item.Title))
 
 	for _, payloadType := range payloadTypes {
 		switch payloadType {
 		case aiFilterExtraPayloadArticleSummary:
 			if strings.TrimSpace(articleSummary) != "" {
-				builder.WriteString(fmt.Sprintf("\n\nArticle Summary:\n```markdown\n%s\n```", strings.TrimSpace(articleSummary)))
+				fmt.Fprintf(&builder, "\n\nArticle Summary:\n```markdown\n%s\n```", strings.TrimSpace(articleSummary))
 			}
 		case aiFilterExtraPayloadArticleContent:
-			builder.WriteString(fmt.Sprintf("\n\nArticle Content:\n```markdown\n%s\n```", strings.TrimSpace(getPrimaryFeedItemContent(item))))
+			fmt.Fprintf(&builder, "\n\nArticle Content:\n```markdown\n%s\n```", strings.TrimSpace(getPrimaryFeedItemContent(item)))
 		case aiFilterExtraPayloadArticleDate:
 			builder.WriteString("\n\nArticle Date:\n```text\n")
 			if !item.Created.IsZero() {

--- a/internal/craft/ai_filter.go
+++ b/internal/craft/ai_filter.go
@@ -101,14 +101,7 @@ func evaluateAIFilterItem(item *feeds.Item, rule string, payloadTypes []aiFilter
 		return aiFilterDecision{}, err
 	}
 
-	result, err := llmContextCaller(buildAIFilterPrompt(rule), context, util.ContentProcessOption{
-		RemoveImage: true,
-		ConvertToMd: true,
-	})
-	if err != nil {
-		return aiFilterDecision{}, err
-	}
-	return parseAIFilterDecision(result)
+	return cachedAIFilterDecision(item.Title, buildAIFilterPrompt(rule), context)
 }
 
 func parseAIFilterExtraPayload(raw string) []aiFilterExtraPayloadType {
@@ -158,6 +151,39 @@ Output requirements:
 Examples:
 {"reason":"The article is about semiconductor technology and matches the rule.","result":"keep"}
 {"reason":"The article is unrelated to the requested topic.","result":"drop"}`, rule)
+}
+
+func cachedAIFilterDecision(title string, prompt string, context string) (aiFilterDecision, error) {
+	hashVal := util.GetTextContentHash(strings.Join([]string{
+		util.GetTextContentHash(prompt),
+		util.GetTextContentHash(context),
+	}, "|"))
+	cacheKey := getCraftCacheKey("ai-filter", hashVal)
+
+	cached, err := util.CachedFuncWithPreLog(cacheKey, func() (string, error) {
+		result, err := llmContextCaller(prompt, context, util.ContentProcessOption{
+			RemoveImage: true,
+			ConvertToMd: true,
+		})
+		if err != nil {
+			return "", err
+		}
+		decision, err := parseAIFilterDecision(result)
+		if err != nil {
+			return "", err
+		}
+		normalized, err := json.Marshal(decision)
+		if err != nil {
+			return "", err
+		}
+		return string(normalized), nil
+	}, func(isCached bool) {
+		logrus.Infof("applying craft [ai-filter] to article [%s], cached: %v", title, isCached)
+	})
+	if err != nil {
+		return aiFilterDecision{}, err
+	}
+	return parseAIFilterDecision(cached)
 }
 
 func buildAIFilterArticlePayload(item *feeds.Item, payloadTypes []aiFilterExtraPayloadType, articleSummary string) (string, error) {

--- a/internal/craft/ai_filter_test.go
+++ b/internal/craft/ai_filter_test.go
@@ -109,6 +109,34 @@ func TestOptionAIFilterKeepsArticleOnInvalidLLMResponse(t *testing.T) {
 	assert.Equal(t, "Keep on malformed response", feed.Items[0].Title)
 }
 
+func TestAIFilterCraftLoadParamUsesRuleParam(t *testing.T) {
+	setupTestRedis(t)
+
+	original := llmContextCaller
+	llmContextCaller = func(prompt, context string, option util.ContentProcessOption) (string, error) {
+		assert.Contains(t, prompt, "只保留科技有关的文章")
+		return `{"reason":"not a tech article","result":"drop"}`, nil
+	}
+	t.Cleanup(func() { llmContextCaller = original })
+
+	options := aiFilterCraftLoadParam(map[string]string{
+		"rule":          "只保留科技有关的文章",
+		"extra-payload": "article_content",
+	})
+	require.Len(t, options, 1)
+
+	feed := &feeds.Feed{
+		Items: []*feeds.Item{
+			{Title: "Sports", Content: "<p>football news</p>"},
+		},
+	}
+
+	err := options[0](feed, ExtraPayload{})
+
+	require.NoError(t, err)
+	require.Empty(t, feed.Items)
+}
+
 func TestBuildAIFilterArticlePayloadIncludesRawRSSItemAsJSON(t *testing.T) {
 	item := &feeds.Item{
 		Title:       "Raw item title",

--- a/internal/craft/ai_filter_test.go
+++ b/internal/craft/ai_filter_test.go
@@ -1,0 +1,122 @@
+package craft
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"FeedCraft/internal/util"
+
+	"github.com/gorilla/feeds"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseAIFilterDecisionAcceptsFencedJSON(t *testing.T) {
+	decision, err := parseAIFilterDecision("```json\n{\"reason\":\"not relevant\",\"result\":\"drop\"}\n```")
+
+	require.NoError(t, err)
+	assert.Equal(t, aiFilterResultDrop, decision.Result)
+	assert.Equal(t, "not relevant", decision.Reason)
+}
+
+func TestBuildAIFilterArticlePayloadIncludesRequestedContent(t *testing.T) {
+	item := &feeds.Item{
+		Title:       "AI chip news",
+		Description: "short description",
+		Content:     "<p>complete article content</p>",
+	}
+
+	payload, err := buildAIFilterArticlePayload(item, []aiFilterExtraPayloadType{aiFilterExtraPayloadArticleContent}, "")
+
+	require.NoError(t, err)
+	assert.Contains(t, payload, "Article Title:")
+	assert.Contains(t, payload, "AI chip news")
+	assert.Contains(t, payload, "Article Content:")
+	assert.Contains(t, payload, "complete article content")
+	assert.NotContains(t, payload, "short description")
+}
+
+func TestOptionAIFilterDropsOnlyDropDecisionAndUsesSummaryPayload(t *testing.T) {
+	setupTestRedis(t)
+
+	original := llmContextCaller
+	var filterContexts []string
+	var summaryContexts []string
+	llmContextCaller = func(prompt, context string, option util.ContentProcessOption) (string, error) {
+		if strings.Contains(prompt, "professional summarizer") {
+			summaryContexts = append(summaryContexts, context)
+			if strings.Contains(context, "drop article original") {
+				return "summary says drop", nil
+			}
+			return "summary says keep", nil
+		}
+
+		filterContexts = append(filterContexts, context)
+		if strings.Contains(context, "summary says drop") {
+			return `{"reason":"summary matched exclusion","result":"drop"}`, nil
+		}
+		return `{"reason":"summary did not match exclusion","result":"keep"}`, nil
+	}
+	t.Cleanup(func() { llmContextCaller = original })
+
+	feed := &feeds.Feed{
+		Items: []*feeds.Item{
+			{Title: "Drop", Content: "<p>drop article original</p>"},
+			{Title: "Keep", Content: "<p>keep article original</p>"},
+		},
+	}
+
+	err := OptionAIFilter("只保留科技有关的文章", "article_summary")(feed, ExtraPayload{})
+
+	require.NoError(t, err)
+	require.Len(t, feed.Items, 1)
+	assert.Equal(t, "Keep", feed.Items[0].Title)
+	require.Len(t, summaryContexts, 2)
+	require.Len(t, filterContexts, 2)
+	assert.Contains(t, filterContexts[0], "Article Summary:")
+	assert.Contains(t, filterContexts[0], "summary says drop")
+	assert.NotContains(t, filterContexts[0], "drop article original")
+}
+
+func TestOptionAIFilterKeepsArticleOnInvalidLLMResponse(t *testing.T) {
+	setupTestRedis(t)
+
+	original := llmContextCaller
+	llmContextCaller = func(prompt, context string, option util.ContentProcessOption) (string, error) {
+		return "not json", nil
+	}
+	t.Cleanup(func() { llmContextCaller = original })
+
+	feed := &feeds.Feed{
+		Items: []*feeds.Item{
+			{Title: "Keep on malformed response", Content: "<p>article content long enough</p>"},
+		},
+	}
+
+	err := OptionAIFilter("只保留科技有关的文章", "article_content")(feed, ExtraPayload{})
+
+	require.NoError(t, err)
+	require.Len(t, feed.Items, 1)
+	assert.Equal(t, "Keep on malformed response", feed.Items[0].Title)
+}
+
+func TestBuildAIFilterArticlePayloadIncludesRawRSSItemAsJSON(t *testing.T) {
+	item := &feeds.Item{
+		Title:       "Raw item title",
+		Description: "Raw item description",
+		Content:     "<p>Raw item content</p>",
+		Id:          "guid-1",
+		Link:        &feeds.Link{Href: "https://example.com/post"},
+		Created:     time.Date(2026, 5, 16, 10, 0, 0, 0, time.UTC),
+	}
+
+	payload, err := buildAIFilterArticlePayload(item, []aiFilterExtraPayloadType{aiFilterExtraPayloadRawRSSItem}, "")
+
+	require.NoError(t, err)
+	assert.Contains(t, payload, "Raw RSS Item JSON:")
+	assert.Contains(t, payload, `"title":"Raw item title"`)
+	assert.Contains(t, payload, `"link":"https://example.com/post"`)
+	assert.Contains(t, payload, fmt.Sprintf(`"created":%q`, item.Created.Format(time.RFC3339)))
+}

--- a/internal/craft/ai_filter_test.go
+++ b/internal/craft/ai_filter_test.go
@@ -137,6 +137,33 @@ func TestAIFilterCraftLoadParamUsesRuleParam(t *testing.T) {
 	require.Empty(t, feed.Items)
 }
 
+func TestEvaluateAIFilterItemCachesDecision(t *testing.T) {
+	setupTestRedis(t)
+
+	original := llmContextCaller
+	filterCalls := 0
+	llmContextCaller = func(prompt, context string, option util.ContentProcessOption) (string, error) {
+		filterCalls += 1
+		return `{"reason":"cached decision","result":"keep"}`, nil
+	}
+	t.Cleanup(func() { llmContextCaller = original })
+
+	item := &feeds.Item{
+		Title:   "Cache Me",
+		Content: "<p>same article content</p>",
+	}
+	payloadTypes := []aiFilterExtraPayloadType{aiFilterExtraPayloadArticleContent}
+
+	first, err := evaluateAIFilterItem(item, "只保留科技有关的文章", payloadTypes)
+	require.NoError(t, err)
+	second, err := evaluateAIFilterItem(item, "只保留科技有关的文章", payloadTypes)
+	require.NoError(t, err)
+
+	assert.Equal(t, aiFilterResultKeep, first.Result)
+	assert.Equal(t, first, second)
+	assert.Equal(t, 1, filterCalls)
+}
+
 func TestBuildAIFilterArticlePayloadIncludesRawRSSItemAsJSON(t *testing.T) {
 	item := &feeds.Item{
 		Title:       "Raw item title",

--- a/internal/craft/ai_filter_test.go
+++ b/internal/craft/ai_filter_test.go
@@ -3,6 +3,7 @@ package craft
 import (
 	"fmt"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -44,16 +45,21 @@ func TestOptionAIFilterDropsOnlyDropDecisionAndUsesSummaryPayload(t *testing.T) 
 	original := llmContextCaller
 	var filterContexts []string
 	var summaryContexts []string
+	var seenMu sync.Mutex
 	llmContextCaller = func(prompt, context string, option util.ContentProcessOption) (string, error) {
 		if strings.Contains(prompt, "professional summarizer") {
+			seenMu.Lock()
 			summaryContexts = append(summaryContexts, context)
+			seenMu.Unlock()
 			if strings.Contains(context, "drop article original") {
 				return "summary says drop", nil
 			}
 			return "summary says keep", nil
 		}
 
+		seenMu.Lock()
 		filterContexts = append(filterContexts, context)
+		seenMu.Unlock()
 		if strings.Contains(context, "summary says drop") {
 			return `{"reason":"summary matched exclusion","result":"drop"}`, nil
 		}
@@ -75,9 +81,10 @@ func TestOptionAIFilterDropsOnlyDropDecisionAndUsesSummaryPayload(t *testing.T) 
 	assert.Equal(t, "Keep", feed.Items[0].Title)
 	require.Len(t, summaryContexts, 2)
 	require.Len(t, filterContexts, 2)
-	assert.Contains(t, filterContexts[0], "Article Summary:")
-	assert.Contains(t, filterContexts[0], "summary says drop")
-	assert.NotContains(t, filterContexts[0], "drop article original")
+	combinedFilterContexts := strings.Join(filterContexts, "\n---\n")
+	assert.Contains(t, combinedFilterContexts, "Article Summary:")
+	assert.Contains(t, combinedFilterContexts, "summary says drop")
+	assert.NotContains(t, combinedFilterContexts, "drop article original")
 }
 
 func TestOptionAIFilterKeepsArticleOnInvalidLLMResponse(t *testing.T) {

--- a/internal/craft/entry.go
+++ b/internal/craft/entry.go
@@ -106,6 +106,12 @@ func GetSysCraftTemplateDict() map[string]CraftTemplate {
 		ParamTemplateDefine: llmFilterGenericParamTmpl,
 		OptionFunc:          llmFilterGenericLoadParam,
 	}
+	sysCraftTempList["ai-filter"] = CraftTemplate{
+		Name:                "ai-filter",
+		Description:         "使用 LLM 根据自定义规则判断文章应保留还是排除，要求返回 JSON",
+		ParamTemplateDefine: aiFilterCraftParamTmpl,
+		OptionFunc:          aiFilterCraftLoadParam,
+	}
 	sysCraftTempList["translate-title"] = CraftTemplate{
 		Name:                "translate-title",
 		Description:         "使用 LLM 将标题翻译为中文",

--- a/internal/craft/runtime_test.go
+++ b/internal/craft/runtime_test.go
@@ -111,6 +111,19 @@ func TestBuildProcessor_UsesNativeProcessors(t *testing.T) {
 	assert.IsType(t, &ArticlePredicateProcessor{}, flow.Processors[14])
 }
 
+func TestBuildProcessor_AIFilterUsesLegacyOptionAdapter(t *testing.T) {
+	db := newCraftRuntimeTestDB(t)
+
+	processor, err := BuildProcessor(db, "ai-filter", "https://example.com/feed.xml")
+
+	require.NoError(t, err)
+	require.NotNil(t, processor)
+	flow, ok := processor.(*engine.FlowCraftProcessor)
+	require.True(t, ok)
+	require.Len(t, flow.Processors, 1)
+	assert.IsType(t, &LegacyOptionAdapter{}, flow.Processors[0])
+}
+
 func TestNativeProcessors_EndToEnd(t *testing.T) {
 	now := time.Now()
 	processor := &engine.FlowCraftProcessor{

--- a/internal/craft/runtime_test.go
+++ b/internal/craft/runtime_test.go
@@ -121,7 +121,10 @@ func TestBuildProcessor_AIFilterUsesLegacyOptionAdapter(t *testing.T) {
 	flow, ok := processor.(*engine.FlowCraftProcessor)
 	require.True(t, ok)
 	require.Len(t, flow.Processors, 1)
-	assert.IsType(t, &LegacyOptionAdapter{}, flow.Processors[0])
+	legacyFlow, ok := flow.Processors[0].(*engine.FlowCraftProcessor)
+	require.True(t, ok)
+	require.Len(t, legacyFlow.Processors, 1)
+	assert.IsType(t, &LegacyOptionAdapter{}, legacyFlow.Processors[0])
 }
 
 func TestNativeProcessors_EndToEnd(t *testing.T) {

--- a/internal/craft/runtime_test.go
+++ b/internal/craft/runtime_test.go
@@ -388,6 +388,8 @@ func TestLLMFilterProcessor_RemovesMatchedArticleAndUsesTitleContentPayload(t *t
 }
 
 func TestIgnoreAdvertorialProcessor_KeepsArticleOnLLMError(t *testing.T) {
+	setupTestRedis(t)
+
 	original := llmContextCaller
 	llmContextCaller = func(prompt, context string, option util.ContentProcessOption) (string, error) {
 		return "", fmt.Errorf("temporary llm error")

--- a/web/admin/src/views/dashboard/craft_atom/craft_atom.vue
+++ b/web/admin/src/views/dashboard/craft_atom/craft_atom.vue
@@ -111,7 +111,21 @@
                     />
                   </a-col>
                   <a-col :span="14">
+                    <a-select
+                      v-if="
+                        isAIFilterExtraPayloadParam(
+                          editedCraftAtom.template_name,
+                          param.key
+                        )
+                      "
+                      v-model="param.value"
+                      multiple
+                      allow-clear
+                      :options="aiFilterExtraPayloadOptions"
+                      :placeholder="t('craftAtom.form.value')"
+                    />
                     <a-textarea
+                      v-else
                       v-model="param.value"
                       :placeholder="t('craftAtom.form.value')"
                     />
@@ -164,6 +178,13 @@
   import { listCraftTemplates } from '@/api/craft_flow';
   import { namingValidator } from '@/utils/validator';
   import { useI18n } from 'vue-i18n';
+  import {
+    aiFilterExtraPayloadOptions,
+    CraftParamValue,
+    isAIFilterExtraPayloadParam,
+    serializeCraftParamValue,
+    toCraftParamFormValue,
+  } from './paramOptions';
 
   const { t } = useI18n();
 
@@ -176,7 +197,7 @@
     template_name: '',
     params: {},
   });
-  const formParams = ref<{ key: string; value: string }[]>([]);
+  const formParams = ref<{ key: string; value: CraftParamValue }[]>([]);
   const showEditModal = ref(false);
   const isUpdating = ref(false);
 
@@ -224,7 +245,11 @@
     const params = paramTemplates.value[templateName as string] || [];
     formParams.value = params.map((param) => ({
       key: param.key,
-      value: editedCraftAtom.value.params[param.key] || param.default,
+      value: toCraftParamFormValue(
+        templateName as string,
+        param.key,
+        editedCraftAtom.value.params[param.key] || param.default
+      ),
     }));
   };
 
@@ -236,7 +261,10 @@
   const editBtnHandler = (craftAtom: CraftAtom) => {
     editedCraftAtom.value = { ...craftAtom };
     formParams.value = Object.entries(editedCraftAtom.value.params).map(
-      ([key, value]) => ({ key, value })
+      ([key, value]) => ({
+        key,
+        value: toCraftParamFormValue(craftAtom.template_name, key, value),
+      })
     );
     showEditModal.value = true;
     isUpdating.value = true;
@@ -268,8 +296,9 @@
     // Convert formParams to map
     const paramsMap: Record<string, string> = {};
     formParams.value.forEach((param) => {
-      if (param.key && param.value) {
-        paramsMap[param.key] = param.value;
+      const value = serializeCraftParamValue(param.value);
+      if (param.key && value) {
+        paramsMap[param.key] = value;
       }
     });
     editedCraftAtom.value.params = paramsMap;

--- a/web/admin/src/views/dashboard/craft_atom/paramOptions.ts
+++ b/web/admin/src/views/dashboard/craft_atom/paramOptions.ts
@@ -1,0 +1,58 @@
+export type CraftParamValue = string | string[];
+
+export const aiFilterExtraPayloadOptions = [
+  {
+    label: 'article_summary',
+    value: 'article_summary',
+  },
+  {
+    label: 'article_content',
+    value: 'article_content',
+  },
+  {
+    label: 'article_date',
+    value: 'article_date',
+  },
+  {
+    label: 'raw_rss_item',
+    value: 'raw_rss_item',
+  },
+];
+
+const AI_FILTER_TEMPLATE = 'ai-filter';
+const AI_FILTER_EXTRA_PAYLOAD_PARAM = 'extra-payload';
+
+export function isAIFilterExtraPayloadParam(
+  templateName: string,
+  paramKey: string
+) {
+  return (
+    templateName === AI_FILTER_TEMPLATE &&
+    paramKey === AI_FILTER_EXTRA_PAYLOAD_PARAM
+  );
+}
+
+export function deserializeAIFilterExtraPayloadValue(value?: string) {
+  return (value || '')
+    .split(/[,\n\t|]+/)
+    .map((item) => item.trim())
+    .filter(Boolean);
+}
+
+export function toCraftParamFormValue(
+  templateName: string,
+  paramKey: string,
+  value?: string
+): CraftParamValue {
+  if (isAIFilterExtraPayloadParam(templateName, paramKey)) {
+    return deserializeAIFilterExtraPayloadValue(value);
+  }
+  return value || '';
+}
+
+export function serializeCraftParamValue(value: CraftParamValue) {
+  if (Array.isArray(value)) {
+    return value.join(',');
+  }
+  return value;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add a legacy `ai-filter` AtomCraft template using JSON `keep`/`drop` LLM decisions.
- Support `rule` and `extra-payload` parameters, including generated `article_summary`, `article_content`, `article_date`, and JSON `raw_rss_item` payloads.
- Add explicit atom-level caching for validated `ai-filter` decisions, keyed by rule prompt and final article payload, in addition to cached generated summaries.
- Add an admin UI multi-select for `ai-filter` `extra-payload`, while serializing selected values back to the backend's comma-separated parameter string.
- Add unit coverage for parsing, payload construction, rule parameter loading, summary-driven filtering, malformed LLM responses, decision caching, and deterministic concurrent assertions.
- Initialize test Redis for an existing advertorial processor cache-path test so package verification can run reliably.
- Add a regression test proving `ai-filter` stays on the legacy adapter path and is not wired into native processors.

### Manual Testing
[ai_filter_admin_browser_test.mp4](https://cursor.com/agents/bc-18cadb50-ec46-4ded-bf81-3c274bc578ba/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fai_filter_admin_browser_test.mp4)
[ai_filter_extra_payload_multiselect.mp4](https://cursor.com/agents/bc-18cadb50-ec46-4ded-bf81-3c274bc578ba/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fai_filter_extra_payload_multiselect.mp4)

### Automated Testing
- `go test ./internal/craft -run 'Test(ParseAIFilterDecisionAcceptsFencedJSON|BuildAIFilterArticlePayloadIncludesRequestedContent|OptionAIFilterDropsOnlyDropDecisionAndUsesSummaryPayload|OptionAIFilterKeepsArticleOnInvalidLLMResponse|AIFilterCraftLoadParamUsesRuleParam|EvaluateAIFilterItemCachesDecision|BuildAIFilterArticlePayloadIncludesRawRSSItemAsJSON|BuildProcessor_AIFilterUsesLegacyOptionAdapter)'` passed.
- `go test ./internal/craft` passed.
- `go test ./...` passed.
- helper conversion check for `paramOptions.ts` passed via `tsc` + Node assertions.
- `pnpm --dir web/admin run type:check` passed.
- `pnpm --dir web/admin run lint` passed with one unrelated existing warning in `topic_feed/detail.vue`.
- `task backend-build` passed.
- `task --force frontend-build` passed.
- `task fix` failed only on pre-existing `internal/controller/feed_viewer.go` ST1005 lint warnings unrelated to this change.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-18cadb50-ec46-4ded-bf81-3c274bc578ba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-18cadb50-ec46-4ded-bf81-3c274bc578ba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

## Summary by Sourcery

Add a legacy AI-powered article filter craft that uses LLM JSON decisions to keep or drop RSS items and ensure it is wired through the legacy option adapter path.

New Features:
- Introduce the `ai-filter` craft template with configurable rule and extra-payload parameters for LLM-based article filtering.
- Support configurable extra payloads for filtering decisions, including article summaries, full content, dates, and raw RSS item JSON.

Enhancements:
- Implement caching for AI filter decisions and generated article summaries to avoid redundant LLM calls and improve performance.

Tests:
- Add unit tests covering AI filter payload construction, parameter loading, malformed LLM responses, decision caching, and summary-driven filtering behavior.
- Add a regression test to ensure `ai-filter` continues to use the legacy option adapter path and does not switch to native processors.
- Initialize test Redis in the advertorial processor error-handling test to make cache-dependent tests deterministic.