### PR TITLE
feat: sort AtomCraft template options alphabetically

### DIFF
--- a/web/admin/src/views/dashboard/craft_atom/craft_atom.vue
+++ b/web/admin/src/views/dashboard/craft_atom/craft_atom.vue
@@ -211,7 +211,10 @@
 
   const fetchTemplates = async () => {
     const response = await listCraftTemplates();
-    templateOptions.value = response.data.map((template) => ({
+    const sortedTemplates = [...response.data].sort((a, b) =>
+      a.name.localeCompare(b.name, undefined, { sensitivity: 'base' })
+    );
+    templateOptions.value = sortedTemplates.map((template) => ({
       label: template.name,
       value: template.name,
     }));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- sort template options by template name in `fetchTemplates` on the AtomCraft create/edit modal.
- use case-insensitive alphabetical comparison via `localeCompare(..., { sensitivity: 'base' })` to ensure stable default ordering.

## Testing
- `task fix` (fails due pre-existing Go lint issues in `internal/controller/feed_viewer.go`)
- `go test ./...` (fails due existing Redis URI-related test env issue in `internal/craft`)
- `task backend-build` (pass)
- `task frontend-build` (pass)
- manual UI validation on AtomCraft create modal: dropdown displays alphabetically ordered templates.

## Walkthrough artifacts
[atom_craft_template_alphabetical_order_demo.mp4](https://cursor.com/agents/bc-e110b59e-403b-49cc-aca7-fbb14b2905aa/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fatom_craft_template_alphabetical_order_demo.mp4)
[atom-craft-template-dropdown-sorted](https://cursor.com/agents/bc-e110b59e-403b-49cc-aca7-fbb14b2905aa/artifacts?path=%2Ftmp%2Fcomputer-use%2F7cfd9.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e110b59e-403b-49cc-aca7-fbb14b2905aa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e110b59e-403b-49cc-aca7-fbb14b2905aa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

## Summary by Sourcery

New Features:
- Apply case-insensitive alphabetical sorting to AtomCraft templates before populating the template dropdown options.