### PR TITLE
Cherry-pick embedding filter into dev

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,6 +26,16 @@ FC_LLM_API_MODEL=gpt-3.5-turbo
 FC_LLM_API_TYPE=openai
 FC_DEFAULT_TARGET_LANG=zh-CN
 
+# Embedding Configuration (for embedding-filter feature)
+# If not set, falls back to LLM configuration above
+FC_EMBEDDING_API_TYPE=openai
+FC_EMBEDDING_API_BASE=https://api.openai.com/v1
+FC_EMBEDDING_API_KEY=sk-your-api-key-here
+FC_EMBEDDING_API_MODEL=text-embedding-3-small
+FC_EMBEDDING_INSTRUCTION=
+# Max texts per batch sent to embedding service. Adjust based on model size and hardware. (default: 5)
+FC_EMBEDDING_BATCH_SIZE=5
+
 # Browser Rendering (for fulltext-plus feature)
 FC_PUPPETEER_HTTP_ENDPOINT=http://localhost:3000
 

--- a/.gitignore
+++ b/.gitignore
@@ -145,4 +145,10 @@ feedcraft.exe
 *.log
 **/*.log
 .gocache
-.claude/settings.local.json
+.codebuddy/
+
+# SQLite 数据库目录
+db/
+start.sh
+start-full.sh
+.claude/

--- a/internal/adapter/embedding.go
+++ b/internal/adapter/embedding.go
@@ -1,0 +1,332 @@
+package adapter
+
+import (
+	"FeedCraft/internal/util"
+	"context"
+	"fmt"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/avast/retry-go/v4"
+	"github.com/sirupsen/logrus"
+	"github.com/tmc/langchaingo/embeddings"
+	"github.com/tmc/langchaingo/llms/ollama"
+	"github.com/tmc/langchaingo/llms/openai"
+)
+
+/*
+ * Embedding 适配器层
+ * 提供统一的 Embedding 接口，支持 OpenAI、Gemini（通过 OpenAI 兼容接口）、Ollama 三种后端。
+ * 锚点向量缓存在进程内存中，不依赖外部向量数据库。
+ */
+
+const (
+	defaultEmbeddingModel     = "text-embedding-3-small"
+	embeddingCallTimeout      = 2 * time.Minute
+	embeddingTotalTimeout     = 5 * time.Minute // 全局超时预算，所有重试在此预算内执行
+	defaultEmbeddingBatchSize = 5               // 每批发送给 Embedding 服务的默认最大文本数
+)
+
+var (
+	// embeddingClients 缓存已创建的 Embedding 客户端实例（惰性单例）
+	embeddingClients sync.Map
+
+	// anchorVectorCache 锚点向量内存缓存，key = MD5(锚点文本) + "|" + 模型名称
+	anchorVectorCache sync.Map
+)
+
+// embeddingConfig 从环境变量读取的 Embedding 配置
+type embeddingConfig struct {
+	apiType     string
+	apiBase     string
+	apiKey      string
+	apiModel    string
+	instruction string // 全局默认 instruction
+	batchSize   int    // 每批发送给 Embedding 服务的最大文本数，用户可根据模型和硬件自行调整
+}
+
+// loadEmbeddingConfig 读取 Embedding 环境变量，未配置时回退使用 LLM 配置
+func loadEmbeddingConfig() (embeddingConfig, error) {
+	envClient := util.GetEnvClient()
+	if envClient == nil {
+		return embeddingConfig{}, fmt.Errorf("failed to initialize env client")
+	}
+
+	cfg := embeddingConfig{}
+
+	// 1. 读取 Embedding 专用环境变量
+	cfg.apiType = envClient.GetString("EMBEDDING_API_TYPE")
+	cfg.apiBase = envClient.GetString("EMBEDDING_API_BASE")
+	cfg.apiKey = envClient.GetString("EMBEDDING_API_KEY")
+	cfg.apiModel = envClient.GetString("EMBEDDING_API_MODEL")
+	cfg.instruction = envClient.GetString("EMBEDDING_INSTRUCTION")
+
+	// 读取批次大小配置，未配置或无效时使用默认值
+	cfg.batchSize = defaultEmbeddingBatchSize
+	if batchSizeStr := envClient.GetString("EMBEDDING_BATCH_SIZE"); batchSizeStr != "" {
+		if parsed, parseErr := strconv.Atoi(batchSizeStr); parseErr != nil || parsed <= 0 {
+			logrus.Warnf("FC_EMBEDDING_BATCH_SIZE value [%s] is invalid, using default %d", batchSizeStr, defaultEmbeddingBatchSize)
+		} else {
+			cfg.batchSize = parsed
+			logrus.Debugf("Embedding batch size set to %d from FC_EMBEDDING_BATCH_SIZE", parsed)
+		}
+	}
+
+	// 2. 回退逻辑：未配置时使用 LLM 配置
+	if cfg.apiType == "" {
+		cfg.apiType = "openai"
+	}
+
+	if cfg.apiBase == "" {
+		cfg.apiBase = envClient.GetString("LLM_API_BASE")
+		if cfg.apiBase != "" {
+			logrus.Debug("FC_EMBEDDING_API_BASE not set, falling back to FC_LLM_API_BASE")
+		}
+	}
+
+	if cfg.apiKey == "" {
+		cfg.apiKey = envClient.GetString("LLM_API_KEY")
+		if cfg.apiKey != "" {
+			logrus.Debug("FC_EMBEDDING_API_KEY not set, falling back to FC_LLM_API_KEY")
+		}
+	}
+
+	if cfg.apiModel == "" {
+		switch cfg.apiType {
+		case "ollama", "gemini":
+			return embeddingConfig{}, fmt.Errorf("FC_EMBEDDING_API_MODEL must be set when using FC_EMBEDDING_API_TYPE='%s'", cfg.apiType)
+		default: // "openai" 及其他 OpenAI 兼容服务
+			cfg.apiModel = defaultEmbeddingModel
+			logrus.Debugf("FC_EMBEDDING_API_MODEL not set, using default: %s", defaultEmbeddingModel)
+		}
+	}
+
+	return cfg, nil
+}
+
+// getOrCreateEmbedder 获取或创建 Embedding 客户端（带缓存）
+func getOrCreateEmbedder(cfg embeddingConfig) (*embeddings.EmbedderImpl, error) {
+	cacheKey := fmt.Sprintf("emb|%s|%s|%s|%s", cfg.apiType, cfg.apiBase, cfg.apiKey, cfg.apiModel)
+
+	if cached, ok := embeddingClients.Load(cacheKey); ok {
+		return cached.(*embeddings.EmbedderImpl), nil
+	}
+
+	var client embeddings.EmbedderClient
+	var err error
+
+	switch cfg.apiType {
+	case "ollama":
+		logrus.Debug("Creating Ollama embedding client")
+		if cfg.apiBase == "" {
+			return nil, fmt.Errorf("FC_EMBEDDING_API_BASE (or FC_LLM_API_BASE) must be set when using FC_EMBEDDING_API_TYPE='ollama'")
+		}
+		var ollamaLLM *ollama.LLM
+		ollamaLLM, err = ollama.New(
+			ollama.WithServerURL(cfg.apiBase),
+			ollama.WithModel(cfg.apiModel),
+		)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create Ollama embedding client: %w", err)
+		}
+		client = ollamaLLM
+
+	case "gemini":
+		// Gemini 通过 OpenAI 兼容接口调用（Google 提供了 OpenAI 兼容的 Embedding 端点）
+		// 用户需要将 FC_EMBEDDING_API_BASE 设置为 Gemini 的 OpenAI 兼容端点
+		logrus.Debug("Creating Gemini embedding client (via OpenAI-compatible API)")
+		if cfg.apiBase == "" {
+			return nil, fmt.Errorf("FC_EMBEDDING_API_BASE (or FC_LLM_API_BASE) must be set when using FC_EMBEDDING_API_TYPE='gemini' to avoid sending credentials to wrong endpoint")
+		}
+		if cfg.apiKey == "" {
+			return nil, fmt.Errorf("FC_EMBEDDING_API_KEY (or FC_LLM_API_KEY) must be set when using apiType 'gemini'")
+		}
+		opts := []openai.Option{
+			openai.WithToken(cfg.apiKey),
+			openai.WithEmbeddingModel(cfg.apiModel),
+			openai.WithBaseURL(cfg.apiBase), // apiBase 已在上方强制校验非空
+		}
+		var openaiLLM *openai.LLM
+		openaiLLM, err = openai.New(opts...)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create Gemini embedding client: %w", err)
+		}
+		client = openaiLLM
+
+	default: // "openai" 及其他 OpenAI 兼容服务
+		logrus.Debug("Creating OpenAI embedding client")
+		if cfg.apiKey == "" {
+			return nil, fmt.Errorf("FC_EMBEDDING_API_KEY (or FC_LLM_API_KEY) must be set when using apiType '%s'", cfg.apiType)
+		}
+		opts := []openai.Option{
+			openai.WithToken(cfg.apiKey),
+			openai.WithEmbeddingModel(cfg.apiModel),
+		}
+		if cfg.apiBase != "" {
+			opts = append(opts, openai.WithBaseURL(cfg.apiBase))
+		}
+		var openaiLLM *openai.LLM
+		openaiLLM, err = openai.New(opts...)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create OpenAI embedding client: %w", err)
+		}
+		client = openaiLLM
+	}
+
+	embedder, err := embeddings.NewEmbedder(client)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create embedder: %w", err)
+	}
+
+	embeddingClients.Store(cacheKey, embedder)
+	return embedder, nil
+}
+
+// resolveInstruction 解析最终生效的 instruction：调用方传入的优先，为空时 fallback 到全局配置
+func resolveInstruction(instruction string, cfg embeddingConfig) string {
+	if instruction != "" {
+		return instruction
+	}
+	return cfg.instruction
+}
+
+// EmbedTexts 统一的 Embedding 接口，将文本列表编码为向量
+// instruction 参数：对于支持 instruction 的模型会拼接到文本前面，不支持的静默忽略
+// 返回 [][]float64 以便后续余弦相似度计算
+func EmbedTexts(ctx context.Context, texts []string, instruction string) ([][]float64, error) {
+	cfg, err := loadEmbeddingConfig()
+	if err != nil {
+		return nil, fmt.Errorf("failed to load embedding config: %w", err)
+	}
+
+	// 解析最终生效的 instruction（调用方传入优先，为空时 fallback 到全局配置）
+	effectiveInstruction := resolveInstruction(instruction, cfg)
+
+	processedTexts := texts
+	if effectiveInstruction != "" {
+		processedTexts = make([]string, len(texts))
+		for i, t := range texts {
+			processedTexts[i] = effectiveInstruction + ": " + t
+		}
+	}
+
+	embedder, embedErr := getOrCreateEmbedder(cfg)
+	if embedErr != nil {
+		return nil, fmt.Errorf("failed to get embedder: %w", embedErr)
+	}
+
+	// 全局超时预算：所有批次和重试在此预算内执行，避免总耗时无限增长
+	// 如果调用方已传入带 deadline 的 context，WithTimeout 会取两者中较短的那个
+	totalCtx, totalCancel := context.WithTimeout(ctx, embeddingTotalTimeout)
+	defer totalCancel()
+
+	// 分批处理：将大批量文本拆分为小批次，逐批调用 Embedding 服务
+	// 避免一次性发送过多文本导致本地模型（如 Ollama）OOM 崩溃或超时
+	batchSize := cfg.batchSize
+	allResults := make([][]float64, len(processedTexts))
+
+	for batchStart := 0; batchStart < len(processedTexts); batchStart += batchSize {
+		batchEnd := batchStart + batchSize
+		if batchEnd > len(processedTexts) {
+			batchEnd = len(processedTexts)
+		}
+		batch := processedTexts[batchStart:batchEnd]
+
+		logrus.Debugf("Embedding batch [%d-%d] of %d texts", batchStart, batchEnd-1, len(processedTexts))
+
+		// 带重试的 Embedding 调用，绑定全局超时 Context 以尊重取消信号
+		var result32 [][]float32
+		result32, err = retry.DoWithData(
+			func() ([][]float32, error) {
+				callCtx, cancel := context.WithTimeout(totalCtx, embeddingCallTimeout)
+				defer cancel()
+				return embedder.EmbedDocuments(callCtx, batch)
+			},
+			retry.Context(totalCtx),
+			retry.Attempts(3),
+			retry.DelayType(retry.BackOffDelay),
+			retry.Delay(1*time.Second),
+			retry.MaxDelay(5*time.Second),
+			retry.OnRetry(func(n uint, err error) {
+				logrus.Warnf("Retrying embedding call (attempt %d), batch [%d-%d], err: %v", n+1, batchStart, batchEnd-1, err)
+			}),
+		)
+		if err != nil {
+			return nil, fmt.Errorf("embedding call failed after retries (batch [%d-%d]): %w", batchStart, batchEnd-1, err)
+		}
+
+		// 将 float32 转换为 float64（余弦相似度计算使用 float64 精度更高）
+		for i, vec32 := range result32 {
+			vec64 := make([]float64, len(vec32))
+			for j, v := range vec32 {
+				vec64[j] = float64(v)
+			}
+			allResults[batchStart+i] = vec64
+		}
+	}
+
+	return allResults, nil
+}
+
+// GetOrComputeAnchorVectors 获取或计算锚点向量（带内存缓存）
+// 缓存键 = MD5(锚点文本) + "|" + 模型名称
+// 惰性加载：系统重启后首次使用时重新计算
+func GetOrComputeAnchorVectors(ctx context.Context, anchors []string, instruction string) ([][]float64, error) {
+	if len(anchors) == 0 {
+		return nil, nil
+	}
+
+	cfg, err := loadEmbeddingConfig()
+	if err != nil {
+		return nil, fmt.Errorf("failed to load embedding config: %w", err)
+	}
+	modelName := cfg.apiModel
+	// 使用 resolveInstruction 解析最终生效的 instruction，确保缓存 key 与 EmbedTexts 实际使用的一致
+	effectiveInstruction := resolveInstruction(instruction, cfg)
+	instructionHash := util.GetMD5Hash(effectiveInstruction)
+
+	// 检查哪些锚点已缓存，哪些需要计算
+	result := make([][]float64, len(anchors))
+	var uncachedIndices []int
+	var uncachedTexts []string
+
+	for i, anchor := range anchors {
+		cacheKey := fmt.Sprintf("anchor|%s|%s|%s", util.GetMD5Hash(anchor), modelName, instructionHash)
+		if cached, ok := anchorVectorCache.Load(cacheKey); ok {
+			result[i] = cached.([]float64)
+		} else {
+			uncachedIndices = append(uncachedIndices, i)
+			uncachedTexts = append(uncachedTexts, anchor)
+		}
+	}
+
+	// 如果所有锚点都已缓存，直接返回
+	if len(uncachedTexts) == 0 {
+		logrus.Debugf("All %d anchor vectors found in cache", len(anchors))
+		return result, nil
+	}
+
+	logrus.Infof("Computing embeddings for %d uncached anchors (out of %d total)", len(uncachedTexts), len(anchors))
+
+	// 批量计算未缓存的锚点向量
+	newVectors, err := EmbedTexts(ctx, uncachedTexts, instruction)
+	if err != nil {
+		return nil, fmt.Errorf("failed to compute anchor vectors: %w", err)
+	}
+
+	// 越界防御：检查返回的向量数量是否与请求数量一致
+	if len(newVectors) != len(uncachedTexts) {
+		return nil, fmt.Errorf("embedding returned %d vectors, expected %d", len(newVectors), len(uncachedTexts))
+	}
+
+	// 将新计算的向量写入缓存和结果
+	for j, idx := range uncachedIndices {
+		cacheKey := fmt.Sprintf("anchor|%s|%s|%s", util.GetMD5Hash(anchors[idx]), modelName, instructionHash)
+		anchorVectorCache.Store(cacheKey, newVectors[j])
+		result[idx] = newVectors[j]
+	}
+
+	logrus.Infof("Anchor vector computation complete. Cached %d new vectors.", len(uncachedTexts))
+	return result, nil
+}

--- a/internal/adapter/embedding_test.go
+++ b/internal/adapter/embedding_test.go
@@ -1,0 +1,192 @@
+package adapter
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// --- loadEmbeddingConfig 测试 ---
+
+func TestLoadEmbeddingConfig_Defaults(t *testing.T) {
+	cfg, err := loadEmbeddingConfig()
+	assert.NoError(t, err)
+	// 默认 apiType 应为 "openai"
+	assert.Equal(t, "openai", cfg.apiType)
+	// 默认模型应为 defaultEmbeddingModel
+	assert.Equal(t, defaultEmbeddingModel, cfg.apiModel)
+}
+
+func TestLoadEmbeddingConfig_ApiTypeDefault(t *testing.T) {
+	cfg, err := loadEmbeddingConfig()
+	assert.NoError(t, err)
+	// 未设置 FC_EMBEDDING_API_TYPE 时应默认为 "openai"
+	assert.Equal(t, "openai", cfg.apiType)
+}
+
+func TestLoadEmbeddingConfig_ReturnsNoFatal(t *testing.T) {
+	// 确保 loadEmbeddingConfig 不会 panic 或 fatal
+	cfg, err := loadEmbeddingConfig()
+	assert.NoError(t, err)
+	assert.NotEmpty(t, cfg.apiType)
+}
+
+// --- getOrCreateEmbedder 测试 ---
+
+func TestGetOrCreateEmbedder_OllamaWithoutBase(t *testing.T) {
+	cfg := embeddingConfig{
+		apiType:  "ollama",
+		apiBase:  "",
+		apiKey:   "",
+		apiModel: "nomic-embed-text",
+	}
+	_, err := getOrCreateEmbedder(cfg)
+	assert.Error(t, err, "ollama without apiBase should return error")
+	assert.Contains(t, err.Error(), "FC_EMBEDDING_API_BASE")
+}
+
+func TestGetOrCreateEmbedder_OpenAIDefault(t *testing.T) {
+	cfg := embeddingConfig{
+		apiType:  "openai",
+		apiBase:  "",
+		apiKey:   "test-key",
+		apiModel: "text-embedding-3-small",
+	}
+	embedder, err := getOrCreateEmbedder(cfg)
+	assert.NoError(t, err)
+	assert.NotNil(t, embedder)
+}
+
+func TestGetOrCreateEmbedder_GeminiType(t *testing.T) {
+	cfg := embeddingConfig{
+		apiType:  "gemini",
+		apiBase:  "https://generativelanguage.googleapis.com/v1beta/openai/",
+		apiKey:   "test-key",
+		apiModel: "gemini-embedding-001",
+	}
+	embedder, err := getOrCreateEmbedder(cfg)
+	assert.NoError(t, err)
+	assert.NotNil(t, embedder)
+}
+
+func TestGetOrCreateEmbedder_ClientCaching(t *testing.T) {
+	cfg := embeddingConfig{
+		apiType:  "openai",
+		apiBase:  "https://test.example.com/v1",
+		apiKey:   "cache-test-key",
+		apiModel: "text-embedding-3-small",
+	}
+
+	// 第一次创建
+	embedder1, err := getOrCreateEmbedder(cfg)
+	assert.NoError(t, err)
+	assert.NotNil(t, embedder1)
+
+	// 第二次应该从缓存获取（同一个实例）
+	embedder2, err := getOrCreateEmbedder(cfg)
+	assert.NoError(t, err)
+	assert.Equal(t, embedder1, embedder2, "should return cached embedder instance")
+}
+
+// --- API Key 校验测试 ---
+
+func TestGetOrCreateEmbedder_OpenAIEmptyApiKey(t *testing.T) {
+	cfg := embeddingConfig{
+		apiType:  "openai",
+		apiBase:  "https://api.openai.com/v1",
+		apiKey:   "",
+		apiModel: "text-embedding-3-small",
+	}
+	_, err := getOrCreateEmbedder(cfg)
+	assert.Error(t, err, "openai with empty apiKey should return error")
+	assert.Contains(t, err.Error(), "FC_EMBEDDING_API_KEY")
+}
+
+func TestGetOrCreateEmbedder_GeminiEmptyApiKey(t *testing.T) {
+	cfg := embeddingConfig{
+		apiType:  "gemini",
+		apiBase:  "https://generativelanguage.googleapis.com/v1beta/openai/",
+		apiKey:   "",
+		apiModel: "gemini-embedding-001",
+	}
+	_, err := getOrCreateEmbedder(cfg)
+	assert.Error(t, err, "gemini with empty apiKey should return error")
+	assert.Contains(t, err.Error(), "FC_EMBEDDING_API_KEY")
+}
+
+func TestGetOrCreateEmbedder_OllamaNoApiKeyRequired(t *testing.T) {
+	cfg := embeddingConfig{
+		apiType:  "ollama",
+		apiBase:  "http://localhost:11434",
+		apiKey:   "",
+		apiModel: "bge-m3",
+	}
+	embedder, err := getOrCreateEmbedder(cfg)
+	assert.NoError(t, err, "ollama should not require apiKey")
+	assert.NotNil(t, embedder)
+}
+
+// --- Gemini apiBase 校验测试（需求 3）---
+
+func TestGetOrCreateEmbedder_GeminiEmptyApiBase(t *testing.T) {
+	cfg := embeddingConfig{
+		apiType:  "gemini",
+		apiBase:  "",
+		apiKey:   "test-key",
+		apiModel: "gemini-embedding-001",
+	}
+	_, err := getOrCreateEmbedder(cfg)
+	assert.Error(t, err, "gemini with empty apiBase should return error")
+	assert.Contains(t, err.Error(), "FC_EMBEDDING_API_BASE")
+	assert.Contains(t, err.Error(), "gemini")
+}
+
+// --- 默认模型逻辑测试（需求 4）---
+
+func TestLoadEmbeddingConfig_OllamaEmptyModel(t *testing.T) {
+	// 设置环境变量模拟 ollama 类型但不设模型
+	t.Setenv("FC_EMBEDDING_API_TYPE", "ollama")
+	t.Setenv("FC_EMBEDDING_API_BASE", "http://localhost:11434")
+	t.Setenv("FC_EMBEDDING_API_MODEL", "")
+	_, err := loadEmbeddingConfig()
+	assert.Error(t, err, "ollama with empty model should return error")
+	assert.Contains(t, err.Error(), "FC_EMBEDDING_API_MODEL")
+}
+
+func TestLoadEmbeddingConfig_GeminiEmptyModel(t *testing.T) {
+	t.Setenv("FC_EMBEDDING_API_TYPE", "gemini")
+	t.Setenv("FC_EMBEDDING_API_BASE", "https://generativelanguage.googleapis.com/v1beta/openai/")
+	t.Setenv("FC_EMBEDDING_API_KEY", "test-key")
+	t.Setenv("FC_EMBEDDING_API_MODEL", "")
+	_, err := loadEmbeddingConfig()
+	assert.Error(t, err, "gemini with empty model should return error")
+	assert.Contains(t, err.Error(), "FC_EMBEDDING_API_MODEL")
+}
+
+func TestLoadEmbeddingConfig_OpenAIDefaultModel(t *testing.T) {
+	t.Setenv("FC_EMBEDDING_API_TYPE", "openai")
+	t.Setenv("FC_EMBEDDING_API_MODEL", "")
+	cfg, err := loadEmbeddingConfig()
+	assert.NoError(t, err)
+	assert.Equal(t, defaultEmbeddingModel, cfg.apiModel, "openai should use default model when not set")
+}
+
+// --- resolveInstruction 测试（需求 1）---
+
+func TestResolveInstruction_ExplicitInstruction(t *testing.T) {
+	cfg := embeddingConfig{instruction: "global_instruction"}
+	result := resolveInstruction("explicit_instruction", cfg)
+	assert.Equal(t, "explicit_instruction", result, "explicit instruction should take priority")
+}
+
+func TestResolveInstruction_FallbackToGlobal(t *testing.T) {
+	cfg := embeddingConfig{instruction: "global_instruction"}
+	result := resolveInstruction("", cfg)
+	assert.Equal(t, "global_instruction", result, "should fallback to global instruction when empty")
+}
+
+func TestResolveInstruction_BothEmpty(t *testing.T) {
+	cfg := embeddingConfig{instruction: ""}
+	result := resolveInstruction("", cfg)
+	assert.Equal(t, "", result, "should return empty when both are empty")
+}

--- a/internal/controller/feed_viewer.go
+++ b/internal/controller/feed_viewer.go
@@ -57,7 +57,7 @@ func PreviewFeedViewer(c *gin.Context) {
 	}
 
 	if err := validateFeedViewerURL(req.InputURL); err != nil {
-		c.JSON(http.StatusBadRequest, util.APIResponse[any]{StatusCode: -1, Msg: err.Error()})
+		c.JSON(http.StatusBadRequest, util.APIResponse[any]{StatusCode: -1, Msg: formatFeedViewerValidationError(err)})
 		return
 	}
 
@@ -189,6 +189,17 @@ func formatFeedViewerISOTime(primary, fallback time.Time) string {
 	return ""
 }
 
+func formatFeedViewerValidationError(err error) string {
+	if err == nil {
+		return ""
+	}
+	msg := err.Error()
+	if msg == "" {
+		return ""
+	}
+	return strings.ToUpper(msg[:1]) + msg[1:]
+}
+
 func validateFeedViewerURL(rawURL string) error {
 	parsedURL, err := url.Parse(rawURL)
 	if err != nil || parsedURL == nil {
@@ -217,17 +228,18 @@ func validateFeedViewerURL(rawURL string) error {
 func classifyFeedViewerError(err error) (int, string) {
 	msg := err.Error()
 	msg = strings.TrimPrefix(msg, "all items failed to process. last error: ")
+	lowerMsg := strings.ToLower(msg)
 
 	switch {
-	case strings.Contains(msg, "browserless service returned status"):
+	case strings.Contains(lowerMsg, "browserless service returned status"):
 		return http.StatusOK, humanizeBrowserlessStatus(msg)
-	case strings.Contains(msg, "http status not ok:"):
+	case strings.Contains(lowerMsg, "http status not ok:"):
 		return http.StatusOK, humanizeFeedViewerHTTPStatus(msg)
-	case strings.Contains(msg, "http get failed:"), strings.Contains(msg, "browserless fetch failed:"), strings.Contains(msg, "failed to read response body:"), strings.Contains(msg, "Unable to resolve this URL"):
+	case strings.Contains(lowerMsg, "http get failed:"), strings.Contains(lowerMsg, "browserless fetch failed:"), strings.Contains(lowerMsg, "failed to read response body:"), strings.Contains(lowerMsg, "unable to resolve this url"):
 		return http.StatusOK, "Unable to fetch this URL. Please check the address and try again."
-	case strings.Contains(msg, "parse failed:"), strings.Contains(msg, "invalid XML"):
+	case strings.Contains(lowerMsg, "parse failed:"), strings.Contains(lowerMsg, "invalid xml"):
 		return http.StatusOK, "The URL is reachable, but it does not appear to be a valid RSS or Atom feed."
-	case strings.Contains(msg, "not a valid craft name"):
+	case strings.Contains(lowerMsg, "not a valid craft name"):
 		return http.StatusBadRequest, "Please select a valid craft before comparing feeds."
 	default:
 		return http.StatusInternalServerError, "Failed to preview this feed due to an internal error."

--- a/internal/controller/feed_viewer.go
+++ b/internal/controller/feed_viewer.go
@@ -192,22 +192,22 @@ func formatFeedViewerISOTime(primary, fallback time.Time) string {
 func validateFeedViewerURL(rawURL string) error {
 	parsedURL, err := url.Parse(rawURL)
 	if err != nil || parsedURL == nil {
-		return errors.New("Please enter a valid http(s) feed URL")
+		return errors.New("please enter a valid http(s) feed URL")
 	}
 	if parsedURL.Scheme != "http" && parsedURL.Scheme != "https" {
-		return errors.New("Please enter a valid http(s) feed URL")
+		return errors.New("please enter a valid http(s) feed URL")
 	}
 	if parsedURL.Hostname() == "" {
-		return errors.New("Please enter a valid http(s) feed URL")
+		return errors.New("please enter a valid http(s) feed URL")
 	}
 
 	ips, err := net.LookupIP(parsedURL.Hostname())
 	if err != nil {
-		return fmt.Errorf("Unable to resolve this URL: %w", err)
+		return fmt.Errorf("unable to resolve this URL: %w", err)
 	}
 	for _, ip := range ips {
 		if ip.IsLoopback() || ip.IsPrivate() {
-			return fmt.Errorf("Access to private IP %s is forbidden", ip.String())
+			return fmt.Errorf("access to private IP %s is forbidden", ip.String())
 		}
 	}
 

--- a/internal/controller/feed_viewer_test.go
+++ b/internal/controller/feed_viewer_test.go
@@ -1,0 +1,47 @@
+package controller
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+)
+
+func TestFormatFeedViewerValidationErrorPreservesUserFacingCapitalization(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{
+			name: "invalid URL",
+			err:  errors.New("please enter a valid http(s) feed URL"),
+			want: "Please enter a valid http(s) feed URL",
+		},
+		{
+			name: "private IP",
+			err:  errors.New("access to private IP 127.0.0.1 is forbidden"),
+			want: "Access to private IP 127.0.0.1 is forbidden",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := formatFeedViewerValidationError(tt.err)
+			if got != tt.want {
+				t.Fatalf("formatFeedViewerValidationError() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestClassifyFeedViewerErrorHandlesLowercaseResolveMessage(t *testing.T) {
+	status, msg := classifyFeedViewerError(errors.New("unable to resolve this URL: lookup example.invalid: no such host"))
+
+	if status != http.StatusOK {
+		t.Fatalf("status = %d, want %d", status, http.StatusOK)
+	}
+	const want = "Unable to fetch this URL. Please check the address and try again."
+	if msg != want {
+		t.Fatalf("msg = %q, want %q", msg, want)
+	}
+}

--- a/internal/craft/embedding_filter.go
+++ b/internal/craft/embedding_filter.go
@@ -1,0 +1,290 @@
+package craft
+
+import (
+	"FeedCraft/internal/adapter"
+	"FeedCraft/internal/util"
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/gorilla/feeds"
+	"github.com/samber/lo"
+	"github.com/sirupsen/logrus"
+)
+
+/*
+ * Embedding 零样本分类主题过滤器
+ * 通过将文章和预设的"课题锚点"分别编码为向量，利用余弦相似度进行语义级别的主题匹配。
+ * 文章与任一锚点的相似度超过阈值即被保留，否则丢弃。
+ */
+
+const (
+	defaultEmbeddingThreshold = 0.6
+	defaultMaxContentLength   = 2000
+)
+
+// EmbeddingFilterMode 定义 Embedding 过滤器的工作模式
+type EmbeddingFilterMode string
+
+var (
+	EmbeddingIncludeMode EmbeddingFilterMode = "include" // 匹配锚点的文章被保留（默认）
+	EmbeddingExcludeMode EmbeddingFilterMode = "exclude" // 匹配锚点的文章被移除（反选）
+)
+
+// OptionEmbeddingFilter 创建 Embedding 主题过滤器的 CraftOption
+// anchors: 锚点文本列表
+// threshold: 余弦相似度阈值
+// maxContentLen: 文章正文最大截取长度
+// instruction: 传递给 Embedding 模型的 instruction 参数
+// mode: include（匹配即保留，默认）或 exclude（匹配即移除，反选）
+func OptionEmbeddingFilter(anchors []string, threshold float64, maxContentLen int, instruction string, mode EmbeddingFilterMode) CraftOption {
+	return func(feed *feeds.Feed, payload ExtraPayload) error {
+		items := feed.Items
+		if len(items) == 0 {
+			return nil
+		}
+
+		// 0. 阈值 clamp：将 threshold 钳制到 [0, 1] 范围
+		if threshold < 0 {
+			logrus.Warnf("[embedding-filter] threshold %.4f is below 0, clamping to 0", threshold)
+			threshold = 0
+		}
+		if threshold > 1 {
+			logrus.Warnf("[embedding-filter] threshold %.4f is above 1, clamping to 1", threshold)
+			threshold = 1
+		}
+
+		// 1. 校验锚点
+		if len(anchors) == 0 {
+			logrus.Warn("[embedding-filter] anchors list is empty, skipping filter (returning all items)")
+			return nil
+		}
+
+		ctx := context.Background()
+
+		// 2. 获取或计算锚点向量（带内存缓存）
+		anchorVectors, err := adapter.GetOrComputeAnchorVectors(ctx, anchors, instruction)
+		if err != nil {
+			return fmt.Errorf("[embedding-filter] failed to compute anchor vectors: %w", err)
+		}
+
+		// 3. 收集所有文章文本，批量调用 Embedding
+		texts := make([]string, len(items))
+		for i, item := range items {
+			texts[i] = buildArticleText(item, maxContentLen)
+		}
+
+		// 过滤掉空文本的索引，记录有效文本的映射
+		var validTexts []string
+		var validIndices []int
+		// emptyTextSet 记录空文本文章的索引，用于区分"空文本保留"和"计算失败保留"
+		emptyTextSet := make(map[int]bool)
+		for i, text := range texts {
+			if len(strings.TrimSpace(text)) > 0 {
+				validTexts = append(validTexts, text)
+				validIndices = append(validIndices, i)
+			} else {
+				emptyTextSet[i] = true
+			}
+		}
+
+		// 批量计算文章向量
+		articleVectors := make([][]float64, len(items)) // nil 表示未计算
+		var embedErr error
+		if len(validTexts) > 0 {
+			vectors, batchErr := adapter.EmbedTexts(ctx, validTexts, instruction)
+			if batchErr != nil {
+				embedErr = batchErr
+				logrus.Errorf("[embedding-filter] batch embedding failed: %v", batchErr)
+			} else {
+				// 检查返回的向量数量是否与请求数量一致
+				if len(vectors) < len(validTexts) {
+					logrus.Warnf("[embedding-filter] embedding returned %d vectors for %d texts, some articles may not be properly filtered", len(vectors), len(validTexts))
+				}
+				for j, idx := range validIndices {
+					if j < len(vectors) {
+						articleVectors[idx] = vectors[j]
+					}
+				}
+			}
+		}
+
+		// 4. 如果批量 Embedding 全部失败，返回错误
+		if embedErr != nil {
+			return fmt.Errorf("[embedding-filter] all article embeddings failed: %w", embedErr)
+		}
+
+		// 5. 根据相似度过滤
+		totalCount := len(items)
+		feed.Items = lo.Filter(items, func(item *feeds.Item, index int) bool {
+			vec := articleVectors[index]
+
+			// 向量为 nil 时区分原因
+			if vec == nil {
+				if emptyTextSet[index] {
+					// 空文本文章：保留（行为不变）
+					return true
+				}
+				// 有效文本但向量计算失败：保留但记录警告
+				logrus.Warnf("[embedding-filter] article [%s] has valid text but nil vector (embedding failed), keeping by default", item.Title)
+				return true
+			}
+
+			// 与所有锚点计算相似度，任一超过阈值即保留
+			maxSim := -1.0
+			for _, anchorVec := range anchorVectors {
+				sim := util.CosineSimilarity(vec, anchorVec)
+				if sim > maxSim {
+					maxSim = sim
+				}
+			}
+
+			matched := maxSim >= threshold
+
+			// 根据 mode 决定保留逻辑
+			var keep bool
+			switch mode {
+			case EmbeddingExcludeMode:
+				keep = !matched // 反选：匹配的移除，不匹配的保留
+			default: // include
+				keep = matched // 选中：匹配的保留，不匹配的移除
+			}
+
+			if keep {
+				logrus.Debugf("[embedding-filter] article [%s] KEPT (max similarity: %.4f, threshold: %.4f, mode: %s)", item.Title, maxSim, threshold, mode)
+			} else {
+				logrus.Debugf("[embedding-filter] article [%s] DROPPED (max similarity: %.4f, threshold: %.4f, mode: %s)", item.Title, maxSim, threshold, mode)
+			}
+			return keep
+		})
+
+		keptCount := len(feed.Items)
+		droppedCount := totalCount - keptCount
+		logrus.Infof("[embedding-filter] filtering complete: %d total, %d kept, %d dropped (threshold: %.4f, mode: %s)", totalCount, keptCount, droppedCount, threshold, mode)
+
+		return nil
+	}
+}
+
+// buildArticleText 拼接文章标题和正文，正文超过 maxLen 时按 Unicode 字符截取
+func buildArticleText(item *feeds.Item, maxLen int) string {
+	content := item.Content
+	if len(content) == 0 {
+		content = item.Description
+	}
+
+	// 按 Unicode 字符（rune）截取正文，避免切断多字节字符
+	if utf8.RuneCountInString(content) > maxLen {
+		runes := []rune(content)
+		content = string(runes[:maxLen])
+	}
+
+	if item.Title != "" && content != "" {
+		return item.Title + "\n" + content
+	}
+	if item.Title != "" {
+		return item.Title
+	}
+	return content
+}
+
+// GetEmbeddingFilterOptions 返回 Embedding 过滤器的 CraftOption 列表
+func GetEmbeddingFilterOptions(anchors []string, threshold float64, maxContentLen int, instruction string, mode EmbeddingFilterMode) []CraftOption {
+	return []CraftOption{
+		OptionEmbeddingFilter(anchors, threshold, maxContentLen, instruction, mode),
+	}
+}
+
+// --- CraftTemplate 参数定义 ---
+
+var embeddingFilterParamTmpl = []ParamTemplate{
+	{
+		Key:         "anchors",
+		Description: "自然语言描述的主题锚点文本，每行一条。文章与任一锚点相似度超过阈值即被视为匹配。",
+		Default:     "",
+	},
+	{
+		Key:         "threshold",
+		Description: "余弦相似度阈值（0-1），越高越严格。默认 0.6。",
+		Default:     "0.6",
+	},
+	{
+		Key:         "mode",
+		Description: "过滤模式：include（保留匹配项，默认）或 exclude（移除匹配项，反选）。",
+		Default:     "include",
+	},
+	{
+		Key:         "max_content_length",
+		Description: "文章正文截取的最大字符数，用于控制 Embedding 输入长度。默认 2000。",
+		Default:     "2000",
+	},
+	{
+		Key:         "instruction",
+		Description: "传递给 Embedding 模型的 instruction 参数（如果模型支持）。留空则使用全局配置。",
+		Default:     "",
+	},
+}
+
+// embeddingFilterLoadParam 从参数 map 加载 Embedding 过滤器配置
+func embeddingFilterLoadParam(m map[string]string) []CraftOption {
+	// 解析锚点文本（换行分隔）
+	anchorsStr := m["anchors"]
+	if anchorsStr == "" {
+		logrus.Warn("[embedding-filter] anchors parameter is empty")
+		return []CraftOption{}
+	}
+	rawAnchors := strings.Split(anchorsStr, "\n")
+	var anchors []string
+	for _, a := range rawAnchors {
+		a = strings.TrimSpace(a)
+		if a != "" {
+			anchors = append(anchors, a)
+		}
+	}
+	if len(anchors) == 0 {
+		logrus.Warn("[embedding-filter] no valid anchors after parsing")
+		return []CraftOption{}
+	}
+
+	// 解析阈值
+	threshold := defaultEmbeddingThreshold
+	if thresholdStr, ok := m["threshold"]; ok && thresholdStr != "" {
+		parsed, err := strconv.ParseFloat(thresholdStr, 64)
+		if err != nil || parsed < 0 || parsed > 1 {
+			logrus.Warnf("[embedding-filter] invalid threshold value [%s], using default %.2f", thresholdStr, defaultEmbeddingThreshold)
+		} else {
+			threshold = parsed
+		}
+	}
+
+	// 解析最大内容长度
+	maxContentLen := defaultMaxContentLength
+	if maxLenStr, ok := m["max_content_length"]; ok && maxLenStr != "" {
+		parsed, err := strconv.Atoi(maxLenStr)
+		if err != nil || parsed <= 0 {
+			logrus.Warnf("[embedding-filter] invalid max_content_length value [%s], using default %d", maxLenStr, defaultMaxContentLength)
+		} else {
+			maxContentLen = parsed
+		}
+	}
+
+	// 解析过滤模式
+	mode := EmbeddingIncludeMode
+	if modeStr, ok := m["mode"]; ok && modeStr != "" {
+		switch strings.ToLower(strings.TrimSpace(modeStr)) {
+		case "exclude":
+			mode = EmbeddingExcludeMode
+		case "include":
+			mode = EmbeddingIncludeMode
+		default:
+			logrus.Warnf("[embedding-filter] unknown mode [%s], using default 'include'", modeStr)
+		}
+	}
+
+	// 解析 instruction
+	instruction := m["instruction"]
+
+	return GetEmbeddingFilterOptions(anchors, threshold, maxContentLen, instruction, mode)
+}

--- a/internal/craft/embedding_filter_test.go
+++ b/internal/craft/embedding_filter_test.go
@@ -1,0 +1,344 @@
+package craft
+
+import (
+	"testing"
+	"unicode/utf8"
+
+	"github.com/gorilla/feeds"
+	"github.com/stretchr/testify/assert"
+)
+
+// --- 参数解析测试 ---
+
+func TestEmbeddingFilterLoadParam_EmptyAnchors(t *testing.T) {
+	params := map[string]string{
+		"anchors": "",
+	}
+	options := embeddingFilterLoadParam(params)
+	assert.Empty(t, options, "empty anchors should return no options")
+}
+
+func TestEmbeddingFilterLoadParam_ValidAnchors(t *testing.T) {
+	params := map[string]string{
+		"anchors":   "人工智能\n机器学习\n深度学习",
+		"threshold": "0.7",
+	}
+	options := embeddingFilterLoadParam(params)
+	assert.Len(t, options, 1, "should return exactly one CraftOption")
+}
+
+func TestEmbeddingFilterLoadParam_AnchorsWithBlankLines(t *testing.T) {
+	params := map[string]string{
+		"anchors": "人工智能\n\n  \n机器学习\n",
+	}
+	options := embeddingFilterLoadParam(params)
+	assert.Len(t, options, 1, "blank lines should be filtered out, valid anchors remain")
+}
+
+func TestEmbeddingFilterLoadParam_InvalidThreshold(t *testing.T) {
+	params := map[string]string{
+		"anchors":   "test anchor",
+		"threshold": "invalid",
+	}
+	options := embeddingFilterLoadParam(params)
+	assert.Len(t, options, 1, "invalid threshold should fallback to default, still return option")
+}
+
+func TestEmbeddingFilterLoadParam_ThresholdOutOfRange(t *testing.T) {
+	params := map[string]string{
+		"anchors":   "test anchor",
+		"threshold": "1.5",
+	}
+	options := embeddingFilterLoadParam(params)
+	assert.Len(t, options, 1, "out-of-range threshold should fallback to default")
+}
+
+func TestEmbeddingFilterLoadParam_NegativeThreshold(t *testing.T) {
+	params := map[string]string{
+		"anchors":   "test anchor",
+		"threshold": "-0.1",
+	}
+	options := embeddingFilterLoadParam(params)
+	assert.Len(t, options, 1, "negative threshold should fallback to default")
+}
+
+func TestEmbeddingFilterLoadParam_DefaultValues(t *testing.T) {
+	params := map[string]string{
+		"anchors": "test anchor",
+	}
+	options := embeddingFilterLoadParam(params)
+	assert.Len(t, options, 1, "should use default threshold and max_content_length")
+}
+
+func TestEmbeddingFilterLoadParam_InvalidMaxContentLength(t *testing.T) {
+	params := map[string]string{
+		"anchors":            "test anchor",
+		"max_content_length": "abc",
+	}
+	options := embeddingFilterLoadParam(params)
+	assert.Len(t, options, 1, "invalid max_content_length should fallback to default")
+}
+
+func TestEmbeddingFilterLoadParam_ZeroMaxContentLength(t *testing.T) {
+	params := map[string]string{
+		"anchors":            "test anchor",
+		"max_content_length": "0",
+	}
+	options := embeddingFilterLoadParam(params)
+	assert.Len(t, options, 1, "zero max_content_length should fallback to default")
+}
+
+// --- buildArticleText 测试 ---
+
+func TestBuildArticleText_TitleAndContent(t *testing.T) {
+	item := &feeds.Item{
+		Title:   "Test Title",
+		Content: "Test Content Body",
+	}
+	result := buildArticleText(item, 2000)
+	assert.Equal(t, "Test Title\nTest Content Body", result)
+}
+
+func TestBuildArticleText_TitleOnly(t *testing.T) {
+	item := &feeds.Item{
+		Title: "Test Title",
+	}
+	result := buildArticleText(item, 2000)
+	assert.Equal(t, "Test Title", result)
+}
+
+func TestBuildArticleText_ContentOnly(t *testing.T) {
+	item := &feeds.Item{
+		Content: "Test Content Body",
+	}
+	result := buildArticleText(item, 2000)
+	assert.Equal(t, "Test Content Body", result)
+}
+
+func TestBuildArticleText_FallbackToDescription(t *testing.T) {
+	item := &feeds.Item{
+		Title:       "Test Title",
+		Description: "Test Description",
+	}
+	result := buildArticleText(item, 2000)
+	assert.Equal(t, "Test Title\nTest Description", result)
+}
+
+func TestBuildArticleText_ContentTruncation(t *testing.T) {
+	longContent := ""
+	for i := 0; i < 300; i++ {
+		longContent += "abcdefghij" // 3000 chars total
+	}
+	item := &feeds.Item{
+		Title:   "Title",
+		Content: longContent,
+	}
+	result := buildArticleText(item, 100)
+	// 标题 + "\n" + 截取后的100字符（ASCII 字符 rune 和 byte 长度一致）
+	assert.Equal(t, "Title\n"+longContent[:100], result)
+}
+
+func TestBuildArticleText_EmptyItem(t *testing.T) {
+	item := &feeds.Item{}
+	result := buildArticleText(item, 2000)
+	assert.Equal(t, "", result)
+}
+
+// --- UTF-8 安全截断测试 ---
+
+func TestBuildArticleText_ChineseTruncation(t *testing.T) {
+	// 中文字符每个占 3 字节，按 rune 截断应保证完整字符
+	chineseContent := "这是一段中文测试内容用于验证截断功能是否正确处理多字节字符"
+	item := &feeds.Item{
+		Content: chineseContent,
+	}
+	result := buildArticleText(item, 5)
+	// 应截取前 5 个 Unicode 字符
+	assert.Equal(t, "这是一段中", result)
+	assert.True(t, utf8.ValidString(result), "truncated string should be valid UTF-8")
+}
+
+func TestBuildArticleText_EmojiTruncation(t *testing.T) {
+	// Emoji 字符占 4 字节，按 rune 截断应保证完整字符
+	emojiContent := "🎉🎊🎈🎁🎄🎃🎆🎇"
+	item := &feeds.Item{
+		Content: emojiContent,
+	}
+	result := buildArticleText(item, 3)
+	assert.Equal(t, "🎉🎊🎈", result)
+	assert.True(t, utf8.ValidString(result), "truncated emoji string should be valid UTF-8")
+}
+
+func TestBuildArticleText_MixedUTF8Truncation(t *testing.T) {
+	// 混合 ASCII + 中文 + Emoji
+	mixedContent := "Hi你好🎉World世界"
+	item := &feeds.Item{
+		Content: mixedContent,
+	}
+	result := buildArticleText(item, 6)
+	// 前 6 个 rune: H, i, 你, 好, 🎉, W
+	assert.Equal(t, "Hi你好🎉W", result)
+	assert.True(t, utf8.ValidString(result), "truncated mixed string should be valid UTF-8")
+}
+
+// --- OptionEmbeddingFilter 边界测试 ---
+
+func TestOptionEmbeddingFilter_EmptyItems(t *testing.T) {
+	option := OptionEmbeddingFilter([]string{"test"}, 0.6, 2000, "", EmbeddingIncludeMode)
+	feed := &feeds.Feed{Items: []*feeds.Item{}}
+	err := option(feed, ExtraPayload{})
+	assert.NoError(t, err)
+	assert.Empty(t, feed.Items)
+}
+
+func TestOptionEmbeddingFilter_EmptyAnchors(t *testing.T) {
+	option := OptionEmbeddingFilter([]string{}, 0.6, 2000, "", EmbeddingIncludeMode)
+	feed := &feeds.Feed{
+		Items: []*feeds.Item{
+			{Title: "Article 1", Content: "Content 1"},
+			{Title: "Article 2", Content: "Content 2"},
+		},
+	}
+	err := option(feed, ExtraPayload{})
+	assert.NoError(t, err)
+	// 锚点为空时不过滤，保留所有文章
+	assert.Len(t, feed.Items, 2)
+}
+
+// --- 阈值 clamp 测试（需求 9）---
+
+func TestOptionEmbeddingFilter_ThresholdClampBelowZero(t *testing.T) {
+	// 阈值 < 0 应被钳制为 0，不应 panic
+	option := OptionEmbeddingFilter([]string{"test"}, -0.5, 2000, "", EmbeddingIncludeMode)
+	feed := &feeds.Feed{Items: []*feeds.Item{}}
+	err := option(feed, ExtraPayload{})
+	assert.NoError(t, err)
+}
+
+func TestOptionEmbeddingFilter_ThresholdClampAboveOne(t *testing.T) {
+	// 阈值 > 1 应被钳制为 1，不应 panic
+	option := OptionEmbeddingFilter([]string{"test"}, 1.5, 2000, "", EmbeddingIncludeMode)
+	feed := &feeds.Feed{Items: []*feeds.Item{}}
+	err := option(feed, ExtraPayload{})
+	assert.NoError(t, err)
+}
+
+func TestOptionEmbeddingFilter_ThresholdExactBoundary(t *testing.T) {
+	// 阈值恰好为 0 和 1 应正常工作
+	option0 := OptionEmbeddingFilter([]string{"test"}, 0.0, 2000, "", EmbeddingIncludeMode)
+	feed0 := &feeds.Feed{Items: []*feeds.Item{}}
+	err := option0(feed0, ExtraPayload{})
+	assert.NoError(t, err)
+
+	option1 := OptionEmbeddingFilter([]string{"test"}, 1.0, 2000, "", EmbeddingIncludeMode)
+	feed1 := &feeds.Feed{Items: []*feeds.Item{}}
+	err = option1(feed1, ExtraPayload{})
+	assert.NoError(t, err)
+}
+
+// --- buildArticleText 空文本标记测试（需求 2 辅助）---
+
+func TestBuildArticleText_EmptyItemReturnsEmpty(t *testing.T) {
+	item := &feeds.Item{}
+	result := buildArticleText(item, 2000)
+	assert.Equal(t, "", result, "empty item should produce empty text for emptyTextSet marking")
+}
+
+func TestBuildArticleText_WhitespaceOnlyContent(t *testing.T) {
+	item := &feeds.Item{
+		Content: "   \t\n  ",
+	}
+	result := buildArticleText(item, 2000)
+	// buildArticleText 不做 trim，但调用方会用 strings.TrimSpace 判断
+	assert.NotEmpty(t, result, "whitespace content is returned as-is by buildArticleText")
+}
+
+// --- CraftTemplate 注册测试 ---
+
+func TestEmbeddingFilterTemplateRegistered(t *testing.T) {
+	templates := GetSysCraftTemplateDict()
+	tmpl, exists := templates["embedding-filter"]
+	assert.True(t, exists, "embedding-filter template should be registered")
+	assert.Equal(t, "embedding-filter", tmpl.Name)
+	assert.NotEmpty(t, tmpl.Description)
+	assert.NotEmpty(t, tmpl.ParamTemplateDefine)
+
+	// 验证参数模板包含所有必要字段
+	paramKeys := make(map[string]bool)
+	for _, p := range tmpl.ParamTemplateDefine {
+		paramKeys[p.Key] = true
+	}
+	assert.True(t, paramKeys["anchors"], "should have 'anchors' param")
+	assert.True(t, paramKeys["threshold"], "should have 'threshold' param")
+	assert.True(t, paramKeys["max_content_length"], "should have 'max_content_length' param")
+	assert.True(t, paramKeys["instruction"], "should have 'instruction' param")
+	assert.True(t, paramKeys["mode"], "should have 'mode' param")
+}
+
+// --- mode 参数解析测试 ---
+
+func TestEmbeddingFilterLoadParam_ModeInclude(t *testing.T) {
+	params := map[string]string{
+		"anchors": "test anchor",
+		"mode":    "include",
+	}
+	options := embeddingFilterLoadParam(params)
+	assert.Len(t, options, 1, "include mode should return one option")
+}
+
+func TestEmbeddingFilterLoadParam_ModeExclude(t *testing.T) {
+	params := map[string]string{
+		"anchors": "test anchor",
+		"mode":    "exclude",
+	}
+	options := embeddingFilterLoadParam(params)
+	assert.Len(t, options, 1, "exclude mode should return one option")
+}
+
+func TestEmbeddingFilterLoadParam_ModeDefault(t *testing.T) {
+	params := map[string]string{
+		"anchors": "test anchor",
+	}
+	options := embeddingFilterLoadParam(params)
+	assert.Len(t, options, 1, "missing mode should default to include")
+}
+
+func TestEmbeddingFilterLoadParam_ModeInvalid(t *testing.T) {
+	params := map[string]string{
+		"anchors": "test anchor",
+		"mode":    "invalid_mode",
+	}
+	options := embeddingFilterLoadParam(params)
+	assert.Len(t, options, 1, "invalid mode should fallback to include")
+}
+
+func TestEmbeddingFilterLoadParam_ModeCaseInsensitive(t *testing.T) {
+	params := map[string]string{
+		"anchors": "test anchor",
+		"mode":    "EXCLUDE",
+	}
+	options := embeddingFilterLoadParam(params)
+	assert.Len(t, options, 1, "mode should be case-insensitive")
+}
+
+func TestOptionEmbeddingFilter_ExcludeMode_EmptyItems(t *testing.T) {
+	option := OptionEmbeddingFilter([]string{"test"}, 0.6, 2000, "", EmbeddingExcludeMode)
+	feed := &feeds.Feed{Items: []*feeds.Item{}}
+	err := option(feed, ExtraPayload{})
+	assert.NoError(t, err)
+	assert.Empty(t, feed.Items)
+}
+
+func TestOptionEmbeddingFilter_ExcludeMode_EmptyAnchors(t *testing.T) {
+	option := OptionEmbeddingFilter([]string{}, 0.6, 2000, "", EmbeddingExcludeMode)
+	feed := &feeds.Feed{
+		Items: []*feeds.Item{
+			{Title: "Article 1", Content: "Content 1"},
+			{Title: "Article 2", Content: "Content 2"},
+		},
+	}
+	err := option(feed, ExtraPayload{})
+	assert.NoError(t, err)
+	// 锚点为空时不过滤，保留所有文章
+	assert.Len(t, feed.Items, 2)
+}

--- a/internal/craft/entry.go
+++ b/internal/craft/entry.go
@@ -136,6 +136,12 @@ func GetSysCraftTemplateDict() map[string]CraftTemplate {
 		ParamTemplateDefine: beautifyContentParamTmpl,
 		OptionFunc:          beautifyContentCraftLoadParam,
 	}
+	sysCraftTempList["embedding-filter"] = CraftTemplate{
+		Name:                "embedding-filter",
+		Description:         "使用 Embedding 模型按主题过滤文章（零样本分类）。支持 include（保留匹配项）和 exclude（移除匹配项）两种模式。",
+		ParamTemplateDefine: embeddingFilterParamTmpl,
+		OptionFunc:          embeddingFilterLoadParam,
+	}
 	return sysCraftTempList
 }
 

--- a/internal/util/env_var.go
+++ b/internal/util/env_var.go
@@ -1,11 +1,17 @@
 package util
 
 import (
+	"os"
+	"sync"
+
+	"github.com/sirupsen/logrus"
 	"strings"
 
 	"github.com/spf13/viper"
+	"github.com/subosito/gotenv"
 )
 
+var loadEnvOnce sync.Once
 const (
 	defaultFeedUserAgent = "FeedCraft/2.0"
 	htmlDefaultUserAgent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/135.0.0.0 Safari/537.36"
@@ -28,6 +34,18 @@ func DefaultHTMLUserAgent() string {
 }
 
 func GetEnvClient() *viper.Viper {
+	// 确保 .env 文件仅加载一次，避免高频调用时的重复文件 I/O
+	loadEnvOnce.Do(func() {
+		if err := gotenv.Load(); err != nil {
+			// 区分"文件不存在"（正常）和"文件存在但加载失败"（异常）
+			if _, statErr := os.Stat(".env"); os.IsNotExist(statErr) {
+				logrus.Debugf("gotenv.Load() skipped: .env file not found (this is normal)")
+			} else {
+				logrus.Warnf("gotenv.Load() failed: .env file exists but could not be loaded: %v", err)
+			}
+		}
+	})
+
 	v := viper.New()
 
 	// Set the name of the environment variable prefix (optional)

--- a/internal/util/env_var.go
+++ b/internal/util/env_var.go
@@ -12,6 +12,7 @@ import (
 )
 
 var loadEnvOnce sync.Once
+
 const (
 	defaultFeedUserAgent = "FeedCraft/2.0"
 	htmlDefaultUserAgent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/135.0.0.0 Safari/537.36"

--- a/internal/util/hash.go
+++ b/internal/util/hash.go
@@ -12,8 +12,12 @@ func GetTextContentHash(text string) string {
 	return hex.EncodeToString(h.Sum(nil))
 }
 
-func GetPasswordMD5Hash(text string) string {
+func GetMD5Hash(text string) string {
 	h := md5.New()
 	_, _ = h.Write([]byte(text))
 	return hex.EncodeToString(h.Sum(nil))
+}
+
+func GetPasswordMD5Hash(text string) string {
+	return GetMD5Hash(text)
 }

--- a/internal/util/hash_test.go
+++ b/internal/util/hash_test.go
@@ -1,0 +1,11 @@
+package util
+
+import "testing"
+
+func TestGetMD5HashReturnsHexEncodedMD5(t *testing.T) {
+	got := GetMD5Hash("FeedCraft")
+	const want = "01ec1a92ca7590baf10433c270707cd5"
+	if got != want {
+		t.Fatalf("GetMD5Hash() = %q, want %q", got, want)
+	}
+}

--- a/internal/util/vector.go
+++ b/internal/util/vector.go
@@ -1,0 +1,26 @@
+package util
+
+import "math"
+
+// CosineSimilarity 计算两个向量的余弦相似度
+// 返回值范围 [-1, 1]，1 表示完全相同，0 表示正交，-1 表示完全相反
+// 边界情况：零向量、维度不匹配等返回 0.0
+func CosineSimilarity(a, b []float64) float64 {
+	if len(a) == 0 || len(b) == 0 || len(a) != len(b) {
+		return 0.0
+	}
+
+	var dotProduct, normA, normB float64
+	for i := range a {
+		dotProduct += a[i] * b[i]
+		normA += a[i] * a[i]
+		normB += b[i] * b[i]
+	}
+
+	// 零向量检查
+	if normA == 0 || normB == 0 {
+		return 0.0
+	}
+
+	return dotProduct / (math.Sqrt(normA) * math.Sqrt(normB))
+}

--- a/internal/util/vector_test.go
+++ b/internal/util/vector_test.go
@@ -1,0 +1,76 @@
+package util
+
+import (
+	"math"
+	"testing"
+)
+
+func TestCosineSimilarity_IdenticalVectors(t *testing.T) {
+	a := []float64{1.0, 2.0, 3.0}
+	b := []float64{1.0, 2.0, 3.0}
+	result := CosineSimilarity(a, b)
+	if math.Abs(result-1.0) > 1e-9 {
+		t.Errorf("expected 1.0, got %f", result)
+	}
+}
+
+func TestCosineSimilarity_OrthogonalVectors(t *testing.T) {
+	a := []float64{1.0, 0.0}
+	b := []float64{0.0, 1.0}
+	result := CosineSimilarity(a, b)
+	if math.Abs(result) > 1e-9 {
+		t.Errorf("expected 0.0, got %f", result)
+	}
+}
+
+func TestCosineSimilarity_OppositeVectors(t *testing.T) {
+	a := []float64{1.0, 2.0, 3.0}
+	b := []float64{-1.0, -2.0, -3.0}
+	result := CosineSimilarity(a, b)
+	if math.Abs(result-(-1.0)) > 1e-9 {
+		t.Errorf("expected -1.0, got %f", result)
+	}
+}
+
+func TestCosineSimilarity_ZeroVector(t *testing.T) {
+	a := []float64{0.0, 0.0, 0.0}
+	b := []float64{1.0, 2.0, 3.0}
+	result := CosineSimilarity(a, b)
+	if result != 0.0 {
+		t.Errorf("expected 0.0 for zero vector, got %f", result)
+	}
+}
+
+func TestCosineSimilarity_EmptyVectors(t *testing.T) {
+	result := CosineSimilarity([]float64{}, []float64{})
+	if result != 0.0 {
+		t.Errorf("expected 0.0 for empty vectors, got %f", result)
+	}
+}
+
+func TestCosineSimilarity_DimensionMismatch(t *testing.T) {
+	a := []float64{1.0, 2.0}
+	b := []float64{1.0, 2.0, 3.0}
+	result := CosineSimilarity(a, b)
+	if result != 0.0 {
+		t.Errorf("expected 0.0 for dimension mismatch, got %f", result)
+	}
+}
+
+func TestCosineSimilarity_NilVectors(t *testing.T) {
+	result := CosineSimilarity(nil, nil)
+	if result != 0.0 {
+		t.Errorf("expected 0.0 for nil vectors, got %f", result)
+	}
+}
+
+func TestCosineSimilarity_PartialSimilarity(t *testing.T) {
+	a := []float64{1.0, 1.0, 0.0}
+	b := []float64{1.0, 0.0, 0.0}
+	result := CosineSimilarity(a, b)
+	// cos(45°) ≈ 0.7071
+	expected := 1.0 / math.Sqrt(2.0)
+	if math.Abs(result-expected) > 1e-9 {
+		t.Errorf("expected %f, got %f", expected, result)
+	}
+}

--- a/web/admin/config/vite.config.dev.ts
+++ b/web/admin/config/vite.config.dev.ts
@@ -16,6 +16,14 @@ export default mergeConfig(
           target: 'http://localhost:8080',
           changeOrigin: true,
         },
+        '/craft': {
+          target: 'http://localhost:8080',
+          changeOrigin: true,
+        },
+        '/recipe': {
+          target: 'http://localhost:8080',
+          changeOrigin: true,
+        },
       },
     },
     plugins: [


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Cherry-picks `5abc6361b229d7c8a3fbad2c7e18bdc0bec909c3` from `main` into `dev` via this branch.
- Adds a missing generic `util.GetMD5Hash` helper and coverage needed by the embedding filter on `dev`.
- Normalizes `feed_viewer` internal error strings for lint while preserving user-facing validation messages and adding regression coverage.

### Testing
- `go test ./internal/util ./internal/adapter ./internal/craft`
- `go test ./internal/controller`
- `task fix`
- `go test ./...`
- `task backend-build`
- `task --force frontend-build`
- Code review subagent completed; non-blocking UX feedback was addressed in `df59ba1`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1301c92a-5a36-4148-b24b-344ee39ec20c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1301c92a-5a36-4148-b24b-344ee39ec20c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

## Summary by Sourcery

Introduce an embedding-based feed filtering capability, wire it into the craft system, and align supporting utilities and feed viewer error handling to match main.

New Features:
- Add an embedding adapter layer that supports OpenAI-compatible, Gemini, and Ollama backends with batching, retries, and in-memory anchor vector caching.
- Add an embedding-based zero-shot classification filter as a craft template, including include/exclude modes and configurable anchors, thresholds, and content length limits.

Bug Fixes:
- Normalize feed viewer validation error messages and error classification to be case-insensitive while preserving user-facing capitalization.

Enhancements:
- Load .env configuration once via gotenv in the env client helper with structured logging for missing or failing files.
- Expose a generic MD5 hashing helper and refactor password hashing to reuse it.
- Add development proxy routes for /craft and /recipe in the admin Vite dev config.

Tests:
- Add comprehensive tests for the embedding adapter configuration and client creation, embedding filter behavior and parameter parsing, MD5 helper, vector cosine similarity, and feed viewer validation error handling.