### PR TITLE
Fix RSS preview access policy

### DIFF
--- a/internal/controller/feed_viewer.go
+++ b/internal/controller/feed_viewer.go
@@ -9,7 +9,6 @@ import (
 	"FeedCraft/internal/util"
 	"errors"
 	"fmt"
-	"net"
 	"net/http"
 	"net/url"
 	"strings"
@@ -49,10 +48,18 @@ type FeedViewerPreviewItem struct {
 	ContentSnippet string `json:"contentSnippet"`
 }
 
+const feedViewerInvalidURLMessage = "Please enter a valid http(s) feed URL"
+const feedViewerInvalidURLError = "please enter a valid http(s) feed URL"
+
 func PreviewFeedViewer(c *gin.Context) {
+	if c.Request.Method != http.MethodGet {
+		c.JSON(http.StatusMethodNotAllowed, util.APIResponse[any]{StatusCode: -1, Msg: "Only GET requests are allowed for feed preview"})
+		return
+	}
+
 	var req FeedViewerPreviewReq
 	if err := c.ShouldBindQuery(&req); err != nil {
-		c.JSON(http.StatusBadRequest, util.APIResponse[any]{StatusCode: -1, Msg: "Please enter a valid http(s) feed URL"})
+		c.JSON(http.StatusBadRequest, util.APIResponse[any]{StatusCode: -1, Msg: feedViewerInvalidURLMessage})
 		return
 	}
 
@@ -203,23 +210,13 @@ func formatFeedViewerValidationError(err error) string {
 func validateFeedViewerURL(rawURL string) error {
 	parsedURL, err := url.Parse(rawURL)
 	if err != nil || parsedURL == nil {
-		return errors.New("please enter a valid http(s) feed URL")
+		return errors.New(feedViewerInvalidURLError)
 	}
 	if parsedURL.Scheme != "http" && parsedURL.Scheme != "https" {
-		return errors.New("please enter a valid http(s) feed URL")
+		return errors.New(feedViewerInvalidURLError)
 	}
 	if parsedURL.Hostname() == "" {
-		return errors.New("please enter a valid http(s) feed URL")
-	}
-
-	ips, err := net.LookupIP(parsedURL.Hostname())
-	if err != nil {
-		return fmt.Errorf("unable to resolve this URL: %w", err)
-	}
-	for _, ip := range ips {
-		if ip.IsLoopback() || ip.IsPrivate() {
-			return fmt.Errorf("access to private IP %s is forbidden", ip.String())
-		}
+		return errors.New(feedViewerInvalidURLError)
 	}
 
 	return nil
@@ -238,7 +235,7 @@ func classifyFeedViewerError(err error) (int, string) {
 	case strings.Contains(lowerMsg, "http get failed:"), strings.Contains(lowerMsg, "browserless fetch failed:"), strings.Contains(lowerMsg, "failed to read response body:"), strings.Contains(lowerMsg, "unable to resolve this url"):
 		return http.StatusOK, "Unable to fetch this URL. Please check the address and try again."
 	case strings.Contains(lowerMsg, "parse failed:"), strings.Contains(lowerMsg, "invalid xml"):
-		return http.StatusOK, "The URL is reachable, but it does not appear to be a valid RSS or Atom feed."
+		return http.StatusOK, "The URL is reachable, but it does not appear to be a valid RSS, Atom, or JSON feed."
 	case strings.Contains(lowerMsg, "not a valid craft name"):
 		return http.StatusBadRequest, "Please select a valid craft before comparing feeds."
 	default:

--- a/internal/controller/feed_viewer_test.go
+++ b/internal/controller/feed_viewer_test.go
@@ -1,10 +1,134 @@
 package controller
 
 import (
+	"encoding/json"
 	"errors"
 	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
 	"testing"
+
+	"github.com/gin-gonic/gin"
 )
+
+func TestPreviewFeedViewerAllowsInternalFeedURL(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	var upstreamMethod string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upstreamMethod = r.Method
+		w.Header().Set("Content-Type", "application/rss+xml")
+		_, _ = w.Write([]byte(`<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+  <channel>
+    <title>Internal Feed</title>
+    <link>http://example.com/</link>
+    <description>Internal preview feed</description>
+    <item>
+      <title>Internal Item</title>
+      <link>http://example.com/item</link>
+      <guid>item-1</guid>
+      <description>Hello from internal network</description>
+    </item>
+  </channel>
+</rss>`))
+	}))
+	defer server.Close()
+
+	recorder := performFeedViewerPreviewRequest(t, http.MethodGet, server.URL)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d: %s", http.StatusOK, recorder.Code, recorder.Body.String())
+	}
+	if upstreamMethod != http.MethodGet {
+		t.Fatalf("expected upstream request method GET, got %s", upstreamMethod)
+	}
+
+	var response struct {
+		Code int `json:"code"`
+		Data struct {
+			Title string `json:"title"`
+			Items []struct {
+				Title string `json:"title"`
+			} `json:"items"`
+		} `json:"data"`
+		Msg string `json:"msg"`
+	}
+	if err := json.Unmarshal(recorder.Body.Bytes(), &response); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if response.Code != 0 {
+		t.Fatalf("expected success code, got %d with msg %q", response.Code, response.Msg)
+	}
+	if response.Data.Title != "Internal Feed" {
+		t.Fatalf("expected internal feed title, got %q", response.Data.Title)
+	}
+	if len(response.Data.Items) != 1 || response.Data.Items[0].Title != "Internal Item" {
+		t.Fatalf("expected one internal item, got %+v", response.Data.Items)
+	}
+}
+
+func TestPreviewFeedViewerRejectsNonGETRequest(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	upstreamCalled := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upstreamCalled = true
+		w.Header().Set("Content-Type", "application/rss+xml")
+		_, _ = w.Write([]byte(`<rss version="2.0"><channel><title>Unexpected</title><link>http://example.com/</link><description>Unexpected</description></channel></rss>`))
+	}))
+	defer server.Close()
+
+	recorder := performFeedViewerPreviewRequest(t, http.MethodPost, server.URL)
+
+	if recorder.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("expected status %d, got %d: %s", http.StatusMethodNotAllowed, recorder.Code, recorder.Body.String())
+	}
+	if upstreamCalled {
+		t.Fatal("expected non-GET request to be rejected before fetching upstream")
+	}
+}
+
+func TestPreviewFeedViewerDoesNotReturnDataForInvalidFeedResponse(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		_, _ = w.Write([]byte(`<html><body>not a feed</body></html>`))
+	}))
+	defer server.Close()
+
+	recorder := performFeedViewerPreviewRequest(t, http.MethodGet, server.URL)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d: %s", http.StatusOK, recorder.Code, recorder.Body.String())
+	}
+
+	var response struct {
+		Code int             `json:"code"`
+		Data json.RawMessage `json:"data,omitempty"`
+		Msg  string          `json:"msg"`
+	}
+	if err := json.Unmarshal(recorder.Body.Bytes(), &response); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if response.Code != -1 {
+		t.Fatalf("expected error code -1, got %d", response.Code)
+	}
+	if len(response.Data) != 0 {
+		t.Fatalf("expected invalid feed response to omit data, got %s", string(response.Data))
+	}
+	if !strings.Contains(response.Msg, "valid RSS, Atom, or JSON feed") {
+		t.Fatalf("expected valid feed error message, got %q", response.Msg)
+	}
+}
+
+func TestValidateFeedViewerURLAllowsPrivateIPLiteral(t *testing.T) {
+	if err := validateFeedViewerURL("http://172.21.0.13/feed.xml"); err != nil {
+		t.Fatalf("expected private IP literal to be allowed, got %v", err)
+	}
+}
 
 func TestFormatFeedViewerValidationErrorPreservesUserFacingCapitalization(t *testing.T) {
 	tests := []struct {
@@ -44,4 +168,16 @@ func TestClassifyFeedViewerErrorHandlesLowercaseResolveMessage(t *testing.T) {
 	if msg != want {
 		t.Fatalf("msg = %q, want %q", msg, want)
 	}
+}
+
+func performFeedViewerPreviewRequest(t *testing.T, method, inputURL string) *httptest.ResponseRecorder {
+	t.Helper()
+
+	router := gin.New()
+	router.Handle(method, "/preview", PreviewFeedViewer)
+
+	request := httptest.NewRequest(method, "/preview?input_url="+url.QueryEscape(inputURL), nil)
+	recorder := httptest.NewRecorder()
+	router.ServeHTTP(recorder, request)
+	return recorder
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Allow RSS preview requests to internal and loopback feed URLs while keeping preview limited to GET requests.
- Return an error response without `data` when the fetched response cannot be parsed as RSS, Atom, or JSON feed.
- Add handler tests for internal URL preview, non-GET rejection, invalid feed response handling, private IP literal validation, and upstream validation-error casing behavior.
- Rebase the PR branch onto latest `origin/dev` to remove GitHub rebase conflicts.

### Testing
- `git merge-base --is-ancestor origin/dev HEAD && git rev-list --left-right --count origin/dev...HEAD`
- `go test ./internal/controller -run 'TestPreviewFeedViewer|TestValidateFeedViewerURLAllowsPrivateIPLiteral|TestFormatFeedViewerValidationErrorPreservesUserFacingCapitalization|TestClassifyFeedViewerErrorHandlesLowercaseResolveMessage' -count=1`
- `go test ./...`
- `task fix`
- `go build -o feed-craft ./cmd/main.go`
- `pnpm --dir web/admin build`
- `gh pr view 761 --json mergeStateStatus,mergeable,headRefOid,baseRefOid,url`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2c4879a6-6575-496e-b985-a733cc589c32"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2c4879a6-6575-496e-b985-a733cc589c32"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

## Summary by Sourcery

Relax feed viewer URL validation and improve RSS preview handling while adding coverage for new behaviors.

Bug Fixes:
- Allow feed preview for internal and private IP literal URLs while still enforcing HTTP/HTTPS schemes.
- Restrict feed preview to GET requests and return a clear error for non-GET methods.
- Ensure invalid or non-feed responses return an error without any preview data and with an updated message covering RSS, Atom, and JSON feeds.

Tests:
- Add controller tests for internal URL feed preview, non-GET request rejection, invalid feed response behavior, and validation of private IP literal URLs.