### PR TITLE
Improve LLM retry model failover

### DIFF
--- a/internal/adapter/common_llm.go
+++ b/internal/adapter/common_llm.go
@@ -26,6 +26,10 @@ const UseDefaultModel = ""
 
 var llmCallTimeout = 10 * time.Minute
 var (
+	llmRetryAttemptsPerModel = uint(3)
+	llmRetryDelay            = 2 * time.Second
+	llmRetryMaxDelay         = 10 * time.Second
+
 	// llmClients acts as a lazy-loaded singleton registry, NOT a traditional acquire/release connection pool.
 	// It maps configuration keys to a single llms.Model instance.
 	// We reuse these instances so the underlying http.Transport can naturally maintain TCP Keep-Alive connections.
@@ -54,6 +58,11 @@ func getLLMDispatcher() *util.PriorityDispatcher[string] {
 		logrus.Infof("LLM Global Priority Dispatcher initialized with max concurrency: %d", concurrency)
 	})
 	return llmDispatcher
+}
+
+type llmModelClient struct {
+	model string
+	llm   llms.Model
 }
 
 func SimpleLLMCall(model string, promptInput string) (string, error) {
@@ -107,18 +116,20 @@ func SimpleLLMCall(model string, promptInput string) (string, error) {
 		}
 	}
 
-	modelList := strings.Split(llmApiModel, ",")
+	modelList := make([]string, 0)
+	for _, currentModel := range strings.Split(llmApiModel, ",") {
+		currentModel = strings.TrimSpace(currentModel)
+		if currentModel != "" {
+			modelList = append(modelList, currentModel)
+		}
+	}
 	rand.Shuffle(len(modelList), func(i, j int) {
 		modelList[i], modelList[j] = modelList[j], modelList[i]
 	})
 
 	var lastErr error
+	modelClients := make([]llmModelClient, 0, len(modelList))
 	for _, currentModel := range modelList {
-		currentModel = strings.TrimSpace(currentModel)
-		if currentModel == "" {
-			continue
-		}
-
 		cacheKey := fmt.Sprintf("%s|%s|%s|%s", llmApiType, llmApiBase, llmApiKey, currentModel)
 		var llm llms.Model
 
@@ -150,48 +161,59 @@ func SimpleLLMCall(model string, promptInput string) (string, error) {
 			llmClients.Store(cacheKey, llm)
 		}
 
-		dispatcher := getLLMDispatcher()
-
-		// try to execute
-		isUrgent := false // Will be set to true on retry
-
-		result, err := retry.DoWithData(
-			func() (string, error) {
-				return dispatcher.Execute(context.Background(), isUrgent, func(ctx context.Context) (string, error) {
-					ctx, cancel := context.WithTimeout(ctx, llmCallTimeout)
-					defer cancel()
-
-					content := []llms.MessageContent{
-						llms.TextParts(llms.ChatMessageTypeHuman, promptInput),
-					}
-
-					resp, err := llm.GenerateContent(ctx, content)
-					if err != nil {
-						return "", err
-					}
-					if len(resp.Choices) > 0 {
-						return resp.Choices[0].Content, nil
-					}
-					return "", fmt.Errorf("empty llm call response")
-				})
-			},
-			retry.Attempts(3),
-			retry.DelayType(retry.BackOffDelay),
-			retry.Delay(2*time.Second),
-			retry.MaxDelay(10*time.Second),
-			retry.OnRetry(func(n uint, err error) {
-				isUrgent = true // Elevate priority on retry
-				logrus.Warnf("Retrying LLM call (attempt %d) with model %s, err: %v", n+1, currentModel, err)
-			}),
-		)
-
-		if err == nil {
-			return result, nil
-		}
-
-		lastErr = err
-		logrus.Warnf("LLM call failed with model %s after retries: %v", currentModel, err)
+		modelClients = append(modelClients, llmModelClient{model: currentModel, llm: llm})
 	}
 
+	if len(modelClients) == 0 {
+		return "", fmt.Errorf("all models failed, last error: %v", lastErr)
+	}
+
+	dispatcher := getLLMDispatcher()
+	isUrgent := false // Will be set to true on retry
+	attemptIndex := 0
+	currentModel := ""
+	maxAttempts := uint(len(modelClients)) * llmRetryAttemptsPerModel
+
+	result, err := retry.DoWithData(
+		func() (string, error) {
+			modelClient := modelClients[attemptIndex%len(modelClients)]
+			attemptIndex++
+			currentModel = modelClient.model
+
+			return dispatcher.Execute(context.Background(), isUrgent, func(ctx context.Context) (string, error) {
+				ctx, cancel := context.WithTimeout(ctx, llmCallTimeout)
+				defer cancel()
+
+				content := []llms.MessageContent{
+					llms.TextParts(llms.ChatMessageTypeHuman, promptInput),
+				}
+
+				resp, err := modelClient.llm.GenerateContent(ctx, content)
+				if err != nil {
+					return "", err
+				}
+				if len(resp.Choices) > 0 {
+					return resp.Choices[0].Content, nil
+				}
+				return "", fmt.Errorf("empty llm call response")
+			})
+		},
+		retry.Attempts(maxAttempts),
+		retry.DelayType(retry.BackOffDelay),
+		retry.Delay(llmRetryDelay),
+		retry.MaxDelay(llmRetryMaxDelay),
+		retry.OnRetry(func(n uint, err error) {
+			isUrgent = true // Elevate priority on retry
+			nextModel := modelClients[attemptIndex%len(modelClients)].model
+			logrus.Warnf("Retrying LLM call (attempt %d) with model %s, err from previous model %s: %v", n+1, nextModel, currentModel, err)
+		}),
+	)
+
+	if err == nil {
+		return result, nil
+	}
+
+	lastErr = err
+	logrus.Warnf("LLM call failed after retries: %v", err)
 	return "", fmt.Errorf("all models failed, last error: %v", lastErr)
 }

--- a/internal/adapter/common_llm.go
+++ b/internal/adapter/common_llm.go
@@ -26,10 +26,6 @@ const UseDefaultModel = ""
 
 var llmCallTimeout = 10 * time.Minute
 var (
-	llmRetryAttemptsPerModel = uint(3)
-	llmRetryDelay            = 2 * time.Second
-	llmRetryMaxDelay         = 10 * time.Second
-
 	// llmClients acts as a lazy-loaded singleton registry, NOT a traditional acquire/release connection pool.
 	// It maps configuration keys to a single llms.Model instance.
 	// We reuse these instances so the underlying http.Transport can naturally maintain TCP Keep-Alive connections.
@@ -40,6 +36,18 @@ var (
 	llmDispatcher *util.PriorityDispatcher[string]
 	llmDispOnce   sync.Once
 )
+
+type llmRetryConfig struct {
+	attemptsPerModel uint
+	delay            time.Duration
+	maxDelay         time.Duration
+}
+
+var defaultLLMRetryConfig = llmRetryConfig{
+	attemptsPerModel: 3,
+	delay:            2 * time.Second,
+	maxDelay:         10 * time.Second,
+}
 
 func getLLMDispatcher() *util.PriorityDispatcher[string] {
 	llmDispOnce.Do(func() {
@@ -66,9 +74,16 @@ type llmModelClient struct {
 }
 
 func SimpleLLMCall(model string, promptInput string) (string, error) {
+	return simpleLLMCall(model, promptInput, defaultLLMRetryConfig)
+}
+
+func simpleLLMCall(model string, promptInput string, retryConfig llmRetryConfig) (string, error) {
 	envClient := util.GetEnvClient()
 	if envClient == nil {
 		log.Fatalf("get env client error.")
+	}
+	if retryConfig.attemptsPerModel == 0 {
+		retryConfig.attemptsPerModel = defaultLLMRetryConfig.attemptsPerModel
 	}
 
 	// 1. Load new standard env vars
@@ -117,11 +132,17 @@ func SimpleLLMCall(model string, promptInput string) (string, error) {
 	}
 
 	modelList := make([]string, 0)
+	seenModels := make(map[string]struct{})
 	for _, currentModel := range strings.Split(llmApiModel, ",") {
 		currentModel = strings.TrimSpace(currentModel)
-		if currentModel != "" {
-			modelList = append(modelList, currentModel)
+		if currentModel == "" {
+			continue
 		}
+		if _, ok := seenModels[currentModel]; ok {
+			continue
+		}
+		seenModels[currentModel] = struct{}{}
+		modelList = append(modelList, currentModel)
 	}
 	rand.Shuffle(len(modelList), func(i, j int) {
 		modelList[i], modelList[j] = modelList[j], modelList[i]
@@ -172,7 +193,7 @@ func SimpleLLMCall(model string, promptInput string) (string, error) {
 	isUrgent := false // Will be set to true on retry
 	attemptIndex := 0
 	currentModel := ""
-	maxAttempts := uint(len(modelClients)) * llmRetryAttemptsPerModel
+	maxAttempts := uint(len(modelClients)) * retryConfig.attemptsPerModel
 
 	result, err := retry.DoWithData(
 		func() (string, error) {
@@ -199,9 +220,9 @@ func SimpleLLMCall(model string, promptInput string) (string, error) {
 			})
 		},
 		retry.Attempts(maxAttempts),
-		retry.DelayType(retry.BackOffDelay),
-		retry.Delay(llmRetryDelay),
-		retry.MaxDelay(llmRetryMaxDelay),
+		retry.DelayType(modelRotationBackoffDelay(len(modelClients))),
+		retry.Delay(retryConfig.delay),
+		retry.MaxDelay(retryConfig.maxDelay),
 		retry.OnRetry(func(n uint, err error) {
 			isUrgent = true // Elevate priority on retry
 			nextModel := modelClients[attemptIndex%len(modelClients)].model
@@ -216,4 +237,16 @@ func SimpleLLMCall(model string, promptInput string) (string, error) {
 	lastErr = err
 	logrus.Warnf("LLM call failed after retries: %v", err)
 	return "", fmt.Errorf("all models failed, last error: %v", lastErr)
+}
+
+func modelRotationBackoffDelay(modelCount int) retry.DelayTypeFunc {
+	return func(n uint, err error, config *retry.Config) time.Duration {
+		if modelCount <= 1 {
+			return retry.BackOffDelay(n, err, config)
+		}
+		if n%uint(modelCount) != 0 {
+			return 0
+		}
+		return retry.BackOffDelay(n/uint(modelCount), err, config)
+	}
 }

--- a/internal/adapter/common_llm_test.go
+++ b/internal/adapter/common_llm_test.go
@@ -16,17 +16,6 @@ func TestSimpleLLMCallRetriesDifferentModelsBeforeRepeating(t *testing.T) {
 	t.Cleanup(func() {
 		llmClients = sync.Map{}
 	})
-	originalAttemptsPerModel := llmRetryAttemptsPerModel
-	originalDelay := llmRetryDelay
-	originalMaxDelay := llmRetryMaxDelay
-	llmRetryAttemptsPerModel = 1
-	llmRetryDelay = time.Nanosecond
-	llmRetryMaxDelay = time.Nanosecond
-	t.Cleanup(func() {
-		llmRetryAttemptsPerModel = originalAttemptsPerModel
-		llmRetryDelay = originalDelay
-		llmRetryMaxDelay = originalMaxDelay
-	})
 
 	var mu sync.Mutex
 	requestedModels := make([]string, 0)
@@ -59,11 +48,49 @@ func TestSimpleLLMCallRetriesDifferentModelsBeforeRepeating(t *testing.T) {
 	t.Setenv("FC_LLM_API_KEY", "test-key")
 	t.Setenv("FC_LLM_API_MODEL", "")
 
-	_, err := SimpleLLMCall("model-a,model-b", "hello")
+	_, err := simpleLLMCall("model-a, model-a, model-b", "hello", llmRetryConfig{
+		attemptsPerModel: 2,
+		delay:            time.Nanosecond,
+		maxDelay:         time.Nanosecond,
+	})
 	require.Error(t, err)
 
 	mu.Lock()
 	defer mu.Unlock()
-	require.GreaterOrEqual(t, len(requestedModels), 2)
-	require.NotEqual(t, requestedModels[0], requestedModels[1], "retry should try another configured model before repeating the same model")
+	require.Len(t, requestedModels, 4)
+
+	modelCounts := map[string]int{}
+	for i, requestedModel := range requestedModels {
+		modelCounts[requestedModel]++
+		if i > 0 {
+			require.NotEqual(t, requestedModels[i-1], requestedModel, "retry should try another configured model before repeating the same model")
+		}
+	}
+	require.Equal(t, map[string]int{"model-a": 2, "model-b": 2}, modelCounts)
+}
+
+func TestSimpleLLMCallRetriesNextModelWithoutBackoff(t *testing.T) {
+	llmClients = sync.Map{}
+	t.Cleanup(func() {
+		llmClients = sync.Map{}
+	})
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "temporary upstream failure", http.StatusBadGateway)
+	}))
+	t.Cleanup(server.Close)
+
+	t.Setenv("FC_LLM_API_TYPE", "openai")
+	t.Setenv("FC_LLM_API_BASE", server.URL)
+	t.Setenv("FC_LLM_API_KEY", "test-key")
+	t.Setenv("FC_LLM_API_MODEL", "")
+
+	start := time.Now()
+	_, err := simpleLLMCall("model-a,model-b", "hello", llmRetryConfig{
+		attemptsPerModel: 1,
+		delay:            100 * time.Millisecond,
+		maxDelay:         200 * time.Millisecond,
+	})
+	require.Error(t, err)
+	require.Less(t, time.Since(start), 150*time.Millisecond, "switching to another configured model should not wait for backoff")
 }

--- a/internal/adapter/common_llm_test.go
+++ b/internal/adapter/common_llm_test.go
@@ -1,0 +1,69 @@
+package adapter
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSimpleLLMCallRetriesDifferentModelsBeforeRepeating(t *testing.T) {
+	llmClients = sync.Map{}
+	t.Cleanup(func() {
+		llmClients = sync.Map{}
+	})
+	originalAttemptsPerModel := llmRetryAttemptsPerModel
+	originalDelay := llmRetryDelay
+	originalMaxDelay := llmRetryMaxDelay
+	llmRetryAttemptsPerModel = 1
+	llmRetryDelay = time.Nanosecond
+	llmRetryMaxDelay = time.Nanosecond
+	t.Cleanup(func() {
+		llmRetryAttemptsPerModel = originalAttemptsPerModel
+		llmRetryDelay = originalDelay
+		llmRetryMaxDelay = originalMaxDelay
+	})
+
+	var mu sync.Mutex
+	requestedModels := make([]string, 0)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/chat/completions" {
+			t.Errorf("unexpected request path: %s", r.URL.Path)
+			http.Error(w, "unexpected path", http.StatusNotFound)
+			return
+		}
+
+		var payload struct {
+			Model string `json:"model"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			t.Errorf("decode request body: %v", err)
+			http.Error(w, "bad request", http.StatusBadRequest)
+			return
+		}
+
+		mu.Lock()
+		requestedModels = append(requestedModels, payload.Model)
+		mu.Unlock()
+
+		http.Error(w, "temporary upstream failure", http.StatusBadGateway)
+	}))
+	t.Cleanup(server.Close)
+
+	t.Setenv("FC_LLM_API_TYPE", "openai")
+	t.Setenv("FC_LLM_API_BASE", server.URL)
+	t.Setenv("FC_LLM_API_KEY", "test-key")
+	t.Setenv("FC_LLM_API_MODEL", "")
+
+	_, err := SimpleLLMCall("model-a,model-b", "hello")
+	require.Error(t, err)
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.GreaterOrEqual(t, len(requestedModels), 2)
+	require.NotEqual(t, requestedModels[0], requestedModels[1], "retry should try another configured model before repeating the same model")
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Rotate across configured LLM models during retries before repeating the same model.
- Keep the existing per-model retry budget while interleaving attempts across available distinct models.
- Avoid backoff when immediately switching to another configured model; apply backoff only after a full model rotation.
- Add adapter regression tests using a local OpenAI-compatible test server.

## Testing
- `go test ./internal/adapter -run 'TestSimpleLLMCallRetries(DifferentModelsBeforeRepeating|NextModelWithoutBackoff)' -count=1`
- `task fix` (exits 0; existing frontend ESLint warning remains in `topic_feed/detail.vue`)
- `go test ./...`
- `task backend-build`
- `task --force frontend-build`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2e5ed913-0792-4ecb-a294-bd30337e317c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2e5ed913-0792-4ecb-a294-bd30337e317c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

## Summary by Sourcery

Improve LLM call retry behavior to rotate across distinct configured models while preserving per-model retry budgets and adjusting backoff to apply only after a full model rotation.

Enhancements:
- Deduplicate and randomize configured LLM models, then interleave retries across all available models before retrying the same model.
- Introduce configurable LLM retry parameters and a rotation-aware backoff strategy that avoids delay when switching to a different model but still backs off between full rotations.
- Simplify LLM client caching and dispatching by building model clients up front and handling retries in a single loop with improved logging of model failover behavior.

Tests:
- Add adapter tests using a local OpenAI-compatible HTTP test server to verify model rotation before repeats and the absence of backoff when failing over to the next model.