### PR TITLE
feat: add AI content process craft

### DIFF
--- a/internal/adapter/common_llm.go
+++ b/internal/adapter/common_llm.go
@@ -74,10 +74,18 @@ type llmModelClient struct {
 }
 
 func SimpleLLMCall(model string, promptInput string) (string, error) {
-	return simpleLLMCall(model, promptInput, defaultLLMRetryConfig)
+	return simpleLLMCallWithOptions(model, promptInput, defaultLLMRetryConfig, nil)
+}
+
+func SimpleLLMCallWithOptions(model string, promptInput string, callOptions ...llms.CallOption) (string, error) {
+	return simpleLLMCallWithOptions(model, promptInput, defaultLLMRetryConfig, callOptions)
 }
 
 func simpleLLMCall(model string, promptInput string, retryConfig llmRetryConfig) (string, error) {
+	return simpleLLMCallWithOptions(model, promptInput, retryConfig, nil)
+}
+
+func simpleLLMCallWithOptions(model string, promptInput string, retryConfig llmRetryConfig, callOptions []llms.CallOption) (string, error) {
 	envClient := util.GetEnvClient()
 	if envClient == nil {
 		log.Fatalf("get env client error.")
@@ -209,7 +217,7 @@ func simpleLLMCall(model string, promptInput string, retryConfig llmRetryConfig)
 					llms.TextParts(llms.ChatMessageTypeHuman, promptInput),
 				}
 
-				resp, err := modelClient.llm.GenerateContent(ctx, content)
+				resp, err := modelClient.llm.GenerateContent(ctx, content, callOptions...)
 				if err != nil {
 					return "", err
 				}

--- a/internal/adapter/common_llm_test.go
+++ b/internal/adapter/common_llm_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"github.com/tmc/langchaingo/llms"
 )
 
 func TestSimpleLLMCallRetriesDifferentModelsBeforeRepeating(t *testing.T) {
@@ -93,4 +94,46 @@ func TestSimpleLLMCallRetriesNextModelWithoutBackoff(t *testing.T) {
 	})
 	require.Error(t, err)
 	require.Less(t, time.Since(start), 150*time.Millisecond, "switching to another configured model should not wait for backoff")
+}
+
+func TestSimpleLLMCallWithOptionsSendsTemperature(t *testing.T) {
+	llmClients = sync.Map{}
+	t.Cleanup(func() {
+		llmClients = sync.Map{}
+	})
+
+	var capturedTemperature float64
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/chat/completions" {
+			t.Errorf("unexpected request path: %s", r.URL.Path)
+			http.Error(w, "unexpected path", http.StatusNotFound)
+			return
+		}
+
+		var payload struct {
+			Model       string  `json:"model"`
+			Temperature float64 `json:"temperature"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			t.Errorf("decode request body: %v", err)
+			http.Error(w, "bad request", http.StatusBadRequest)
+			return
+		}
+		capturedTemperature = payload.Temperature
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"choices":[{"message":{"content":"ok"}}],"usage":{"total_tokens":1}}`))
+	}))
+	t.Cleanup(server.Close)
+
+	t.Setenv("FC_LLM_API_TYPE", "openai")
+	t.Setenv("FC_LLM_API_BASE", server.URL)
+	t.Setenv("FC_LLM_API_KEY", "test-key")
+	t.Setenv("FC_LLM_API_MODEL", "")
+
+	result, err := SimpleLLMCallWithOptions("model-a", "hello", llms.WithTemperature(0))
+
+	require.NoError(t, err)
+	require.Equal(t, "ok", result)
+	require.Equal(t, 0.0, capturedTemperature)
 }

--- a/internal/adapter/llm.go
+++ b/internal/adapter/llm.go
@@ -4,6 +4,8 @@ import (
 	"FeedCraft/internal/util"
 	"fmt"
 	"strings"
+
+	"github.com/tmc/langchaingo/llms"
 )
 
 // CallLLMUsingContext using openai compatible api
@@ -13,9 +15,19 @@ func CallLLMUsingContext(prompt, context string, option util.ContentProcessOptio
 	processedContext = strings.ReplaceAll(processedContext, "`", "")
 
 	finalPrompt := fmt.Sprintf("%s \n```\n%s\n```", prompt, processedContext)
-	cacheKey := fmt.Sprintf("llm_call_%s", util.GetTextContentHash(finalPrompt))
+	cacheKey := fmt.Sprintf("llm_call_%s_%s", util.GetTextContentHash(finalPrompt), llmCallTemperatureCachePart(option))
 	valFunc := func() (string, error) {
+		if option.Temperature != nil {
+			return SimpleLLMCallWithOptions(UseDefaultModel, finalPrompt, llms.WithTemperature(*option.Temperature))
+		}
 		return SimpleLLMCall(UseDefaultModel, finalPrompt)
 	}
 	return util.CachedFunc(cacheKey, valFunc)
+}
+
+func llmCallTemperatureCachePart(option util.ContentProcessOption) string {
+	if option.Temperature == nil {
+		return "default-temperature"
+	}
+	return fmt.Sprintf("temperature:%g", *option.Temperature)
 }

--- a/internal/controller/list_all_craft.go
+++ b/internal/controller/list_all_craft.go
@@ -18,9 +18,10 @@ var (
 )
 
 type CraftItem struct {
-	Type        CraftType `json:"type"`
-	Name        string    `json:"name"`
-	Description string    `json:"description"`
+	Type         CraftType `json:"type"`
+	Name         string    `json:"name"`
+	Description  string    `json:"description"`
+	TemplateOnly bool      `json:"template_only"`
 }
 
 func ListAllCraft(c *gin.Context) {
@@ -31,9 +32,10 @@ func ListAllCraft(c *gin.Context) {
 	sysCraftTemplates := craft.GetSysCraftTemplateDict()
 	for _, tmpl := range sysCraftTemplates {
 		allCrafts = append(allCrafts, CraftItem{
-			Type:        SysDefinedCraftAtom,
-			Name:        tmpl.Name,
-			Description: tmpl.Description,
+			Type:         SysDefinedCraftAtom,
+			Name:         tmpl.Name,
+			Description:  tmpl.Description,
+			TemplateOnly: tmpl.TemplateOnly,
 		})
 	}
 

--- a/internal/craft/ai_content_process.go
+++ b/internal/craft/ai_content_process.go
@@ -1,0 +1,190 @@
+package craft
+
+import (
+	"fmt"
+	"strings"
+
+	"FeedCraft/internal/util"
+
+	"github.com/gorilla/feeds"
+)
+
+type aiContentProcessPlacement string
+
+const (
+	aiContentProcessPlacementPrepend aiContentProcessPlacement = "prepend"
+	aiContentProcessPlacementReplace aiContentProcessPlacement = "replace"
+	aiContentProcessPlacementAppend  aiContentProcessPlacement = "append"
+)
+
+var aiContentProcessCraftParamTmpl = []ParamTemplate{
+	{
+		Key:         "rule",
+		Description: "Instruction for processing each article content. Example: 总结文章的关键观点并列出行动建议",
+		Default:     "",
+	},
+	{
+		Key:         "extra-payload",
+		Description: "Comma-separated extra payload list. Supported: article_summary, article_content, article_date, raw_rss_item",
+		Default:     string(aiFilterExtraPayloadArticleContent),
+	},
+	{
+		Key:         "placement",
+		Description: "Where to write generated content. Supported: prepend, replace, append",
+		Default:     string(aiContentProcessPlacementPrepend),
+	},
+}
+
+func aiContentProcessCraftLoadParam(m map[string]string) []CraftOption {
+	return GetAIContentProcessCraftOptions(m["rule"], m["extra-payload"], m["placement"])
+}
+
+func GetAIContentProcessCraftOptions(rule string, extraPayloadRaw string, placementRaw string) []CraftOption {
+	return []CraftOption{
+		OptionAIContentProcess(rule, extraPayloadRaw, placementRaw),
+	}
+}
+
+func OptionAIContentProcess(rule string, extraPayloadRaw string, placementRaw string) CraftOption {
+	rule = strings.TrimSpace(rule)
+	payloadTypes := parseAIFilterExtraPayloadWithDefault(extraPayloadRaw, []aiFilterExtraPayloadType{aiFilterExtraPayloadArticleContent})
+	placement := parseAIContentProcessPlacement(placementRaw)
+
+	transFunc := func(item *feeds.Item) (string, error) {
+		if rule == "" {
+			return "", fmt.Errorf("ai-content-process requires rule param")
+		}
+		original := getPrimaryFeedItemContent(item)
+		generated, err := processAIContentForItem(item, rule, payloadTypes)
+		if err != nil {
+			return "", err
+		}
+		return applyAIContentProcessPlacement(original, generated, placement), nil
+	}
+
+	cachedTransformer := GetCommonCachedTransformer(
+		newAIContentProcessCacheKeyGenerator(rule, payloadTypes, placement),
+		transFunc,
+		"ai-content-process",
+	)
+	return OptionTransformFeedItem(GetArticleContentProcessor(cachedTransformer))
+}
+
+func processAIContentForItem(item *feeds.Item, rule string, payloadTypes []aiFilterExtraPayloadType) (string, error) {
+	context, err := buildAIContentProcessArticlePayload(item, payloadTypes)
+	if err != nil {
+		return "", err
+	}
+
+	prompt := buildAIContentProcessPrompt(rule)
+	result, err := llmContextCaller(prompt, context, util.ContentProcessOption{
+		RemoveImage: true,
+		ConvertToMd: true,
+	})
+	if err != nil {
+		return "", err
+	}
+	return normalizeAIContentProcessMarkdown(result), nil
+}
+
+func buildAIContentProcessArticlePayload(item *feeds.Item, payloadTypes []aiFilterExtraPayloadType) (string, error) {
+	summary := ""
+	if loContainsAIFilterPayload(payloadTypes, aiFilterExtraPayloadArticleSummary) {
+		generated, err := generateAIFilterArticleSummary(item)
+		if err != nil {
+			return "", err
+		}
+		summary = generated
+	}
+	return buildAIFilterArticlePayload(item, payloadTypes, summary)
+}
+
+func buildAIContentProcessPrompt(rule string) string {
+	return fmt.Sprintf(`You are an RSS article content processing assistant.
+
+User processing rule:
+%s
+
+Process the article according to the rule.
+
+Output requirements:
+- Return only the processed article content in Markdown.
+- Do not include explanations, greetings, metadata, or unrelated text.
+- Do not wrap the answer in markdown code fences.
+- Do not use unnecessary code blocks.
+- Preserve useful links and images when they are relevant to the processed result.`, rule)
+}
+
+func parseAIContentProcessPlacement(raw string) aiContentProcessPlacement {
+	switch aiContentProcessPlacement(strings.ToLower(strings.TrimSpace(raw))) {
+	case aiContentProcessPlacementReplace:
+		return aiContentProcessPlacementReplace
+	case aiContentProcessPlacementAppend:
+		return aiContentProcessPlacementAppend
+	default:
+		return aiContentProcessPlacementPrepend
+	}
+}
+
+func applyAIContentProcessPlacement(originalHTML string, generatedMarkdown string, placement aiContentProcessPlacement) string {
+	generatedHTML := util.Markdown2HTML(generatedMarkdown)
+	switch placement {
+	case aiContentProcessPlacementReplace:
+		return generatedHTML
+	case aiContentProcessPlacementAppend:
+		return fmt.Sprintf(`<div><div>%s</div><hr/><br/><div>%s</div></div>`, originalHTML, generatedHTML)
+	default:
+		return combineArticleHTMLWithGeneratedMarkdown(originalHTML, generatedMarkdown)
+	}
+}
+
+func normalizeAIContentProcessMarkdown(raw string) string {
+	trimmed := strings.TrimSpace(raw)
+	if !strings.HasPrefix(trimmed, "```") {
+		return trimmed
+	}
+
+	lines := strings.Split(trimmed, "\n")
+	if len(lines) < 3 {
+		return trimmed
+	}
+	infoString := strings.TrimSpace(strings.TrimPrefix(lines[0], "```"))
+	if infoString != "" && infoString != "markdown" && infoString != "md" {
+		return trimmed
+	}
+	if strings.TrimSpace(lines[len(lines)-1]) != "```" {
+		return trimmed
+	}
+	return strings.TrimSpace(strings.Join(lines[1:len(lines)-1], "\n"))
+}
+
+func newAIContentProcessCacheKeyGenerator(rule string, payloadTypes []aiFilterExtraPayloadType, placement aiContentProcessPlacement) ContentCacheKeyGenerator {
+	ruleHash := util.GetTextContentHash(rule)
+	payloadHash := util.GetTextContentHash(strings.Join(aiFilterPayloadTypesToStrings(payloadTypes), ","))
+	return func(item *feeds.Item) (string, error) {
+		return util.GetTextContentHash(strings.Join([]string{
+			ruleHash,
+			payloadHash,
+			string(placement),
+			strings.TrimSpace(item.Title),
+			util.GetTextContentHash(getPrimaryFeedItemContent(item)),
+		}, "|")), nil
+	}
+}
+
+func aiFilterPayloadTypesToStrings(payloadTypes []aiFilterExtraPayloadType) []string {
+	values := make([]string, 0, len(payloadTypes))
+	for _, payloadType := range payloadTypes {
+		values = append(values, string(payloadType))
+	}
+	return values
+}
+
+func loContainsAIFilterPayload(payloadTypes []aiFilterExtraPayloadType, target aiFilterExtraPayloadType) bool {
+	for _, payloadType := range payloadTypes {
+		if payloadType == target {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/craft/ai_content_process.go
+++ b/internal/craft/ai_content_process.go
@@ -79,6 +79,7 @@ func cachedAIContentProcessItem(item *feeds.Item, prompt string, payloadTypes []
 		result, callErr := llmContextCaller(prompt, context, util.ContentProcessOption{
 			RemoveImage: true,
 			ConvertToMd: true,
+			Temperature: util.LowestLLMTemperaturePtr(),
 		})
 		if callErr != nil {
 			return "", callErr

--- a/internal/craft/ai_content_process.go
+++ b/internal/craft/ai_content_process.go
@@ -7,6 +7,7 @@ import (
 	"FeedCraft/internal/util"
 
 	"github.com/gorilla/feeds"
+	"github.com/sirupsen/logrus"
 )
 
 type aiContentProcessPlacement string
@@ -49,42 +50,48 @@ func OptionAIContentProcess(rule string, extraPayloadRaw string, placementRaw st
 	rule = strings.TrimSpace(rule)
 	payloadTypes := parseAIFilterExtraPayloadWithDefault(extraPayloadRaw, []aiFilterExtraPayloadType{aiFilterExtraPayloadArticleContent})
 	placement := parseAIContentProcessPlacement(placementRaw)
+	prompt := buildAIContentProcessPrompt(rule)
 
 	transFunc := func(item *feeds.Item) (string, error) {
 		if rule == "" {
 			return "", fmt.Errorf("ai-content-process requires rule param")
 		}
-		original := getPrimaryFeedItemContent(item)
-		generated, err := processAIContentForItem(item, rule, payloadTypes)
-		if err != nil {
-			return "", err
-		}
-		return applyAIContentProcessPlacement(original, generated, placement), nil
+		return cachedAIContentProcessItem(item, prompt, payloadTypes, placement)
 	}
 
-	cachedTransformer := GetCommonCachedTransformer(
-		newAIContentProcessCacheKeyGenerator(rule, payloadTypes, placement),
-		transFunc,
-		"ai-content-process",
-	)
-	return OptionTransformFeedItem(GetArticleContentProcessor(cachedTransformer))
+	return OptionTransformFeedItem(GetArticleContentProcessor(transFunc))
 }
 
-func processAIContentForItem(item *feeds.Item, rule string, payloadTypes []aiFilterExtraPayloadType) (string, error) {
+func cachedAIContentProcessItem(item *feeds.Item, prompt string, payloadTypes []aiFilterExtraPayloadType, placement aiContentProcessPlacement) (string, error) {
+	original := getPrimaryFeedItemContent(item)
 	context, err := buildAIContentProcessArticlePayload(item, payloadTypes)
 	if err != nil {
 		return "", err
 	}
+	cacheKey := getCraftCacheKey("ai-content-process-result", util.GetTextContentHash(strings.Join([]string{
+		util.GetTextContentHash(prompt),
+		util.GetTextContentHash(context),
+		string(placement),
+		util.GetTextContentHash(original),
+	}, "|")))
 
-	prompt := buildAIContentProcessPrompt(rule)
-	result, err := llmContextCaller(prompt, context, util.ContentProcessOption{
-		RemoveImage: true,
-		ConvertToMd: true,
+	return util.CachedFuncWithPreLog(cacheKey, func() (string, error) {
+		result, callErr := llmContextCaller(prompt, context, util.ContentProcessOption{
+			RemoveImage: true,
+			ConvertToMd: true,
+		})
+		if callErr != nil {
+			return "", callErr
+		}
+		generated := normalizeAIContentProcessMarkdown(result)
+		return applyAIContentProcessPlacement(original, generated, placement), nil
+	}, func(isCached bool) {
+		title := ""
+		if item != nil {
+			title = item.Title
+		}
+		logrus.Infof("applying craft [ai-content-process] to article [%s], cached: %v", title, isCached)
 	})
-	if err != nil {
-		return "", err
-	}
-	return normalizeAIContentProcessMarkdown(result), nil
 }
 
 func buildAIContentProcessArticlePayload(item *feeds.Item, payloadTypes []aiFilterExtraPayloadType) (string, error) {
@@ -148,7 +155,7 @@ func normalizeAIContentProcessMarkdown(raw string) string {
 	if len(lines) < 3 {
 		return trimmed
 	}
-	infoString := strings.TrimSpace(strings.TrimPrefix(lines[0], "```"))
+	infoString := strings.ToLower(strings.TrimSpace(strings.TrimPrefix(lines[0], "```")))
 	if infoString != "" && infoString != "markdown" && infoString != "md" {
 		return trimmed
 	}
@@ -156,28 +163,6 @@ func normalizeAIContentProcessMarkdown(raw string) string {
 		return trimmed
 	}
 	return strings.TrimSpace(strings.Join(lines[1:len(lines)-1], "\n"))
-}
-
-func newAIContentProcessCacheKeyGenerator(rule string, payloadTypes []aiFilterExtraPayloadType, placement aiContentProcessPlacement) ContentCacheKeyGenerator {
-	ruleHash := util.GetTextContentHash(rule)
-	payloadHash := util.GetTextContentHash(strings.Join(aiFilterPayloadTypesToStrings(payloadTypes), ","))
-	return func(item *feeds.Item) (string, error) {
-		return util.GetTextContentHash(strings.Join([]string{
-			ruleHash,
-			payloadHash,
-			string(placement),
-			strings.TrimSpace(item.Title),
-			util.GetTextContentHash(getPrimaryFeedItemContent(item)),
-		}, "|")), nil
-	}
-}
-
-func aiFilterPayloadTypesToStrings(payloadTypes []aiFilterExtraPayloadType) []string {
-	values := make([]string, 0, len(payloadTypes))
-	for _, payloadType := range payloadTypes {
-		values = append(values, string(payloadType))
-	}
-	return values
 }
 
 func loContainsAIFilterPayload(payloadTypes []aiFilterExtraPayloadType, target aiFilterExtraPayloadType) bool {

--- a/internal/craft/ai_content_process.go
+++ b/internal/craft/ai_content_process.go
@@ -139,9 +139,9 @@ func applyAIContentProcessPlacement(originalHTML string, generatedMarkdown strin
 	case aiContentProcessPlacementReplace:
 		return generatedHTML
 	case aiContentProcessPlacementAppend:
-		return fmt.Sprintf(`<div><div>%s</div><hr/><br/><div>%s</div></div>`, originalHTML, generatedHTML)
+		return combineArticleHTMLFragments(originalHTML, generatedHTML)
 	default:
-		return combineArticleHTMLWithGeneratedMarkdown(originalHTML, generatedMarkdown)
+		return combineArticleHTMLFragments(generatedHTML, originalHTML)
 	}
 }
 

--- a/internal/craft/ai_content_process_test.go
+++ b/internal/craft/ai_content_process_test.go
@@ -210,6 +210,14 @@ func TestAIContentProcessCraftLoadParamUsesDefaultsAndRegistersTemplate(t *testi
 	assert.Contains(t, seenContext, "Article Content:")
 }
 
+func TestParameterizedSystemCraftTemplatesAreMarkedTemplateOnly(t *testing.T) {
+	templates := GetSysCraftTemplateDict()
+
+	assert.True(t, templates["ai-filter"].TemplateOnly)
+	assert.True(t, templates["ai-content-process"].TemplateOnly)
+	assert.False(t, templates["summary"].TemplateOnly)
+}
+
 func TestNormalizeAIContentProcessMarkdownRemovesCodeFence(t *testing.T) {
 	result := normalizeAIContentProcessMarkdown("```markdown\n# Title\n\nBody\n```")
 

--- a/internal/craft/ai_content_process_test.go
+++ b/internal/craft/ai_content_process_test.go
@@ -3,6 +3,7 @@ package craft
 import (
 	"strings"
 	"testing"
+	"time"
 
 	"FeedCraft/internal/util"
 
@@ -115,6 +116,50 @@ func TestOptionAIContentProcessCacheKeyIncludesPlacement(t *testing.T) {
 	assert.Less(t, strings.Index(appendFeed.Items[0].Content, "same original body"), strings.Index(appendFeed.Items[0].Content, "Generated note"))
 }
 
+func TestOptionAIContentProcessCacheKeyIncludesArticleDatePayload(t *testing.T) {
+	setupTestRedis(t)
+
+	original := llmContextCaller
+	calls := 0
+	llmContextCaller = func(prompt, context string, option util.ContentProcessOption) (string, error) {
+		calls += 1
+		if strings.Contains(context, "2026-05-02") {
+			return "Generated for May 2", nil
+		}
+		return "Generated for May 1", nil
+	}
+	t.Cleanup(func() { llmContextCaller = original })
+
+	firstFeed := &feeds.Feed{
+		Items: []*feeds.Item{
+			{
+				Title:   "Same date payload " + t.Name(),
+				Content: "<p>same body</p>",
+				Created: time.Date(2026, 5, 1, 10, 0, 0, 0,
+					time.UTC),
+			},
+		},
+	}
+	err := OptionAIContentProcess("按日期生成说明", "article_date", string(aiContentProcessPlacementReplace))(firstFeed, ExtraPayload{})
+	require.NoError(t, err)
+	assert.Contains(t, firstFeed.Items[0].Content, "Generated for May 1")
+
+	secondFeed := &feeds.Feed{
+		Items: []*feeds.Item{
+			{
+				Title:   "Same date payload " + t.Name(),
+				Content: "<p>same body</p>",
+				Created: time.Date(2026, 5, 2, 10, 0, 0, 0,
+					time.UTC),
+			},
+		},
+	}
+	err = OptionAIContentProcess("按日期生成说明", "article_date", string(aiContentProcessPlacementReplace))(secondFeed, ExtraPayload{})
+	require.NoError(t, err)
+	assert.Contains(t, secondFeed.Items[0].Content, "Generated for May 2")
+	assert.Equal(t, 2, calls)
+}
+
 func TestAIContentProcessCraftLoadParamUsesDefaultsAndRegistersTemplate(t *testing.T) {
 	setupTestRedis(t)
 
@@ -150,6 +195,12 @@ func TestAIContentProcessCraftLoadParamUsesDefaultsAndRegistersTemplate(t *testi
 
 func TestNormalizeAIContentProcessMarkdownRemovesCodeFence(t *testing.T) {
 	result := normalizeAIContentProcessMarkdown("```markdown\n# Title\n\nBody\n```")
+
+	assert.Equal(t, "# Title\n\nBody", result)
+}
+
+func TestNormalizeAIContentProcessMarkdownRemovesCaseInsensitiveMarkdownFence(t *testing.T) {
+	result := normalizeAIContentProcessMarkdown("```Markdown\n# Title\n\nBody\n```")
 
 	assert.Equal(t, "# Title\n\nBody", result)
 }

--- a/internal/craft/ai_content_process_test.go
+++ b/internal/craft/ai_content_process_test.go
@@ -1,0 +1,161 @@
+package craft
+
+import (
+	"strings"
+	"testing"
+
+	"FeedCraft/internal/util"
+
+	"github.com/gorilla/feeds"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOptionAIContentProcessPrependsGeneratedMarkdownAsHTML(t *testing.T) {
+	setupTestRedis(t)
+
+	original := llmContextCaller
+	var seenPrompt string
+	var seenContext string
+	llmContextCaller = func(prompt, context string, option util.ContentProcessOption) (string, error) {
+		seenPrompt = prompt
+		seenContext = context
+		assert.True(t, option.ConvertToMd)
+		assert.True(t, option.RemoveImage)
+		return "## AI Takeaway\n\n- Generated insight", nil
+	}
+	t.Cleanup(func() { llmContextCaller = original })
+
+	feed := &feeds.Feed{
+		Items: []*feeds.Item{
+			{
+				Title:   "Processor input " + t.Name(),
+				Content: "<p>original article content</p>",
+			},
+		},
+	}
+
+	err := OptionAIContentProcess("提取适合忙人阅读的要点", "article_content", string(aiContentProcessPlacementPrepend))(feed, ExtraPayload{})
+
+	require.NoError(t, err)
+	require.Len(t, feed.Items, 1)
+	content := feed.Items[0].Content
+	assert.Contains(t, content, "<h2")
+	assert.Contains(t, content, "AI Takeaway")
+	assert.Contains(t, content, "<li>Generated insight</li>")
+	assert.Contains(t, content, "<p>original article content</p>")
+	assert.Less(t, strings.Index(content, "AI Takeaway"), strings.Index(content, "original article content"))
+	assert.Equal(t, feed.Items[0].Content, feed.Items[0].Description)
+	assert.Contains(t, seenPrompt, "提取适合忙人阅读的要点")
+	assert.Contains(t, seenPrompt, "Return only the processed article content in Markdown")
+	assert.Contains(t, seenPrompt, "Do not wrap the answer in markdown code fences")
+	assert.Contains(t, seenContext, "Article Content:")
+	assert.Contains(t, seenContext, "original article content")
+}
+
+func TestOptionAIContentProcessSupportsReplaceAndAppendPlacements(t *testing.T) {
+	setupTestRedis(t)
+
+	original := llmContextCaller
+	llmContextCaller = func(prompt, context string, option util.ContentProcessOption) (string, error) {
+		return "### Generated\n\nreplacement or appendix", nil
+	}
+	t.Cleanup(func() { llmContextCaller = original })
+
+	replaceFeed := &feeds.Feed{
+		Items: []*feeds.Item{
+			{Title: "Replace " + t.Name(), Content: "<p>original body</p>"},
+		},
+	}
+	err := OptionAIContentProcess("改写正文", "article_content", string(aiContentProcessPlacementReplace))(replaceFeed, ExtraPayload{})
+	require.NoError(t, err)
+	assert.Contains(t, replaceFeed.Items[0].Content, "<h3")
+	assert.Contains(t, replaceFeed.Items[0].Content, "replacement or appendix")
+	assert.NotContains(t, replaceFeed.Items[0].Content, "original body")
+
+	appendFeed := &feeds.Feed{
+		Items: []*feeds.Item{
+			{Title: "Append " + t.Name(), Content: "<p>original body</p>"},
+		},
+	}
+	err = OptionAIContentProcess("生成相关阅读建议", "article_content", string(aiContentProcessPlacementAppend))(appendFeed, ExtraPayload{})
+	require.NoError(t, err)
+	content := appendFeed.Items[0].Content
+	assert.Contains(t, content, "<p>original body</p>")
+	assert.Contains(t, content, "replacement or appendix")
+	assert.Less(t, strings.Index(content, "original body"), strings.Index(content, "replacement or appendix"))
+}
+
+func TestOptionAIContentProcessCacheKeyIncludesPlacement(t *testing.T) {
+	setupTestRedis(t)
+
+	original := llmContextCaller
+	llmContextCaller = func(prompt, context string, option util.ContentProcessOption) (string, error) {
+		return "Generated note", nil
+	}
+	t.Cleanup(func() { llmContextCaller = original })
+
+	replaceFeed := &feeds.Feed{
+		Items: []*feeds.Item{
+			{Title: "Same cache key " + t.Name(), Content: "<p>same original body</p>"},
+		},
+	}
+	err := OptionAIContentProcess("同一规则", "article_content", string(aiContentProcessPlacementReplace))(replaceFeed, ExtraPayload{})
+	require.NoError(t, err)
+	assert.NotContains(t, replaceFeed.Items[0].Content, "same original body")
+
+	appendFeed := &feeds.Feed{
+		Items: []*feeds.Item{
+			{Title: "Same cache key " + t.Name(), Content: "<p>same original body</p>"},
+		},
+	}
+	err = OptionAIContentProcess("同一规则", "article_content", string(aiContentProcessPlacementAppend))(appendFeed, ExtraPayload{})
+	require.NoError(t, err)
+	assert.Contains(t, appendFeed.Items[0].Content, "same original body")
+	assert.Less(t, strings.Index(appendFeed.Items[0].Content, "same original body"), strings.Index(appendFeed.Items[0].Content, "Generated note"))
+}
+
+func TestAIContentProcessCraftLoadParamUsesDefaultsAndRegistersTemplate(t *testing.T) {
+	setupTestRedis(t)
+
+	original := llmContextCaller
+	var seenContext string
+	llmContextCaller = func(prompt, context string, option util.ContentProcessOption) (string, error) {
+		seenContext = context
+		return "Generated default summary", nil
+	}
+	t.Cleanup(func() { llmContextCaller = original })
+
+	tmpl, ok := GetSysCraftTemplateDict()["ai-content-process"]
+	require.True(t, ok)
+	assert.Equal(t, "ai-content-process", tmpl.Name)
+	assert.NotEmpty(t, tmpl.ParamTemplateDefine)
+
+	options := aiContentProcessCraftLoadParam(map[string]string{
+		"rule": "生成一段摘要",
+	})
+	require.Len(t, options, 1)
+
+	feed := &feeds.Feed{
+		Items: []*feeds.Item{
+			{Title: "Default " + t.Name(), Content: "<p>default content payload</p>"},
+		},
+	}
+	err := options[0](feed, ExtraPayload{})
+	require.NoError(t, err)
+	assert.Contains(t, feed.Items[0].Content, "Generated default summary")
+	assert.Contains(t, feed.Items[0].Content, "default content payload")
+	assert.Contains(t, seenContext, "Article Content:")
+}
+
+func TestNormalizeAIContentProcessMarkdownRemovesCodeFence(t *testing.T) {
+	result := normalizeAIContentProcessMarkdown("```markdown\n# Title\n\nBody\n```")
+
+	assert.Equal(t, "# Title\n\nBody", result)
+}
+
+func TestNormalizeAIContentProcessMarkdownKeepsIntentionalCodeBlock(t *testing.T) {
+	result := normalizeAIContentProcessMarkdown("```go\nfmt.Println(\"hello\")\n```")
+
+	assert.Equal(t, "```go\nfmt.Println(\"hello\")\n```", result)
+}

--- a/internal/craft/ai_content_process_test.go
+++ b/internal/craft/ai_content_process_test.go
@@ -23,6 +23,8 @@ func TestOptionAIContentProcessPrependsGeneratedMarkdownAsHTML(t *testing.T) {
 		seenContext = context
 		assert.True(t, option.ConvertToMd)
 		assert.True(t, option.RemoveImage)
+		require.NotNil(t, option.Temperature)
+		assert.Equal(t, 0.0, *option.Temperature)
 		return "## AI Takeaway\n\n- Generated insight", nil
 	}
 	t.Cleanup(func() { llmContextCaller = original })

--- a/internal/craft/ai_content_process_test.go
+++ b/internal/craft/ai_content_process_test.go
@@ -87,6 +87,21 @@ func TestOptionAIContentProcessSupportsReplaceAndAppendPlacements(t *testing.T) 
 	assert.Less(t, strings.Index(content, "original body"), strings.Index(content, "replacement or appendix"))
 }
 
+func TestApplyAIContentProcessPlacementOmitsSeparatorWhenOriginalEmpty(t *testing.T) {
+	generatedMarkdown := "## Generated\n\nNo original content"
+
+	prepended := applyAIContentProcessPlacement("", generatedMarkdown, aiContentProcessPlacementPrepend)
+	appended := applyAIContentProcessPlacement("", generatedMarkdown, aiContentProcessPlacementAppend)
+
+	for _, content := range []string{prepended, appended} {
+		assert.Contains(t, content, "<h2")
+		assert.Contains(t, content, "No original content")
+		assert.NotContains(t, content, "<hr")
+		assert.NotContains(t, content, "<br")
+	}
+	assert.Equal(t, prepended, appended)
+}
+
 func TestOptionAIContentProcessCacheKeyIncludesPlacement(t *testing.T) {
 	setupTestRedis(t)
 

--- a/internal/craft/ai_filter.go
+++ b/internal/craft/ai_filter.go
@@ -105,9 +105,13 @@ func evaluateAIFilterItem(item *feeds.Item, rule string, payloadTypes []aiFilter
 }
 
 func parseAIFilterExtraPayload(raw string) []aiFilterExtraPayloadType {
+	return parseAIFilterExtraPayloadWithDefault(raw, []aiFilterExtraPayloadType{aiFilterExtraPayloadArticleSummary})
+}
+
+func parseAIFilterExtraPayloadWithDefault(raw string, defaultPayloadTypes []aiFilterExtraPayloadType) []aiFilterExtraPayloadType {
 	raw = strings.TrimSpace(raw)
 	if raw == "" {
-		return []aiFilterExtraPayloadType{aiFilterExtraPayloadArticleSummary}
+		return defaultPayloadTypes
 	}
 
 	normalized := strings.NewReplacer("|", ",", "\n", ",", "\t", ",").Replace(raw)
@@ -129,7 +133,7 @@ func parseAIFilterExtraPayload(raw string) []aiFilterExtraPayloadType {
 		}
 	}
 	if len(payloadTypes) == 0 {
-		return []aiFilterExtraPayloadType{aiFilterExtraPayloadArticleSummary}
+		return defaultPayloadTypes
 	}
 	return payloadTypes
 }

--- a/internal/craft/ai_filter.go
+++ b/internal/craft/ai_filter.go
@@ -168,6 +168,7 @@ func cachedAIFilterDecision(title string, prompt string, context string) (aiFilt
 		result, err := llmContextCaller(prompt, context, util.ContentProcessOption{
 			RemoveImage: true,
 			ConvertToMd: true,
+			Temperature: util.LowestLLMTemperaturePtr(),
 		})
 		if err != nil {
 			return "", err
@@ -251,7 +252,9 @@ func generateAIFilterArticleSummary(item *feeds.Item) (string, error) {
 		if strings.TrimSpace(cleanedContent) != "" {
 			processedContent = cleanedContent
 		}
-		return llmContextCaller(summaryPrompt, processedContent, util.ContentProcessOption{})
+		return llmContextCaller(summaryPrompt, processedContent, util.ContentProcessOption{
+			Temperature: util.LowestLLMTemperaturePtr(),
+		})
 	}, func(isCached bool) {
 		logrus.Infof("generating ai-filter article summary for article [%s], cached: %v", item.Title, isCached)
 	})

--- a/internal/craft/ai_filter_test.go
+++ b/internal/craft/ai_filter_test.go
@@ -92,6 +92,8 @@ func TestOptionAIFilterKeepsArticleOnInvalidLLMResponse(t *testing.T) {
 
 	original := llmContextCaller
 	llmContextCaller = func(prompt, context string, option util.ContentProcessOption) (string, error) {
+		require.NotNil(t, option.Temperature)
+		assert.Equal(t, 0.0, *option.Temperature)
 		return "not json", nil
 	}
 	t.Cleanup(func() { llmContextCaller = original })

--- a/internal/craft/common_llm_logic.go
+++ b/internal/craft/common_llm_logic.go
@@ -26,6 +26,7 @@ func CheckConditionWithLLM(title string, content string, conditionPrompt string)
 	option := util.ContentProcessOption{
 		RemoveImage: true,
 		ConvertToMd: true,
+		Temperature: util.LowestLLMTemperaturePtr(),
 	}
 
 	// 如果 prompt 没有明确包含 true/false 的指令，建议调用者在传入前拼接好。

--- a/internal/craft/craft_template.go
+++ b/internal/craft/craft_template.go
@@ -7,6 +7,7 @@ type CraftTemplate struct {
 	Name                string                                `json:"name" binding:"required"`
 	Description         string                                `json:"description"`
 	ParamTemplateDefine []ParamTemplate                       `json:"param_template_define"` // param 格式, 主要给用户填写时提供参考
+	TemplateOnly        bool                                  `json:"template_only"`         // 仅作为用户自定义 AtomCraft 的模板，不应直接作为可选 craft 使用
 	OptionFunc          func(map[string]string) []CraftOption `json:"-"`
 }
 

--- a/internal/craft/entry.go
+++ b/internal/craft/entry.go
@@ -112,6 +112,12 @@ func GetSysCraftTemplateDict() map[string]CraftTemplate {
 		ParamTemplateDefine: aiFilterCraftParamTmpl,
 		OptionFunc:          aiFilterCraftLoadParam,
 	}
+	sysCraftTempList["ai-content-process"] = CraftTemplate{
+		Name:                "ai-content-process",
+		Description:         "使用 LLM 根据自定义规则处理文章内容，可追加到开头、替换原文或追加到末尾",
+		ParamTemplateDefine: aiContentProcessCraftParamTmpl,
+		OptionFunc:          aiContentProcessCraftLoadParam,
+	}
 	sysCraftTempList["translate-title"] = CraftTemplate{
 		Name:                "translate-title",
 		Description:         "使用 LLM 将标题翻译为中文",

--- a/internal/craft/entry.go
+++ b/internal/craft/entry.go
@@ -110,12 +110,14 @@ func GetSysCraftTemplateDict() map[string]CraftTemplate {
 		Name:                "ai-filter",
 		Description:         "使用 LLM 根据自定义规则判断文章应保留还是排除，要求返回 JSON",
 		ParamTemplateDefine: aiFilterCraftParamTmpl,
+		TemplateOnly:        true,
 		OptionFunc:          aiFilterCraftLoadParam,
 	}
 	sysCraftTempList["ai-content-process"] = CraftTemplate{
 		Name:                "ai-content-process",
 		Description:         "使用 LLM 根据自定义规则处理文章内容，可追加到开头、替换原文或追加到末尾",
 		ParamTemplateDefine: aiContentProcessCraftParamTmpl,
+		TemplateOnly:        true,
 		OptionFunc:          aiContentProcessCraftLoadParam,
 	}
 	sysCraftTempList["translate-title"] = CraftTemplate{

--- a/internal/craft/llm_processors.go
+++ b/internal/craft/llm_processors.go
@@ -383,5 +383,17 @@ func getArticleContentForPrompt(article *model.CraftArticle, original string) st
 
 func combineArticleHTMLWithGeneratedMarkdown(originalHTML string, generatedMarkdown string) string {
 	processedHTML := util.Markdown2HTML(generatedMarkdown)
-	return fmt.Sprintf(`<div><div>%s</div><hr/><br/><div>%s</div></div>`, processedHTML, originalHTML)
+	return combineArticleHTMLFragments(processedHTML, originalHTML)
+}
+
+func combineArticleHTMLFragments(firstHTML string, secondHTML string) string {
+	firstHTML = strings.TrimSpace(firstHTML)
+	secondHTML = strings.TrimSpace(secondHTML)
+	if firstHTML == "" {
+		return secondHTML
+	}
+	if secondHTML == "" {
+		return firstHTML
+	}
+	return fmt.Sprintf(`<div><div>%s</div><hr/><br/><div>%s</div></div>`, firstHTML, secondHTML)
 }

--- a/internal/craft/runtime_test.go
+++ b/internal/craft/runtime_test.go
@@ -397,6 +397,8 @@ func TestLLMFilterProcessor_RemovesMatchedArticleAndUsesTitleContentPayload(t *t
 	original := llmContextCaller
 	var seen []string
 	llmContextCaller = func(prompt, context string, option util.ContentProcessOption) (string, error) {
+		require.NotNil(t, option.Temperature)
+		assert.Equal(t, 0.0, *option.Temperature)
 		seen = append(seen, context)
 		if strings.Contains(context, "Drop Me "+t.Name()) {
 			return "true", nil

--- a/internal/util/content_processor.go
+++ b/internal/util/content_processor.go
@@ -16,6 +16,14 @@ type ContentProcessOption struct {
 	RemoveLinks bool
 	RemoveImage bool
 	ConvertToMd bool
+	Temperature *float64
+}
+
+const LowestLLMTemperature = 0.0
+
+func LowestLLMTemperaturePtr() *float64 {
+	temperature := LowestLLMTemperature
+	return &temperature
 }
 
 func ProcessContent(content string, option ContentProcessOption) string {

--- a/web/admin/src/api/craft_flow.ts
+++ b/web/admin/src/api/craft_flow.ts
@@ -79,6 +79,7 @@ interface CraftTemplate {
   name: string;
   description?: string;
   param_template_define: ParamTemplate[];
+  template_only?: boolean;
 }
 
 export function listCraftTemplates(): Promise<APIResponse<CraftTemplate[]>> {

--- a/web/admin/src/locale/en-US/allCraftList.ts
+++ b/web/admin/src/locale/en-US/allCraftList.ts
@@ -4,6 +4,7 @@ export default {
   'allCraftList.query': 'Query',
   'allCraftList.table.name': 'Name',
   'allCraftList.table.type': 'Type',
+  'allCraftList.table.templateOnly': 'Template Only',
   'allCraftList.table.description': 'Description',
   'allCraftList.message.fetchFailed': 'Failed to fetch all Crafts',
 };

--- a/web/admin/src/locale/zh-CN/allCraftList.ts
+++ b/web/admin/src/locale/zh-CN/allCraftList.ts
@@ -4,6 +4,7 @@ export default {
   'allCraftList.query': '查询',
   'allCraftList.table.name': '名称',
   'allCraftList.table.type': '类型',
+  'allCraftList.table.templateOnly': '仅模板',
   'allCraftList.table.description': '描述',
   'allCraftList.message.fetchFailed': '获取所有 Craft 失败',
 };

--- a/web/admin/src/views/dashboard/all_craft_list/all_craft_list.vue
+++ b/web/admin/src/views/dashboard/all_craft_list/all_craft_list.vue
@@ -32,6 +32,7 @@
     name: string;
     description: string;
     type: string;
+    template_only?: boolean;
   }
 
   const isLoading = ref(false);
@@ -40,6 +41,7 @@
   const columns = [
     { title: t('allCraftList.table.name'), dataIndex: 'name' },
     { title: t('allCraftList.table.type'), dataIndex: 'type' },
+    { title: t('allCraftList.table.templateOnly'), dataIndex: 'template_only' },
     { title: t('allCraftList.table.description'), dataIndex: 'description' },
   ];
 

--- a/web/admin/src/views/dashboard/craft_flow/components/CraftList.vue
+++ b/web/admin/src/views/dashboard/craft_flow/components/CraftList.vue
@@ -89,7 +89,9 @@
 
   const searchText = ref('');
   const craftFlows = ref<CraftFlow[]>([]);
-  const sysCraftAtomList = ref<{ name: string; description?: string }[]>([]);
+  const sysCraftAtomList = ref<
+    { name: string; description?: string; template_only?: boolean }[]
+  >([]);
   const craftAtomList = ref<{ name: string; description?: string }[]>([]);
 
   // Fetch data
@@ -102,7 +104,9 @@
           listCraftAtoms(),
         ]);
       craftFlows.value = craftFlowsResponse.data || [];
-      sysCraftAtomList.value = sysCraftAtomsResponse.data || [];
+      sysCraftAtomList.value = (sysCraftAtomsResponse.data || []).filter(
+        (template) => !template.template_only
+      );
       craftAtomList.value = craftAtomsResponse.data || [];
     } catch (error) {
       // eslint-disable-next-line no-console


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add the `ai-content-process` system AtomCraft for rule-driven LLM article content processing.
- Support `placement` values `prepend`, `replace`, and `append` while converting generated Markdown to HTML.
- Reuse `ai-filter` extra payload parsing with configurable defaults and cover Markdown fence normalization plus cache behavior.
- Harden result caching so the full prompt/context, placement, original content, and low-temperature LLM cache behavior are isolated correctly.
- Avoid empty article content separators by sharing one HTML fragment combiner for prepend/append flows.
- Set deterministic AI craft calls such as `ai-filter`, `ai-content-process`, and LLM predicate filters to `temperature=0` to reduce hallucination risk.
- Mark parameterized system crafts such as `ai-filter` and `ai-content-process` as `template_only` and hide them from default craft pickers while keeping them available for custom AtomCraft creation.

### Walkthrough
[template_only_craft_picker.mp4](https://cursor.com/agents/bc-0bf2d805-9efe-48eb-8469-482214f6297b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftemplate_only_craft_picker.mp4)

### Testing
- `go test ./internal/craft -run TestParameterizedSystemCraftTemplatesAreMarkedTemplateOnly`
- `task fix` (passes; existing frontend ESLint warning remains in `web/admin/src/views/dashboard/topic_feed/detail.vue`)
- `go test ./...`
- `task --force backend-build`
- `task --force frontend-build`
- Manual browser test: Feed Compare picker hides `ai-filter` / `ai-content-process`; AtomCraft template dropdown still shows both.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0bf2d805-9efe-48eb-8469-482214f6297b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0bf2d805-9efe-48eb-8469-482214f6297b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

## Summary by Sourcery

Introduce an AI-driven article content processing craft that applies rule-based LLM transformations with configurable payloads and placements while hardening caching behavior.

New Features:
- Add the `ai-content-process` system craft for LLM-based article content processing with configurable rules and placements (prepend, replace, append).

Enhancements:
- Reuse and generalize AI filter extra payload parsing with customizable defaults for different crafts.
- Include placement, prompt/context, original content, and date payload in the AI content processing cache key to avoid incorrect cache hits.

Tests:
- Add unit tests covering ai-content-process behavior, including HTML/Markdown handling, placement modes, cache key semantics, craft template defaults, and markdown fence normalization.