### PR TITLE
docs: sync embedding filter updates (zh-CN, en, zh-TW) (#5abc636)

### DIFF
--- a/doc-site/src/content/docs/en/guides/advanced/system-craft-atoms.md
+++ b/doc-site/src/content/docs/en/guides/advanced/system-craft-atoms.md
@@ -140,6 +140,16 @@ Re-formats the article using LLM to fix layout, remove ads, and standardizing Ma
 
 Advanced filtering using semantic understanding.
 
+### `embedding-filter`
+
+Uses an Embedding model to filter articles by topic (zero-shot classification). Supports `include` (keep matches) and `exclude` (remove matches) modes.
+
+- **Parameters:**
+  - `anchors`: Topic anchor texts described in natural language, one per line. An article is considered a match if its similarity to any anchor exceeds the threshold.
+  - `threshold` (Default: `0.6`): Cosine similarity threshold (0-1), higher is stricter.
+  - `mode` (Default: `include`): Filter mode: `include` (keep matches) or `exclude` (remove matches).
+  - `max_content_length` (Default: `2000`): Maximum number of characters extracted from the article content to control the Embedding input length.
+
 ### `ignore-advertorial`
 
 Uses LLM to detect if an article is an advertorial or soft advertisement (evaluating both title and content) and removes it.

--- a/doc-site/src/content/docs/zh-tw/guides/advanced/system-craft-atoms.md
+++ b/doc-site/src/content/docs/zh-tw/guides/advanced/system-craft-atoms.md
@@ -141,6 +141,16 @@ FeedCraft 內建了一系列「原子工藝 (AtomCrafts)」，用於對訂閱源
 
 利用語義理解進行進階過濾。
 
+### `embedding-filter` (主題向量過濾)
+
+使用 Embedding 模型按主題過濾文章（零樣本分類）。支援 `include`（保留匹配項）和 `exclude`（移除匹配項）兩種模式。
+
+- **參數:**
+  - `anchors`: 自然語言描述的主題錨點文字，每行一條。文章與任一錨點相似度超過閾值即被視為匹配。
+  - `threshold` (預設: `0.6`): 餘弦相似度閾值（0-1），越高越嚴格。
+  - `mode` (預設: `include`): 過濾模式：`include` (保留匹配項) 或 `exclude` (移除匹配項)。
+  - `max_content_length` (預設: `2000`): 文章正文截取的最大字元數，用於控制 Embedding 輸入長度。
+
 ### `ignore-advertorial` (軟文過濾)
 
 使用 LLM 檢測文章是否為軟文或廣告（綜合評估標題和內容），並將其移除。

--- a/doc-site/src/content/docs/zh/guides/advanced/system-craft-atoms.md
+++ b/doc-site/src/content/docs/zh/guides/advanced/system-craft-atoms.md
@@ -141,6 +141,16 @@ FeedCraft 内置了一系列“原子工艺 (AtomCrafts)”，用于对订阅源
 
 利用语义理解进行高级过滤。
 
+### `embedding-filter` (主题向量过滤)
+
+使用 Embedding 模型按主题过滤文章（零样本分类）。支持 `include`（保留匹配项）和 `exclude`（移除匹配项）两种模式。
+
+- **参数:**
+  - `anchors`: 自然语言描述的主题锚点文本，每行一条。文章与任一锚点相似度超过阈值即被视为匹配。
+  - `threshold` (默认: `0.6`): 余弦相似度阈值（0-1），越高越严格。
+  - `mode` (默认: `include`): 过滤模式：`include` (保留匹配项) 或 `exclude` (移除匹配项)。
+  - `max_content_length` (默认: `2000`): 文章正文截取的最大字符数，用于控制 Embedding 输入长度。
+
 ### `ignore-advertorial` (软文过滤)
 
 使用 LLM 检测文章是否为软文或广告（综合评估标题和内容），并将其移除。


### PR DESCRIPTION
## What Changed 💡
- Synchronized documentation for Add embedding filter (#693) across all supported languages.
- **Languages Updated**: zh-CN (Source), en, zh-TW.

## Why 📖
Recent code changes (5abc636) require documentation sync to maintain multi-language consistency.

## Files Updated
| Language | File | Change Summary |
|----------|------|----------------|
| zh-CN    | `doc-site/src/content/docs/zh/guides/advanced/system-craft-atoms.md` | Primary update (Source) |
| en       | `doc-site/src/content/docs/en/guides/advanced/system-craft-atoms.md` | Native phrasing sync |
| zh-TW    | `doc-site/src/content/docs/zh-tw/guides/advanced/system-craft-atoms.md` | Sync from zh-CN |

---
*PR created automatically by Jules for task [15949527961840845943](https://jules.google.com/task/15949527961840845943) started by @Colin-XKL*

## Summary by Sourcery

Documentation:
- Describe the `embedding-filter` atom, its purpose, and parameters in the advanced system craft atoms guide for English, Simplified Chinese, and Traditional Chinese.