### PR TITLE
docs: sync ai-content-process updates (zh-CN, en, zh-TW) (#a417a5b)

### DIFF
--- a/doc-site/src/content/docs/en/guides/advanced/system-craft-atoms.md
+++ b/doc-site/src/content/docs/en/guides/advanced/system-craft-atoms.md
@@ -127,6 +127,15 @@ Generates a short introduction or "lead-in" for the article.
 - **Parameters:**
   - `prompt`: Custom prompt.
 
+### `ai-content-process`
+
+Process article content using LLM according to custom rules and insert the generated result at a specified position.
+
+- **Parameters:**
+  - `rule` (**Required**): Instruction for processing each article content. Example: "Summarize key points and list action items."
+  - `extra-payload` (Default: `article_content`): Comma-separated list of extra information to send to the LLM. Supported: `article_summary`, `article_content`, `article_date`, `raw_rss_item`.
+  - `placement` (Default: `prepend`): Where to write the generated content. Supported: `prepend`, `replace`, `append`.
+
 ### `beautify-content`
 
 Re-formats the article using LLM to fix layout, remove ads, and standardizing Markdown, then converts back to clean HTML.

--- a/doc-site/src/content/docs/zh-tw/guides/advanced/system-craft-atoms.md
+++ b/doc-site/src/content/docs/zh-tw/guides/advanced/system-craft-atoms.md
@@ -128,6 +128,15 @@ FeedCraft 內建了一系列「原子工藝 (AtomCrafts)」，用於對訂閱源
 - **參數:**
   - `prompt`: 自定義提示詞。
 
+### `ai-content-process` (AI 內容處理)
+
+根據自訂規則使用大型語言模型處理文章內容，並將生成結果插入到指定位置。
+
+- **參數:**
+  - `rule` (**必填**): 針對每篇文章內容的處理指令。例如："總結文章的關鍵觀點並列出行動建議"。
+  - `extra-payload` (預設: `article_content`): 逗號分隔的附加資訊列表，可發送給 LLM。支援：`article_summary` (AI 生成的摘要), `article_content` (文章內容), `article_date` (文章日期), `raw_rss_item` (原始 RSS 節點資料)。
+  - `placement` (預設: `prepend`): 生成內容的寫入位置。支援：`prepend` (在原文前追加), `replace` (替換原文), `append` (在原文後追加)。
+
 ### `beautify-content` (智能排版)
 
 使用 LLM 重新格式化文章，修復排版錯誤，去除廣告，並標準化 Markdown 格式，最後轉換回乾淨的 HTML。

--- a/doc-site/src/content/docs/zh/guides/advanced/system-craft-atoms.md
+++ b/doc-site/src/content/docs/zh/guides/advanced/system-craft-atoms.md
@@ -128,6 +128,15 @@ FeedCraft 内置了一系列“原子工艺 (AtomCrafts)”，用于对订阅源
 - **参数:**
   - `prompt`: 自定义提示词。
 
+### `ai-content-process` (AI 内容处理)
+
+根据自定义规则使用大语言模型处理文章内容，并将生成结果插入到指定位置。
+
+- **参数:**
+  - `rule` (**必填**): 针对每篇文章内容的处理指令。例如："总结文章的关键观点并列出行动建议"。
+  - `extra-payload` (默认: `article_content`): 逗号分隔的附加信息列表，可发送给 LLM。支持：`article_summary` (AI 生成的摘要), `article_content` (文章内容), `article_date` (文章日期), `raw_rss_item` (原始 RSS 节点数据)。
+  - `placement` (默认: `prepend`): 生成内容的写入位置。支持：`prepend` (在原文前追加), `replace` (替换原文), `append` (在原文后追加)。
+
 ### `beautify-content` (智能排版)
 
 使用 LLM 重新格式化文章，修复排版错误，去除广告，并标准化 Markdown 格式，最后转换回干净的 HTML。


### PR DESCRIPTION
## What Changed 💡
- Synchronized documentation for [Improve AtomCraft creation UX] across all supported languages by adding documentation for the `ai-content-process` system craft.
- **Languages Updated**: zh-CN (Source), en, zh-TW.

## Why 📖
Recent code changes (a417a5b97b49079082fb990a53ebfa98d7726357) added the new `ai-content-process` atom craft, which required documentation sync to maintain multi-language consistency.

## Files Updated
| Language | File | Change Summary |
|----------|------|----------------|
| zh-CN    | `doc-site/src/content/docs/zh/guides/advanced/system-craft-atoms.md` | Primary update (Source) |
| en       | `doc-site/src/content/docs/en/guides/advanced/system-craft-atoms.md`    | Native phrasing sync |
| zh-TW    | `doc-site/src/content/docs/zh-tw/guides/advanced/system-craft-atoms.md` | Sync from zh-CN |

---
*PR created automatically by Jules for task [8852455018387466296](https://jules.google.com/task/8852455018387466296) started by @Colin-XKL*

## Summary by Sourcery

Documentation:
- Add usage documentation for the ai-content-process atom in the advanced system-craft-atoms guide for zh-CN, en, and zh-TW.