### PR TITLE
fix: resolve inbox bugs found during end-to-end testing

### DIFF
--- a/internal/controller/feed_viewer.go
+++ b/internal/controller/feed_viewer.go
@@ -192,22 +192,22 @@ func formatFeedViewerISOTime(primary, fallback time.Time) string {
 func validateFeedViewerURL(rawURL string) error {
 	parsedURL, err := url.Parse(rawURL)
 	if err != nil || parsedURL == nil {
-		return errors.New("Please enter a valid http(s) feed URL")
+		return errors.New("please enter a valid http(s) feed URL")
 	}
 	if parsedURL.Scheme != "http" && parsedURL.Scheme != "https" {
-		return errors.New("Please enter a valid http(s) feed URL")
+		return errors.New("please enter a valid http(s) feed URL")
 	}
 	if parsedURL.Hostname() == "" {
-		return errors.New("Please enter a valid http(s) feed URL")
+		return errors.New("please enter a valid http(s) feed URL")
 	}
 
 	ips, err := net.LookupIP(parsedURL.Hostname())
 	if err != nil {
-		return fmt.Errorf("Unable to resolve this URL: %w", err)
+		return fmt.Errorf("unable to resolve this URL: %w", err)
 	}
 	for _, ip := range ips {
 		if ip.IsLoopback() || ip.IsPrivate() {
-			return fmt.Errorf("Access to private IP %s is forbidden", ip.String())
+			return fmt.Errorf("access to private IP %s is forbidden", ip.String())
 		}
 	}
 

--- a/internal/controller/inbox.go
+++ b/internal/controller/inbox.go
@@ -52,12 +52,25 @@ func GetInbox(c *gin.Context) {
 
 func UpdateInbox(c *gin.Context) {
 	id := c.Param("id")
-	var data dao.Inbox
-	if err := c.ShouldBindJSON(&data); err != nil {
+
+	// Use an anonymous struct without binding:"required" on ID since ID comes from the path param.
+	var body struct {
+		Title       string `json:"title"`
+		Description string `json:"description"`
+		MaxItems    int    `json:"max_items"`
+		IsPublic    *bool  `json:"is_public"`
+	}
+	if err := c.ShouldBindJSON(&body); err != nil {
 		c.JSON(http.StatusBadRequest, util.APIResponse[any]{Msg: err.Error()})
 		return
 	}
-	data.ID = id
+	data := dao.Inbox{
+		ID:          id,
+		Title:       body.Title,
+		Description: body.Description,
+		MaxItems:    body.MaxItems,
+		IsPublic:    body.IsPublic,
+	}
 	db := util.GetDatabase()
 
 	if _, err := dao.GetInboxByID(db, id); err != nil {

--- a/internal/controller/inbox_public.go
+++ b/internal/controller/inbox_public.go
@@ -28,7 +28,7 @@ func PublicInboxItemContent(c *gin.Context) {
 	}
 
 	// 权限校验逻辑
-	if !inbox.IsPublic {
+	if inbox.IsPublic == nil || !*inbox.IsPublic {
 		var tokenValue string
 
 		// 1. 优先尝试从 Query 提取 "?token=xxx"

--- a/internal/craft/runtime_test.go
+++ b/internal/craft/runtime_test.go
@@ -340,6 +340,8 @@ func TestLLMFilterProcessor_RemovesMatchedArticleAndUsesTitleContentPayload(t *t
 }
 
 func TestIgnoreAdvertorialProcessor_KeepsArticleOnLLMError(t *testing.T) {
+	setupTestRedis(t)
+
 	original := llmContextCaller
 	llmContextCaller = func(prompt, context string, option util.ContentProcessOption) (string, error) {
 		return "", fmt.Errorf("temporary llm error")

--- a/internal/dao/inbox.go
+++ b/internal/dao/inbox.go
@@ -12,7 +12,8 @@ type Inbox struct {
 	Title       string `json:"title,omitempty"`
 	Description string `json:"description,omitempty"`
 	MaxItems    int    `gorm:"default:100" json:"max_items"`
-	IsPublic    bool   `gorm:"default:true" json:"is_public"`
+	// IsPublic uses *bool so GORM does not treat false as a zero value to skip; the DB default remains true.
+	IsPublic *bool `gorm:"default:true" json:"is_public"`
 }
 
 type InboxItem struct {

--- a/web/admin/src/views/dashboard/inbox/index.vue
+++ b/web/admin/src/views/dashboard/inbox/index.vue
@@ -177,7 +177,7 @@ curl -X POST "{{ pushUrl }}" \
             <li
               >在 Source Config JSON 中，配置当前收件箱的 ID 映射：
               <pre class="monospace-text mt-2 text-xs">
-{ "inbox_id": "{{ selectedInbox.id }}" }</pre
+{ "inbox_source": { "inbox_id": "{{ selectedInbox.id }}" } }</pre
               >
             </li>
             <li


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

This PR fixes 4 bugs discovered during end-to-end testing of the `feat/add-inbox-support-and-refactor` branch.

---

### Bug 1: `is_public: false` not persisted (GORM zero-value / `default:true` issue)

**Root cause**: `IsPublic bool` with `gorm:"default:true"` causes GORM to skip the zero value (`false`) during `INSERT`, letting the database default (`true`) apply instead.

**Fix**: Changed `IsPublic bool` → `IsPublic *bool` in `dao.Inbox`. GORM treats a non-nil pointer correctly and saves the explicit value. Updated `inbox_public.go` to dereference safely with `inbox.IsPublic == nil || !*inbox.IsPublic`.

---

### Bug 2: `PUT /api/admin/inboxes/:id` returns 400 due to `binding:"required"` on `ID`

**Root cause**: `UpdateInbox` called `c.ShouldBindJSON(&dao.Inbox{})`, but the `ID` field has `binding:"required"` and is not present in the request body (it comes from the URL path param). This caused validation failure on every update request.

**Fix**: Uses an anonymous struct without binding constraints to parse the body, then constructs `dao.Inbox` with the path `id`.

---

### Bug 3: Frontend Inbox guide shows incorrect Source Config JSON format

**Root cause**: The integration guide modal displayed `{ "inbox_id": "..." }` as the `source_config` value, but the backend's `SourceConfig` struct requires the nested format `{ "inbox_source": { "inbox_id": "..." } }`. Using the wrong format results in error: `inbox_source config with inbox_id is required for inbox source`.

**Fix**: Updated the example in the guide modal to show the correct nested format.

---

### Bug 4 (test): `TestIgnoreAdvertorialProcessor_KeepsArticleOnLLMError` crashes due to missing Redis setup

**Root cause**: The test called `newIgnoreAdvertorialProcessor` which internally uses the caching layer. The caching layer calls `GetRedisClient()` which calls `log.Fatalf` when `FC_REDIS_URI` is not set. All other tests in the same file correctly called `setupTestRedis(t)` first, but this test was missing that call.

**Fix**: Added `setupTestRedis(t)` at the top of the test.

---

### Bonus: Pre-existing `golangci-lint` ST1005 warnings in `feed_viewer.go`

Fixed 5 error strings that started with a capital letter (Go convention: error strings should be lowercase).

---

## Testing

- ✅ `go test ./...` — all 10 packages pass
- ✅ `task fix` — formatting + lint clean (only 1 pre-existing `no-console` warning in `topic_feed/detail.vue`)
- ✅ `task backend-build` — builds successfully
- ✅ `task frontend-build` — builds successfully
- ✅ Manual API verification of all 3 bug fixes via `curl` against a running server
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-22ac03b6-7021-4f46-b310-1bc1e01edc32"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-22ac03b6-7021-4f46-b310-1bc1e01edc32"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

## Summary by Sourcery

Fix multiple inbox-related issues uncovered during end-to-end testing and address minor lint and test stability problems.

Bug Fixes:
- Ensure inbox updates bind request bodies without requiring the ID field from JSON, using the path parameter instead.
- Persist the inbox public visibility flag correctly by storing it as a pointer-backed boolean.
- Correct public inbox access control to handle nil or false IsPublic values safely.
- Prevent TestIgnoreAdvertorialProcessor_KeepsArticleOnLLMError from crashing by initializing Redis before invoking the processor.
- Normalize feed viewer validation error messages to follow Go’s lowercase error string convention.
- Update the inbox integration guide JSON example to reflect the required nested source_config format.