### PR TITLE
fix: resolve inbox bugs found during testing

### DIFF
--- a/internal/controller/feed_viewer.go
+++ b/internal/controller/feed_viewer.go
@@ -192,22 +192,22 @@ func formatFeedViewerISOTime(primary, fallback time.Time) string {
 func validateFeedViewerURL(rawURL string) error {
 	parsedURL, err := url.Parse(rawURL)
 	if err != nil || parsedURL == nil {
-		return errors.New("Please enter a valid http(s) feed URL")
+		return errors.New("please enter a valid http(s) feed URL")
 	}
 	if parsedURL.Scheme != "http" && parsedURL.Scheme != "https" {
-		return errors.New("Please enter a valid http(s) feed URL")
+		return errors.New("please enter a valid http(s) feed URL")
 	}
 	if parsedURL.Hostname() == "" {
-		return errors.New("Please enter a valid http(s) feed URL")
+		return errors.New("please enter a valid http(s) feed URL")
 	}
 
 	ips, err := net.LookupIP(parsedURL.Hostname())
 	if err != nil {
-		return fmt.Errorf("Unable to resolve this URL: %w", err)
+		return fmt.Errorf("unable to resolve this URL: %w", err)
 	}
 	for _, ip := range ips {
 		if ip.IsLoopback() || ip.IsPrivate() {
-			return fmt.Errorf("Access to private IP %s is forbidden", ip.String())
+			return fmt.Errorf("access to private IP %s is forbidden", ip.String())
 		}
 	}
 

--- a/internal/controller/inbox.go
+++ b/internal/controller/inbox.go
@@ -52,12 +52,25 @@ func GetInbox(c *gin.Context) {
 
 func UpdateInbox(c *gin.Context) {
 	id := c.Param("id")
-	var data dao.Inbox
-	if err := c.ShouldBindJSON(&data); err != nil {
+
+	// Use an anonymous struct without binding:"required" on ID since ID comes from the path param.
+	var body struct {
+		Title       string `json:"title"`
+		Description string `json:"description"`
+		MaxItems    int    `json:"max_items"`
+		IsPublic    *bool  `json:"is_public"`
+	}
+	if err := c.ShouldBindJSON(&body); err != nil {
 		c.JSON(http.StatusBadRequest, util.APIResponse[any]{Msg: err.Error()})
 		return
 	}
-	data.ID = id
+	data := dao.Inbox{
+		ID:          id,
+		Title:       body.Title,
+		Description: body.Description,
+		MaxItems:    body.MaxItems,
+		IsPublic:    body.IsPublic,
+	}
 	db := util.GetDatabase()
 
 	if _, err := dao.GetInboxByID(db, id); err != nil {

--- a/internal/controller/inbox_public.go
+++ b/internal/controller/inbox_public.go
@@ -28,7 +28,7 @@ func PublicInboxItemContent(c *gin.Context) {
 	}
 
 	// 权限校验逻辑
-	if !inbox.IsPublic {
+	if inbox.IsPublic == nil || !*inbox.IsPublic {
 		var tokenValue string
 
 		// 1. 优先尝试从 Query 提取 "?token=xxx"

--- a/internal/craft/runtime_test.go
+++ b/internal/craft/runtime_test.go
@@ -340,6 +340,8 @@ func TestLLMFilterProcessor_RemovesMatchedArticleAndUsesTitleContentPayload(t *t
 }
 
 func TestIgnoreAdvertorialProcessor_KeepsArticleOnLLMError(t *testing.T) {
+	setupTestRedis(t)
+
 	original := llmContextCaller
 	llmContextCaller = func(prompt, context string, option util.ContentProcessOption) (string, error) {
 		return "", fmt.Errorf("temporary llm error")

--- a/internal/dao/inbox.go
+++ b/internal/dao/inbox.go
@@ -12,7 +12,8 @@ type Inbox struct {
 	Title       string `json:"title,omitempty"`
 	Description string `json:"description,omitempty"`
 	MaxItems    int    `gorm:"default:100" json:"max_items"`
-	IsPublic    bool   `gorm:"default:true" json:"is_public"`
+	// IsPublic uses *bool so GORM does not treat false as a zero value to skip; the DB default remains true.
+	IsPublic *bool `gorm:"default:true" json:"is_public"`
 }
 
 type InboxItem struct {

--- a/web/admin/src/views/dashboard/inbox/index.vue
+++ b/web/admin/src/views/dashboard/inbox/index.vue
@@ -177,7 +177,7 @@ curl -X POST "{{ pushUrl }}" \
             <li
               >在 Source Config JSON 中，配置当前收件箱的 ID 映射：
               <pre class="monospace-text mt-2 text-xs">
-{ "inbox_id": "{{ selectedInbox.id }}" }</pre
+{ "inbox_source": { "inbox_id": "{{ selectedInbox.id }}" } }</pre
               >
             </li>
             <li


### PR DESCRIPTION
- Fix is_public=false not persisted (GORM zero-value / default:true issue) Change IsPublic field type from bool to *bool in dao.Inbox so GORM does not skip the false value and apply the database default instead. Update inbox_public.go to dereference the pointer safely.

- Fix UpdateInbox returning 400 due to binding:required on ID field The ID comes from the URL path param, not the request body. Use an anonymous struct without binding constraints for body parsing, then construct dao.Inbox with the path ID.

- Fix incorrect source_config example in frontend Inbox guide modal The guide showed {"inbox_id":"..."} but the correct nested format required by SourceConfig is {"inbox_source":{"inbox_id":"..."}}.

- Fix TestIgnoreAdvertorialProcessor_KeepsArticleOnLLMError test The test was missing setupTestRedis(t) call, causing log.Fatalf when the cache layer attempted to connect to an unconfigured Redis instance.

- Fix pre-existing golangci-lint staticcheck ST1005 warnings in feed_viewer.go (error strings should not be capitalized)

## Summary by Sourcery

Fix multiple inbox-related bugs discovered during testing and address minor validation and test issues.

Bug Fixes:
- Ensure UpdateInbox parses the request body without requiring an ID field and uses the path parameter as the inbox ID.
- Persist is_public=false correctly by changing the Inbox IsPublic field to a pointer and updating public inbox access checks accordingly.
- Adjust feed viewer URL validation error messages to satisfy static analysis rules on error string formatting.
- Prevent TestIgnoreAdvertorialProcessor_KeepsArticleOnLLMError from failing due to missing Redis test setup.
- Correct the inbox guide modal example to show the proper nested inbox_source source_config format.