### PR TITLE
fix: resolve inbox bugs (is_public, UpdateInbox 400, guide source config)

### DIFF
--- a/internal/controller/inbox.go
+++ b/internal/controller/inbox.go
@@ -52,12 +52,25 @@ func GetInbox(c *gin.Context) {
 
 func UpdateInbox(c *gin.Context) {
 	id := c.Param("id")
-	var data dao.Inbox
-	if err := c.ShouldBindJSON(&data); err != nil {
+
+	// Use an anonymous struct without binding:"required" on ID since ID comes from the path param.
+	var body struct {
+		Title       string `json:"title"`
+		Description string `json:"description"`
+		MaxItems    int    `json:"max_items"`
+		IsPublic    *bool  `json:"is_public"`
+	}
+	if err := c.ShouldBindJSON(&body); err != nil {
 		c.JSON(http.StatusBadRequest, util.APIResponse[any]{Msg: err.Error()})
 		return
 	}
-	data.ID = id
+	data := dao.Inbox{
+		ID:          id,
+		Title:       body.Title,
+		Description: body.Description,
+		MaxItems:    body.MaxItems,
+		IsPublic:    body.IsPublic,
+	}
 	db := util.GetDatabase()
 
 	if _, err := dao.GetInboxByID(db, id); err != nil {

--- a/internal/controller/inbox_public.go
+++ b/internal/controller/inbox_public.go
@@ -28,7 +28,7 @@ func PublicInboxItemContent(c *gin.Context) {
 	}
 
 	// 权限校验逻辑
-	if !inbox.IsPublic {
+	if inbox.IsPublic == nil || !*inbox.IsPublic {
 		var tokenValue string
 
 		// 1. 优先尝试从 Query 提取 "?token=xxx"

--- a/internal/dao/inbox.go
+++ b/internal/dao/inbox.go
@@ -12,7 +12,8 @@ type Inbox struct {
 	Title       string `json:"title,omitempty"`
 	Description string `json:"description,omitempty"`
 	MaxItems    int    `gorm:"default:100" json:"max_items"`
-	IsPublic    bool   `gorm:"default:true" json:"is_public"`
+	// IsPublic uses *bool so GORM does not treat false as a zero value to skip; the DB default remains true.
+	IsPublic *bool `gorm:"default:true" json:"is_public"`
 }
 
 type InboxItem struct {

--- a/web/admin/src/views/dashboard/inbox/index.vue
+++ b/web/admin/src/views/dashboard/inbox/index.vue
@@ -177,7 +177,7 @@ curl -X POST "{{ pushUrl }}" \
             <li
               >在 Source Config JSON 中，配置当前收件箱的 ID 映射：
               <pre class="monospace-text mt-2 text-xs">
-{ "inbox_id": "{{ selectedInbox.id }}" }</pre
+{ "inbox_source": { "inbox_id": "{{ selectedInbox.id }}" } }</pre
               >
             </li>
             <li


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

This PR fixes 3 bugs in the inbox feature discovered during end-to-end testing.

---

### Bug 1 — `is_public: false` not persisted (GORM zero-value / `default:true`)

**Root cause**: `IsPublic bool` with `gorm:"default:true"` causes GORM to treat `false` as a zero value and skip it during `INSERT`, letting the database default (`true`) take effect. As a result, every inbox created with `is_public: false` is actually stored as public.

**Fix**: Changed `IsPublic bool` → `IsPublic *bool` in `dao.Inbox`. A non-nil pointer is never treated as a zero value by GORM, so the explicit `false` is correctly persisted. Updated `inbox_public.go` to dereference safely: `inbox.IsPublic == nil || !*inbox.IsPublic`.

---

### Bug 2 — `PUT /api/admin/inboxes/:id` always returns 400

**Root cause**: `UpdateInbox` bound the request body into `dao.Inbox` directly. The `ID` field carries `binding:"required"`, but the ID is supplied via the URL path param—not the body—so every update request fails validation.

**Fix**: Uses an anonymous struct (no `binding` constraints) to decode the body, then builds `dao.Inbox` with the path-param `id`.

---

### Bug 3 — Frontend Inbox guide shows wrong `source_config` format

**Root cause**: The integration guide modal displayed `{ "inbox_id": "..." }` as the value to put in `source_config`. The backend `SourceConfig` struct requires the nested key: `{ "inbox_source": { "inbox_id": "..." } }`. Using the guide's example produces: `inbox_source config with inbox_id is required for inbox source`.

**Fix**: Updated the example snippet in `inbox/index.vue` to show the correct nested format.

---

## Testing

- ✅ `go test ./...` — all 12 packages pass
- ✅ `task backend-build`
- ✅ `task frontend-build`
- ✅ `task fix` — formatting + Go lint clean (pre-existing `no-console` + `vitest` ESLint warnings in `dev` are unrelated to this PR)
- ✅ Manual API verification of all 3 fixes via `curl` against a running server
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-22ac03b6-7021-4f46-b310-1bc1e01edc32"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-22ac03b6-7021-4f46-b310-1bc1e01edc32"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

## Summary by Sourcery

Fix inbox public visibility persistence, correct the inbox update API validation, and align the frontend guide with the backend source_config format.

Bug Fixes:
- Ensure inbox is_public=false values are persisted correctly instead of defaulting to public.
- Allow PUT /api/admin/inboxes/:id to accept request bodies without an ID field by constructing the inbox payload from the path param and body fields.
- Update the inbox public access check to handle a nil is_public value safely and preserve existing behavior for public inboxes.
- Correct the inbox integration guide example to show the required nested inbox_source configuration structure in source_config.