### PR TITLE
feat: unify feed preview targets

### DIFF
--- a/internal/controller/feed_viewer.go
+++ b/internal/controller/feed_viewer.go
@@ -1,11 +1,9 @@
 package controller
 
 import (
-	"FeedCraft/internal/config"
-	"FeedCraft/internal/constant"
 	"FeedCraft/internal/craft"
+	"FeedCraft/internal/feedruntime"
 	"FeedCraft/internal/model"
-	"FeedCraft/internal/source"
 	"FeedCraft/internal/util"
 	"errors"
 	"fmt"
@@ -16,6 +14,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/mmcdole/gofeed"
+	"gorm.io/gorm"
 )
 
 type FeedViewerPreviewReq struct {
@@ -76,6 +75,7 @@ type FeedViewerPreviewItem struct {
 
 const feedViewerInvalidURLMessage = "Please enter a valid http(s) feed URL"
 const feedViewerInvalidURLError = "please enter a valid http(s) feed URL"
+const feedViewerInvalidInputError = "please enter a valid feed input URI"
 
 func PreviewFeedViewer(c *gin.Context) {
 	if c.Request.Method != http.MethodGet {
@@ -89,8 +89,12 @@ func PreviewFeedViewer(c *gin.Context) {
 		return
 	}
 
-	if err := validateFeedViewerURL(req.InputURL); err != nil {
+	if err := validateFeedViewerInputURI(req.InputURL); err != nil {
 		c.JSON(http.StatusBadRequest, util.APIResponse[any]{StatusCode: -1, Msg: formatFeedViewerValidationError(err)})
+		return
+	}
+	if req.CraftName != "" && req.CraftName != "proxy" && isFeedViewerInternalURI(req.InputURL) {
+		c.JSON(http.StatusBadRequest, util.APIResponse[any]{StatusCode: -1, Msg: "craft_name is only supported for external URLs"})
 		return
 	}
 
@@ -159,24 +163,15 @@ func PreviewEmbeddingFilter(c *gin.Context) {
 }
 
 func loadFeedViewerPreview(c *gin.Context, req FeedViewerPreviewReq) (*model.CraftFeed, error) {
-	cfg := &config.SourceConfig{
-		Type: constant.SourceRSS,
-		HttpFetcher: &config.HttpFetcherConfig{
-			URL: req.InputURL,
-		},
-	}
-
-	factory, err := source.Get(constant.SourceRSS)
+	provider, err := feedruntime.BuildProviderFromInput(c.Request.Context(), feedruntime.InputSpec{
+		Kind: feedruntime.InputKindURI,
+		URI:  req.InputURL,
+	}, nil)
 	if err != nil {
-		return nil, fmt.Errorf("factory not found: %w", err)
+		return nil, err
 	}
 
-	src, err := factory(cfg)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create source: %w", err)
-	}
-
-	feed, err := src.Fetch(c.Request.Context())
+	feed, err := provider.Fetch(c.Request.Context())
 	if err != nil {
 		return nil, err
 	}
@@ -376,7 +371,38 @@ func validateFeedViewerURL(rawURL string) error {
 	return nil
 }
 
+func validateFeedViewerInputURI(rawURI string) error {
+	parsedURI, err := url.Parse(rawURI)
+	if err != nil || parsedURI == nil {
+		return errors.New(feedViewerInvalidInputError)
+	}
+	switch parsedURI.Scheme {
+	case "http", "https":
+		return validateFeedViewerURL(rawURI)
+	case "feedcraft":
+		resourceType := strings.TrimSpace(parsedURI.Host)
+		resourceID := strings.Trim(strings.TrimSpace(parsedURI.Path), "/")
+		if resourceType != "recipe" && resourceType != "topic" && resourceType != "inbox" {
+			return errors.New(feedViewerInvalidInputError)
+		}
+		if resourceID == "" || strings.Contains(resourceID, "/") {
+			return errors.New(feedViewerInvalidInputError)
+		}
+		return nil
+	default:
+		return errors.New(feedViewerInvalidInputError)
+	}
+}
+
+func isFeedViewerInternalURI(rawURI string) bool {
+	parsedURI, err := url.Parse(rawURI)
+	return err == nil && parsedURI != nil && parsedURI.Scheme == "feedcraft"
+}
+
 func classifyFeedViewerError(err error) (int, string) {
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return http.StatusNotFound, "The selected preview target was not found."
+	}
 	msg := err.Error()
 	msg = strings.TrimPrefix(msg, "all items failed to process. last error: ")
 	lowerMsg := strings.ToLower(msg)

--- a/internal/controller/feed_viewer.go
+++ b/internal/controller/feed_viewer.go
@@ -4,6 +4,7 @@ import (
 	"FeedCraft/internal/craft"
 	"FeedCraft/internal/feedruntime"
 	"FeedCraft/internal/model"
+	"FeedCraft/internal/observability"
 	"FeedCraft/internal/util"
 	"errors"
 	"fmt"
@@ -163,10 +164,10 @@ func PreviewEmbeddingFilter(c *gin.Context) {
 }
 
 func loadFeedViewerPreview(c *gin.Context, req FeedViewerPreviewReq) (*model.CraftFeed, error) {
-	provider, err := feedruntime.BuildProviderFromInput(c.Request.Context(), feedruntime.InputSpec{
+	provider, err := feedruntime.BuildProviderFromInputWithRecipeTrigger(c.Request.Context(), feedruntime.InputSpec{
 		Kind: feedruntime.InputKindURI,
 		URI:  req.InputURL,
-	}, nil)
+	}, nil, observability.TriggerUserRequest)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/controller/feed_viewer_test.go
+++ b/internal/controller/feed_viewer_test.go
@@ -8,10 +8,13 @@ import (
 	"net/url"
 	"strings"
 	"testing"
+	"time"
 
 	"FeedCraft/internal/craft"
+	"FeedCraft/internal/dao"
 
 	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
 )
 
 func TestPreviewFeedViewerAllowsInternalFeedURL(t *testing.T) {
@@ -129,6 +132,84 @@ func TestPreviewFeedViewerDoesNotReturnDataForInvalidFeedResponse(t *testing.T) 
 func TestValidateFeedViewerURLAllowsPrivateIPLiteral(t *testing.T) {
 	if err := validateFeedViewerURL("http://172.21.0.13/feed.xml"); err != nil {
 		t.Fatalf("expected private IP literal to be allowed, got %v", err)
+	}
+}
+
+func TestPreviewFeedViewerSupportsRecipeURI(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	db := topicFeedTestDatabase(t)
+	require.NoError(t, db.AutoMigrate(&dao.CustomRecipeV2{}, &dao.TopicFeed{}))
+	recipeID := uniqueTestID("preview-recipe")
+	createTopicTestRecipe(t, db, recipeID)
+
+	recorder := performFeedViewerPreviewRequest(t, http.MethodGet, "feedcraft://recipe/"+recipeID)
+
+	assertFeedViewerPreviewSuccess(t, recorder, "Test Feed", "Hello Topic")
+}
+
+func TestPreviewFeedViewerSupportsTopicURI(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	db := topicFeedTestDatabase(t)
+	require.NoError(t, db.AutoMigrate(&dao.CustomRecipeV2{}, &dao.TopicFeed{}))
+	recipeID := uniqueTestID("preview-topic-recipe")
+	topicID := uniqueTestID("preview-topic")
+	createTopicTestRecipe(t, db, recipeID)
+	createTopicTestTopic(t, db, &dao.TopicFeed{
+		ID:          topicID,
+		Title:       "Preview Topic",
+		Description: "Topic preview",
+		InputURIs:   []string{"feedcraft://recipe/" + recipeID},
+	})
+
+	recorder := performFeedViewerPreviewRequest(t, http.MethodGet, "feedcraft://topic/"+topicID)
+
+	assertFeedViewerPreviewSuccess(t, recorder, "Preview Topic", "Hello Topic")
+}
+
+func TestPreviewFeedViewerSupportsInboxURI(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	db := topicFeedTestDatabase(t)
+	require.NoError(t, db.AutoMigrate(&dao.Inbox{}, &dao.InboxItem{}))
+	require.NoError(t, dao.CreateInbox(db, &dao.Inbox{
+		ID:          "alerts",
+		Title:       "Alerts Inbox",
+		Description: "Incoming alerts",
+		MaxItems:    100,
+	}))
+	require.NoError(t, db.Create(&dao.InboxItem{
+		InboxID:     "alerts",
+		ItemID:      "alert-1",
+		Title:       "CPU usage high",
+		URL:         "https://example.com/alerts/1",
+		Content:     "<p>CPU usage exceeded threshold.</p>",
+		Summary:     "CPU alert",
+		Author:      "monitor",
+		PublishedAt: time.Unix(1700000000, 0),
+		CreatedAt:   time.Unix(1700000000, 0),
+	}).Error)
+
+	recorder := performFeedViewerPreviewRequest(t, http.MethodGet, "feedcraft://inbox/alerts")
+
+	assertFeedViewerPreviewSuccess(t, recorder, "Alerts Inbox", "CPU usage high")
+}
+
+func TestPreviewFeedViewerRejectsCraftNameForInternalURI(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	recorder := performFeedViewerPreviewRequestWithCraft(t, http.MethodGet, "feedcraft://recipe/example", "summary")
+
+	if recorder.Code != http.StatusBadRequest {
+		t.Fatalf("expected status %d, got %d: %s", http.StatusBadRequest, recorder.Code, recorder.Body.String())
+	}
+	var response struct {
+		Code int    `json:"code"`
+		Msg  string `json:"msg"`
+	}
+	if err := json.Unmarshal(recorder.Body.Bytes(), &response); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if !strings.Contains(response.Msg, "craft_name is only supported for external URLs") {
+		t.Fatalf("expected craft_name validation message, got %q", response.Msg)
 	}
 }
 
@@ -321,12 +402,52 @@ func TestClassifyFeedViewerErrorHandlesBrowserProviderFailures(t *testing.T) {
 
 func performFeedViewerPreviewRequest(t *testing.T, method, inputURL string) *httptest.ResponseRecorder {
 	t.Helper()
+	return performFeedViewerPreviewRequestWithCraft(t, method, inputURL, "")
+}
+
+func performFeedViewerPreviewRequestWithCraft(t *testing.T, method, inputURL, craftName string) *httptest.ResponseRecorder {
+	t.Helper()
 
 	router := gin.New()
 	router.Handle(method, "/preview", PreviewFeedViewer)
 
-	request := httptest.NewRequest(method, "/preview?input_url="+url.QueryEscape(inputURL), nil)
+	query := url.Values{}
+	query.Set("input_url", inputURL)
+	if craftName != "" {
+		query.Set("craft_name", craftName)
+	}
+	request := httptest.NewRequest(method, "/preview?"+query.Encode(), nil)
 	recorder := httptest.NewRecorder()
 	router.ServeHTTP(recorder, request)
 	return recorder
+}
+
+func assertFeedViewerPreviewSuccess(t *testing.T, recorder *httptest.ResponseRecorder, expectedTitle, expectedItemTitle string) {
+	t.Helper()
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d: %s", http.StatusOK, recorder.Code, recorder.Body.String())
+	}
+
+	var response struct {
+		Code int `json:"code"`
+		Data struct {
+			Title string `json:"title"`
+			Items []struct {
+				Title string `json:"title"`
+			} `json:"items"`
+		} `json:"data"`
+		Msg string `json:"msg"`
+	}
+	if err := json.Unmarshal(recorder.Body.Bytes(), &response); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if response.Code != 0 {
+		t.Fatalf("expected success code, got %d with msg %q", response.Code, response.Msg)
+	}
+	if response.Data.Title != expectedTitle {
+		t.Fatalf("expected title %q, got %q", expectedTitle, response.Data.Title)
+	}
+	if len(response.Data.Items) != 1 || response.Data.Items[0].Title != expectedItemTitle {
+		t.Fatalf("expected one item titled %q, got %+v", expectedItemTitle, response.Data.Items)
+	}
 }

--- a/internal/feedruntime/builder.go
+++ b/internal/feedruntime/builder.go
@@ -35,6 +35,7 @@ const (
 	internalScheme             = "feedcraft"
 	internalResourceTypeRecipe = "recipe"
 	internalResourceTypeTopic  = "topic"
+	internalResourceTypeInbox  = "inbox"
 )
 
 // InputSpec is the unified runtime input model for RecipeFeed and TopicFeed.
@@ -235,6 +236,8 @@ func (b *Builder) buildProviderFromURI(ctx context.Context, rawURI string, stack
 			return b.buildRecipeProvider(ctx, resourceID, observability.TriggerTopicAggregation)
 		case internalResourceTypeTopic:
 			return b.buildTopicProvider(ctx, resourceID, stack)
+		case internalResourceTypeInbox:
+			return &InboxProvider{DB: b.db(), InboxID: resourceID}, nil
 		default:
 			return nil, fmt.Errorf("unsupported internal resource type %q", resourceType)
 		}
@@ -436,6 +439,56 @@ func parseInternalResourceURI(parsed *url.URL) (string, string, error) {
 		return "", "", errors.New("resource id must be a single path segment")
 	}
 	return resourceType, resourceID, nil
+}
+
+// InboxProvider adapts inbox items into a feed without requiring an intermediate recipe.
+type InboxProvider struct {
+	DB      *gorm.DB
+	InboxID string
+}
+
+func (p *InboxProvider) Fetch(ctx context.Context) (*model.CraftFeed, error) {
+	_ = ctx
+	db := p.DB
+	if db == nil {
+		db = util.GetDatabase()
+	}
+
+	inbox, err := dao.GetInboxByID(db, p.InboxID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get inbox %s: %w", p.InboxID, err)
+	}
+
+	items, err := dao.ListInboxItems(db, p.InboxID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list inbox items: %w", err)
+	}
+
+	feed := &model.CraftFeed{
+		Title:       inbox.Title,
+		Description: inbox.Description,
+		Id:          fmt.Sprintf("inbox:%s", p.InboxID),
+		Link:        p.BaseURL(),
+		Articles:    make([]*model.CraftArticle, 0, len(items)),
+	}
+	for _, item := range items {
+		feed.Articles = append(feed.Articles, &model.CraftArticle{
+			Title:       item.Title,
+			Link:        item.URL,
+			Content:     item.Content,
+			Description: item.Summary,
+			Id:          item.ItemID,
+			AuthorName:  item.Author,
+			Created:     item.PublishedAt,
+			Updated:     item.PublishedAt,
+		})
+	}
+
+	return feed, nil
+}
+
+func (p *InboxProvider) BaseURL() string {
+	return fmt.Sprintf("feedcraft://inbox/%s", p.InboxID)
 }
 
 // RecipeProvider adapts a runtime RecipeFeed and adds execution metadata.

--- a/internal/feedruntime/builder.go
+++ b/internal/feedruntime/builder.go
@@ -62,6 +62,10 @@ func BuildProviderFromInput(ctx context.Context, spec InputSpec, stack []string)
 	return NewBuilder(nil).BuildProviderFromInput(ctx, spec, stack)
 }
 
+func BuildProviderFromInputWithRecipeTrigger(ctx context.Context, spec InputSpec, stack []string, recipeTrigger string) (engine.FeedProvider, error) {
+	return NewBuilder(nil).BuildProviderFromInputWithRecipeTrigger(ctx, spec, stack, recipeTrigger)
+}
+
 func BuildTopicProvider(ctx context.Context, topicID string) (engine.FeedProvider, error) {
 	return NewBuilder(nil).BuildTopicProvider(ctx, topicID)
 }
@@ -83,9 +87,16 @@ func BuildAggregator(steps []dao.AggregatorStep) (engine.CraftOption, error) {
 }
 
 func (b *Builder) BuildProviderFromInput(ctx context.Context, spec InputSpec, stack []string) (engine.FeedProvider, error) {
+	return b.BuildProviderFromInputWithRecipeTrigger(ctx, spec, stack, observability.TriggerTopicAggregation)
+}
+
+func (b *Builder) BuildProviderFromInputWithRecipeTrigger(ctx context.Context, spec InputSpec, stack []string, recipeTrigger string) (engine.FeedProvider, error) {
+	if strings.TrimSpace(recipeTrigger) == "" {
+		recipeTrigger = observability.TriggerTopicAggregation
+	}
 	switch spec.Kind {
 	case InputKindURI:
-		return b.buildProviderFromURI(ctx, spec.URI, stack)
+		return b.buildProviderFromURI(ctx, spec.URI, stack, recipeTrigger)
 	case InputKindSource:
 		if spec.SourceConfig == nil {
 			return nil, errors.New("source input requires source_config")
@@ -213,7 +224,7 @@ func buildRecipeInputSpec(recipeData *dao.CustomRecipeV2) (InputSpec, error) {
 	}, nil
 }
 
-func (b *Builder) buildProviderFromURI(ctx context.Context, rawURI string, stack []string) (engine.FeedProvider, error) {
+func (b *Builder) buildProviderFromURI(ctx context.Context, rawURI string, stack []string, recipeTrigger string) (engine.FeedProvider, error) {
 	if rawURI == "" {
 		return nil, errors.New("uri input requires a non-empty uri")
 	}
@@ -233,7 +244,7 @@ func (b *Builder) buildProviderFromURI(ctx context.Context, rawURI string, stack
 		}
 		switch resourceType {
 		case internalResourceTypeRecipe:
-			return b.buildRecipeProvider(ctx, resourceID, observability.TriggerTopicAggregation)
+			return b.buildRecipeProvider(ctx, resourceID, recipeTrigger)
 		case internalResourceTypeTopic:
 			return b.buildTopicProvider(ctx, resourceID, stack)
 		case internalResourceTypeInbox:

--- a/internal/feedruntime/builder_test.go
+++ b/internal/feedruntime/builder_test.go
@@ -67,6 +67,41 @@ func TestBuildProviderFromInput_HTTPURL(t *testing.T) {
 	assert.Equal(t, "https://example.com/feed.xml", rawProvider.URL)
 }
 
+func TestBuildProviderFromInput_InboxURIUsesBuilderDB(t *testing.T) {
+	db := newTestDB(t)
+	require.NoError(t, db.AutoMigrate(&dao.Inbox{}, &dao.InboxItem{}))
+	require.NoError(t, dao.CreateInbox(db, &dao.Inbox{
+		ID:          "inbox-1",
+		Title:       "Inbox Feed",
+		Description: "Inbox description",
+		MaxItems:    100,
+	}))
+	require.NoError(t, db.Create(&dao.InboxItem{
+		InboxID:     "inbox-1",
+		ItemID:      "item-1",
+		Title:       "Inbox Item",
+		URL:         "https://example.com/inbox-item",
+		Content:     "<p>Inbox content</p>",
+		Summary:     "Inbox summary",
+		PublishedAt: time.Unix(1700000000, 0),
+		CreatedAt:   time.Unix(1700000000, 0),
+	}).Error)
+
+	provider, err := NewBuilder(db).BuildProviderFromInput(context.Background(), InputSpec{
+		Kind: InputKindURI,
+		URI:  "feedcraft://inbox/inbox-1",
+	}, nil)
+	require.NoError(t, err)
+	assert.IsType(t, &InboxProvider{}, provider)
+
+	feed, err := provider.Fetch(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, feed)
+	assert.Equal(t, "Inbox Feed", feed.Title)
+	require.Len(t, feed.Articles, 1)
+	assert.Equal(t, "Inbox Item", feed.Articles[0].Title)
+}
+
 func TestBuildProviderFromInput_SourceConfig(t *testing.T) {
 	const testSourceType = constant.SourceType("unit_test_source")
 	registerTestSource(t, testSourceType, func(cfg *config.SourceConfig) (source.Source, error) {

--- a/web/admin/src/locale/en-US/feedViewer.ts
+++ b/web/admin/src/locale/en-US/feedViewer.ts
@@ -1,13 +1,26 @@
 export default {
-  'feedViewer.description': 'Enter RSS link to preview',
-  'feedViewer.inputLink': 'Input Link',
+  'feedViewer.description':
+    'Preview external RSS, Custom Recipe, Topic Feed, or Inbox runtime output',
+  'feedViewer.inputLink': 'Select Preview Target',
   'feedViewer.inputTip':
-    'Enter the RSS feed address to preview. Supports RSS/ATOM',
+    'Choose a resource to preview. Internal resources run through runtime directly without public subscription URLs.',
   'feedViewer.placeholder': 'Enter RSS feed address',
+  'feedViewer.placeholder.recipe': 'Select Custom Recipe',
+  'feedViewer.placeholder.topic': 'Select Topic Feed',
+  'feedViewer.placeholder.inbox': 'Select Inbox',
+  'feedViewer.placeholder.uri': 'Enter http(s):// or feedcraft:// URI',
   'feedViewer.preview': 'Preview',
   'feedViewer.resultPreview': 'Result Preview',
+  'feedViewer.currentInput': 'Current input',
+  'feedViewer.mode.url': 'External URL',
+  'feedViewer.mode.recipe': 'Custom Recipe',
+  'feedViewer.mode.topic': 'Topic Feed',
+  'feedViewer.mode.inbox': 'Inbox',
+  'feedViewer.mode.uri': 'Advanced URI',
   'feedViewer.viewMode': 'View Mode',
   'feedViewer.viewModeNormal': 'Normal',
   'feedViewer.viewModeRich': 'Rich Text',
   'feedViewer.message.unknownError': 'Unknown Error',
+  'feedViewer.message.resourceLoadFailed':
+    'Some internal resource lists failed to load. Please refresh and try again.',
 };

--- a/web/admin/src/locale/en-US/inbox.ts
+++ b/web/admin/src/locale/en-US/inbox.ts
@@ -7,6 +7,7 @@ export default {
   'inbox.btn.edit': 'Edit Inbox',
   'inbox.btn.delete': 'Delete',
   'inbox.btn.guide': 'Integration Guide',
+  'inbox.btn.preview': 'Preview',
   'inbox.id': 'Inbox ID',
   'inbox.id.placeholder': 'Enter unique Inbox ID (e.g., test-inbox)',
   'inbox.name': 'Title',

--- a/web/admin/src/locale/en-US/topic.ts
+++ b/web/admin/src/locale/en-US/topic.ts
@@ -29,6 +29,7 @@ export default {
   'topic.copyLinkFailed': 'Failed to copy link',
   'topic.viewFeed': 'Open Feed',
   'topic.viewDetails': 'View Details',
+  'topic.preview': 'Preview',
   'topic.editAction': 'Edit',
   'topic.deleteAction': 'Delete',
   'topic.deleteConfirm': 'Are you sure you want to delete this topic?',

--- a/web/admin/src/locale/zh-CN/feedViewer.ts
+++ b/web/admin/src/locale/zh-CN/feedViewer.ts
@@ -1,12 +1,26 @@
 export default {
-  'feedViewer.description': '输入 RSS 链接进行预览',
-  'feedViewer.inputLink': '输入链接',
-  'feedViewer.inputTip': '输入要预览的RSS源地址 支持RSS/ATOM',
+  'feedViewer.description':
+    '预览外部 RSS、Custom Recipe、Topic Feed 或 Inbox 的运行结果',
+  'feedViewer.inputLink': '选择预览目标',
+  'feedViewer.inputTip':
+    '选择要预览的资源。内部资源会直接通过运行期执行，不需要公开订阅地址。',
   'feedViewer.placeholder': '输入 RSS 源地址',
+  'feedViewer.placeholder.recipe': '选择 Custom Recipe',
+  'feedViewer.placeholder.topic': '选择 Topic Feed',
+  'feedViewer.placeholder.inbox': '选择 Inbox',
+  'feedViewer.placeholder.uri': '输入 http(s):// 或 feedcraft:// URI',
   'feedViewer.preview': '预览',
   'feedViewer.resultPreview': '结果预览',
+  'feedViewer.currentInput': '当前输入',
+  'feedViewer.mode.url': '外部 URL',
+  'feedViewer.mode.recipe': 'Custom Recipe',
+  'feedViewer.mode.topic': 'Topic Feed',
+  'feedViewer.mode.inbox': 'Inbox',
+  'feedViewer.mode.uri': '高级 URI',
   'feedViewer.viewMode': '预览模式',
   'feedViewer.viewModeNormal': '普通',
   'feedViewer.viewModeRich': '富文本',
   'feedViewer.message.unknownError': '未知错误',
+  'feedViewer.message.resourceLoadFailed':
+    '部分内部资源列表加载失败，可稍后刷新重试',
 };

--- a/web/admin/src/locale/zh-CN/inbox.ts
+++ b/web/admin/src/locale/zh-CN/inbox.ts
@@ -7,6 +7,7 @@ export default {
   'inbox.btn.edit': '编辑收件箱',
   'inbox.btn.delete': '删除',
   'inbox.btn.guide': '集成指南',
+  'inbox.btn.preview': '预览',
   'inbox.id': '收件箱 ID',
   'inbox.id.placeholder': '请输入唯一的收件箱 ID (例如: test-inbox)',
   'inbox.name': '标题',

--- a/web/admin/src/locale/zh-CN/topic.ts
+++ b/web/admin/src/locale/zh-CN/topic.ts
@@ -28,6 +28,7 @@ export default {
   'topic.copyLinkFailed': '复制链接失败',
   'topic.viewFeed': '查看订阅',
   'topic.viewDetails': '查看详情',
+  'topic.preview': '预览',
   'topic.editAction': '编辑',
   'topic.deleteAction': '删除',
   'topic.deleteConfirm': '确定要删除这个主题吗？',

--- a/web/admin/src/views/dashboard/custom_recipe/custom_recipe.vue
+++ b/web/admin/src/views/dashboard/custom_recipe/custom_recipe.vue
@@ -513,8 +513,10 @@
   };
 
   const previewRecipe = (record: CustomRecipe) => {
-    const feedUrl = buildRecipeFeedUrl(record.id);
-    router.push({ name: 'FeedViewer', query: { url: feedUrl } });
+    router.push({
+      name: 'FeedViewer',
+      query: { target: 'recipe', id: record.id },
+    });
   };
 
   function resetForm() {

--- a/web/admin/src/views/dashboard/feed_viewer/feed_viewer.vue
+++ b/web/admin/src/views/dashboard/feed_viewer/feed_viewer.vue
@@ -117,7 +117,7 @@
 </template>
 
 <script lang="ts" setup>
-  import { computed, onMounted, ref } from 'vue';
+  import { computed, onMounted, ref, watch } from 'vue';
   import FeedViewContainer from '@/views/dashboard/feed_viewer/feed_view_container.vue';
   import XHeader from '@/components/header/x-header.vue';
   import { useI18n } from 'vue-i18n';
@@ -172,6 +172,7 @@
     if (!currentInputURI.value) return;
     isLoading.value = true;
     errorMessage.value = '';
+    feedContent.value = null;
     try {
       const response = await previewFeed(currentInputURI.value);
       feedContent.value = response.data;
@@ -298,6 +299,18 @@
       fetchFeed();
     }
   });
+
+  watch(
+    () => route.fullPath,
+    () => {
+      applyRouteQuery();
+      if (currentInputURI.value) {
+        fetchFeed();
+      } else {
+        clearPreviewState();
+      }
+    }
+  );
 </script>
 
 <script lang="ts">

--- a/web/admin/src/views/dashboard/feed_viewer/feed_viewer.vue
+++ b/web/admin/src/views/dashboard/feed_viewer/feed_viewer.vue
@@ -8,25 +8,97 @@
 
     <a-card class="my-2" :title="t('feedViewer.inputLink')">
       <p>{{ t('feedViewer.inputTip') }}</p>
+      <a-radio-group
+        v-model="previewMode"
+        type="button"
+        class="mt-3"
+        @change="clearPreviewState"
+      >
+        <a-radio value="url">{{ t('feedViewer.mode.url') }}</a-radio>
+        <a-radio value="recipe">{{ t('feedViewer.mode.recipe') }}</a-radio>
+        <a-radio value="topic">{{ t('feedViewer.mode.topic') }}</a-radio>
+        <a-radio value="inbox">{{ t('feedViewer.mode.inbox') }}</a-radio>
+        <a-radio value="uri">{{ t('feedViewer.mode.uri') }}</a-radio>
+      </a-radio-group>
       <div
         class="mt-3 grid grid-cols-[minmax(20rem,1fr)_auto] items-center gap-3 max-md:grid-cols-1"
       >
         <a-input
+          v-if="previewMode === 'url'"
           v-model="feedUrl"
           type="text"
           class="w-full min-w-0"
           :placeholder="t('feedViewer.placeholder')"
           allow-clear
-          @input="errorMessage = ''"
+          @input="clearPreviewState"
+          @keyup.enter="fetchFeed"
+        />
+        <a-select
+          v-else-if="previewMode === 'recipe'"
+          v-model="selectedRecipeId"
+          class="w-full min-w-0"
+          :placeholder="t('feedViewer.placeholder.recipe')"
+          :loading="resourceLoading"
+          allow-search
+          allow-clear
+          @change="clearPreviewState"
+        >
+          <a-option
+            v-for="recipe in recipes"
+            :key="recipe.id"
+            :value="recipe.id"
+          >
+            {{ formatRecipeOption(recipe) }}
+          </a-option>
+        </a-select>
+        <a-select
+          v-else-if="previewMode === 'topic'"
+          v-model="selectedTopicId"
+          class="w-full min-w-0"
+          :placeholder="t('feedViewer.placeholder.topic')"
+          :loading="resourceLoading"
+          allow-search
+          allow-clear
+          @change="clearPreviewState"
+        >
+          <a-option v-for="topic in topics" :key="topic.id" :value="topic.id">
+            {{ formatTopicOption(topic) }}
+          </a-option>
+        </a-select>
+        <a-select
+          v-else-if="previewMode === 'inbox'"
+          v-model="selectedInboxId"
+          class="w-full min-w-0"
+          :placeholder="t('feedViewer.placeholder.inbox')"
+          :loading="resourceLoading"
+          allow-search
+          allow-clear
+          @change="clearPreviewState"
+        >
+          <a-option v-for="inbox in inboxes" :key="inbox.id" :value="inbox.id">
+            {{ formatInboxOption(inbox) }}
+          </a-option>
+        </a-select>
+        <a-input
+          v-else
+          v-model="advancedURI"
+          type="text"
+          class="w-full min-w-0"
+          :placeholder="t('feedViewer.placeholder.uri')"
+          allow-clear
+          @input="clearPreviewState"
           @keyup.enter="fetchFeed"
         />
         <a-button
           :loading="isLoading"
-          :disabled="!feedUrl"
+          :disabled="!currentInputURI"
           @click="fetchFeed"
           >{{ t('feedViewer.preview') }}</a-button
         >
       </div>
+      <a-alert v-if="currentInputURI" type="info" class="mt-3" show-icon>
+        {{ t('feedViewer.currentInput') }}: {{ currentInputURI }}
+      </a-alert>
     </a-card>
     <a-card
       :title="t('feedViewer.resultPreview')"
@@ -45,27 +117,63 @@
 </template>
 
 <script lang="ts" setup>
-  import { ref, onMounted } from 'vue';
+  import { computed, onMounted, ref } from 'vue';
   import FeedViewContainer from '@/views/dashboard/feed_viewer/feed_view_container.vue';
   import XHeader from '@/components/header/x-header.vue';
   import { useI18n } from 'vue-i18n';
   import { useRoute } from 'vue-router';
   import { previewFeed, type FeedViewerPreview } from '@/api/feed_viewer';
+  import { getCustomRecipes, type CustomRecipe } from '@/api/custom_recipe';
+  import { listTopicFeeds, type TopicFeed } from '@/api/topic';
+  import { listInboxes, type Inbox } from '@/api/inbox';
+  import { Message } from '@arco-design/web-vue';
+
+  type PreviewMode = 'url' | 'recipe' | 'topic' | 'inbox' | 'uri';
 
   const { t } = useI18n();
   const route = useRoute();
 
+  const previewMode = ref<PreviewMode>('url');
   const feedUrl = ref('');
+  const advancedURI = ref('');
+  const selectedRecipeId = ref('');
+  const selectedTopicId = ref('');
+  const selectedInboxId = ref('');
+  const recipes = ref<CustomRecipe[]>([]);
+  const topics = ref<TopicFeed[]>([]);
+  const inboxes = ref<Inbox[]>([]);
   const feedContent = ref<FeedViewerPreview | null>(null);
   const errorMessage = ref('');
   const isLoading = ref(false);
+  const resourceLoading = ref(false);
+
+  const currentInputURI = computed(() => {
+    if (previewMode.value === 'recipe' && selectedRecipeId.value) {
+      return `feedcraft://recipe/${selectedRecipeId.value}`;
+    }
+    if (previewMode.value === 'topic' && selectedTopicId.value) {
+      return `feedcraft://topic/${selectedTopicId.value}`;
+    }
+    if (previewMode.value === 'inbox' && selectedInboxId.value) {
+      return `feedcraft://inbox/${selectedInboxId.value}`;
+    }
+    if (previewMode.value === 'uri') {
+      return advancedURI.value.trim();
+    }
+    return feedUrl.value.trim();
+  });
+
+  function clearPreviewState() {
+    errorMessage.value = '';
+    feedContent.value = null;
+  }
 
   async function fetchFeed() {
-    if (!feedUrl.value) return;
+    if (!currentInputURI.value) return;
     isLoading.value = true;
     errorMessage.value = '';
     try {
-      const response = await previewFeed(feedUrl.value);
+      const response = await previewFeed(currentInputURI.value);
       feedContent.value = response.data;
     } catch (error) {
       feedContent.value = null;
@@ -78,9 +186,115 @@
     }
   }
 
-  onMounted(() => {
-    if (route.query.url) {
-      feedUrl.value = route.query.url as string;
+  function firstQueryValue(value: unknown): string {
+    if (Array.isArray(value)) return String(value[0] || '');
+    return typeof value === 'string' ? value : '';
+  }
+
+  function selectInputURI(inputURI: string) {
+    if (!inputURI) return;
+    try {
+      const parsed = new URL(inputURI);
+      if (parsed.protocol === 'feedcraft:') {
+        const id = parsed.pathname.replace(/^\/+/, '');
+        if (parsed.hostname === 'recipe') {
+          previewMode.value = 'recipe';
+          selectedRecipeId.value = id;
+          return;
+        }
+        if (parsed.hostname === 'topic') {
+          previewMode.value = 'topic';
+          selectedTopicId.value = id;
+          return;
+        }
+        if (parsed.hostname === 'inbox') {
+          previewMode.value = 'inbox';
+          selectedInboxId.value = id;
+          return;
+        }
+      }
+      if (parsed.protocol === 'http:' || parsed.protocol === 'https:') {
+        previewMode.value = 'url';
+        feedUrl.value = inputURI;
+        return;
+      }
+    } catch {
+      // Fall through to advanced URI mode.
+    }
+    previewMode.value = 'uri';
+    advancedURI.value = inputURI;
+  }
+
+  function applyRouteQuery() {
+    const target = firstQueryValue(route.query.target || route.query.mode);
+    const id = firstQueryValue(route.query.id);
+    if (target === 'recipe') {
+      previewMode.value = 'recipe';
+      selectedRecipeId.value = id || firstQueryValue(route.query.recipe_id);
+      return;
+    }
+    if (target === 'topic') {
+      previewMode.value = 'topic';
+      selectedTopicId.value = id || firstQueryValue(route.query.topic_id);
+      return;
+    }
+    if (target === 'inbox') {
+      previewMode.value = 'inbox';
+      selectedInboxId.value = id || firstQueryValue(route.query.inbox_id);
+      return;
+    }
+
+    selectInputURI(
+      firstQueryValue(
+        route.query.input_uri || route.query.uri || route.query.url
+      )
+    );
+  }
+
+  async function loadPreviewResources() {
+    resourceLoading.value = true;
+    const [recipeResult, topicResult, inboxResult] = await Promise.allSettled([
+      getCustomRecipes(),
+      listTopicFeeds(),
+      listInboxes(),
+    ]);
+    if (recipeResult.status === 'fulfilled') {
+      recipes.value = recipeResult.value.data ?? [];
+    }
+    if (topicResult.status === 'fulfilled') {
+      topics.value = topicResult.value.data ?? [];
+    }
+    if (inboxResult.status === 'fulfilled') {
+      inboxes.value = inboxResult.value.data ?? [];
+    }
+    if (
+      recipeResult.status === 'rejected' ||
+      topicResult.status === 'rejected' ||
+      inboxResult.status === 'rejected'
+    ) {
+      Message.warning(t('feedViewer.message.resourceLoadFailed'));
+    }
+    resourceLoading.value = false;
+  }
+
+  function formatRecipeOption(recipe: CustomRecipe) {
+    return recipe.description
+      ? `${recipe.id} · ${recipe.description}`
+      : recipe.id;
+  }
+
+  function formatTopicOption(topic: TopicFeed) {
+    return topic.title ? `${topic.id} · ${topic.title}` : topic.id;
+  }
+
+  function formatInboxOption(inbox: Inbox) {
+    return inbox.title ? `${inbox.id} · ${inbox.title}` : inbox.id;
+  }
+
+  onMounted(async () => {
+    applyRouteQuery();
+    await loadPreviewResources();
+    if (currentInputURI.value) {
       fetchFeed();
     }
   });

--- a/web/admin/src/views/dashboard/feed_viewer/feed_viewer.vue
+++ b/web/admin/src/views/dashboard/feed_viewer/feed_viewer.vue
@@ -146,6 +146,7 @@
   const errorMessage = ref('');
   const isLoading = ref(false);
   const resourceLoading = ref(false);
+  let previewRequestSeq = 0;
 
   const currentInputURI = computed(() => {
     if (previewMode.value === 'recipe' && selectedRecipeId.value) {
@@ -164,26 +165,34 @@
   });
 
   function clearPreviewState() {
+    previewRequestSeq += 1;
     errorMessage.value = '';
     feedContent.value = null;
   }
 
   async function fetchFeed() {
-    if (!currentInputURI.value) return;
+    const inputURI = currentInputURI.value;
+    if (!inputURI) return;
+    const requestSeq = previewRequestSeq + 1;
+    previewRequestSeq = requestSeq;
     isLoading.value = true;
     errorMessage.value = '';
     feedContent.value = null;
     try {
-      const response = await previewFeed(currentInputURI.value);
+      const response = await previewFeed(inputURI);
+      if (requestSeq !== previewRequestSeq) return;
       feedContent.value = response.data;
     } catch (error) {
+      if (requestSeq !== previewRequestSeq) return;
       feedContent.value = null;
       errorMessage.value =
         error instanceof Error
           ? error.message
           : t('feedViewer.message.unknownError');
     } finally {
-      isLoading.value = false;
+      if (requestSeq === previewRequestSeq) {
+        isLoading.value = false;
+      }
     }
   }
 
@@ -226,6 +235,16 @@
     advancedURI.value = inputURI;
   }
 
+  function resetPreviewTarget() {
+    previewMode.value = 'url';
+    feedUrl.value = '';
+    advancedURI.value = '';
+    selectedRecipeId.value = '';
+    selectedTopicId.value = '';
+    selectedInboxId.value = '';
+    clearPreviewState();
+  }
+
   function applyRouteQuery() {
     const target = firstQueryValue(route.query.target || route.query.mode);
     const id = firstQueryValue(route.query.id);
@@ -245,11 +264,14 @@
       return;
     }
 
-    selectInputURI(
-      firstQueryValue(
-        route.query.input_uri || route.query.uri || route.query.url
-      )
+    const inputURI = firstQueryValue(
+      route.query.input_uri || route.query.uri || route.query.url
     );
+    if (inputURI) {
+      selectInputURI(inputURI);
+      return;
+    }
+    resetPreviewTarget();
   }
 
   async function loadPreviewResources() {

--- a/web/admin/src/views/dashboard/inbox/index.vue
+++ b/web/admin/src/views/dashboard/inbox/index.vue
@@ -42,6 +42,9 @@
             >
               {{ t('inbox.btn.guide') }}
             </a-button>
+            <a-button type="text" size="small" @click="previewInbox(record.id)">
+              {{ t('inbox.btn.preview') }}
+            </a-button>
             <a-popconfirm
               :content="t('inbox.deleteConfirm')"
               @ok="handleDelete(record.id)"
@@ -194,6 +197,7 @@ curl -X POST "{{ pushUrl }}" \
 <script setup lang="ts">
   import { ref, reactive, onMounted, computed } from 'vue';
   import { useI18n } from 'vue-i18n';
+  import { useRouter } from 'vue-router';
   import { Message } from '@arco-design/web-vue';
   import {
     listInboxes,
@@ -212,6 +216,7 @@ curl -X POST "{{ pushUrl }}" \
   } from '@arco-design/web-vue/es/icon';
 
   const { t } = useI18n();
+  const router = useRouter();
   const loading = ref(false);
   const inboxes = ref<Inbox[]>([]);
 
@@ -302,6 +307,13 @@ curl -X POST "{{ pushUrl }}" \
   const handleShowGuide = (record: Inbox) => {
     selectedInbox.value = record;
     showGuideModal.value = true;
+  };
+
+  const previewInbox = (id: string) => {
+    router.push({
+      name: 'FeedViewer',
+      query: { target: 'inbox', id },
+    });
   };
 
   const handleSubmit = async () => {

--- a/web/admin/src/views/dashboard/topic_feed/detail.vue
+++ b/web/admin/src/views/dashboard/topic_feed/detail.vue
@@ -55,6 +55,9 @@
                 <a-button size="mini" @click="copyPublicUrl">
                   {{ t('topic.copyLink') }}
                 </a-button>
+                <a-button size="mini" type="primary" @click="previewTopic">
+                  {{ t('topic.preview') }}
+                </a-button>
               </a-space>
             </a-descriptions-item>
             <a-descriptions-item :label="t('topic.detail.lastSuccess')">
@@ -205,7 +208,7 @@
   import { computed, onMounted, ref } from 'vue';
   import { Message } from '@arco-design/web-vue';
   import { useI18n } from 'vue-i18n';
-  import { useRoute } from 'vue-router';
+  import { useRoute, useRouter } from 'vue-router';
   import XHeader from '@/components/header/x-header.vue';
   import {
     formatObservabilityErrorKind,
@@ -217,6 +220,7 @@
 
   const { t } = useI18n();
   const route = useRoute();
+  const router = useRouter();
   const loading = ref(false);
   const detail = ref<TopicDetail | null>(null);
   const detailsModalVisible = ref(false);
@@ -275,6 +279,14 @@
       console.error(err);
       Message.error(t('topic.copyLinkFailed'));
     }
+  };
+
+  const previewTopic = () => {
+    if (!detail.value) return;
+    router.push({
+      name: 'FeedViewer',
+      query: { target: 'topic', id: detail.value.topic.id },
+    });
   };
 
   const buildExecutionDetails = (

--- a/web/admin/src/views/dashboard/topic_feed/topic_feed.vue
+++ b/web/admin/src/views/dashboard/topic_feed/topic_feed.vue
@@ -61,6 +61,13 @@
                 >
                   {{ t('topic.viewDetails') }}
                 </a-button>
+                <a-button
+                  type="text"
+                  size="small"
+                  @click="previewTopic(record.id)"
+                >
+                  {{ t('topic.preview') }}
+                </a-button>
                 <a-button type="text" size="small" @click="handleEdit(record)">
                   {{ t('topic.editAction') }}
                 </a-button>
@@ -378,6 +385,13 @@
   };
 
   const buildTopicFeedUrl = (id: string) => buildPublicFeedUrl(`/topic/${id}`);
+
+  const previewTopic = (id: string) => {
+    router.push({
+      name: 'FeedViewer',
+      query: { target: 'topic', id },
+    });
+  };
 
   const handleAdd = () => {
     isEdit.value = false;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Route Feed Viewer preview through runtime input URIs for external URLs, Custom Recipes, Topic Feeds, and Inboxes.
- Add direct `feedcraft://inbox/:id` runtime support so Inbox preview does not require an intermediate Recipe.
- Update Feed Viewer and resource pages to launch internal preview targets instead of public RSS URLs.
- Keep Feed Viewer mode state synchronized across route changes, clear stale targets, and prevent stale preview responses from overwriting newer results.
- Preserve `user_request` observability trigger for Recipe previews while keeping Topic aggregation semantics intact.

### Walkthrough
[unified_feed_preview_final.mp4](https://cursor.com/agents/bc-d53cb321-e140-4b52-8a66-90be52ebb8eb/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Funified_feed_preview_final.mp4)

### Testing
- `task fix` passed with the existing frontend ESLint warning in `topic_feed/detail.vue` (`no-console`) and no errors.
- `go test ./...` passed.
- `task backend-build` passed.
- `task frontend-build` passed with existing Browserslist/eval build warnings.
- Manual browser walkthrough passed for empty viewer reset, direct Inbox preview, Recipe preview, and Topic preview.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d53cb321-e140-4b52-8a66-90be52ebb8eb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d53cb321-e140-4b52-8a66-90be52ebb8eb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

## Summary by Sourcery

Unify Feed Viewer preview handling around runtime input URIs, adding internal support for recipes, topics, and inboxes and wiring UI entry points to these targets.

New Features:
- Add Feed Viewer support for selecting and previewing external URLs, Custom Recipes, Topic Feeds, Inboxes, and arbitrary input URIs via a unified interface.
- Introduce runtime support for feedcraft://inbox/:id URIs to expose inbox contents as feeds without intermediary recipes.
- Add preview actions from Topic Feed and Inbox pages that deep-link into the Feed Viewer with the appropriate internal preview target.

Bug Fixes:
- Prevent stale Feed Viewer preview requests and results from overwriting newer responses when inputs or routes change.
- Return a clear 404-style message when a selected internal preview target cannot be found instead of a generic error.
- Reject craft_name usage for internal feedcraft:// URIs to avoid misconfigured previews.

Enhancements:
- Refactor backend feed preview to use the unified feedruntime input pipeline, preserving user_request triggers for recipe execution while maintaining topic aggregation semantics.
- Extend the feedruntime builder to handle internal inbox URIs and share logic for recipe trigger selection.
- Improve Feed Viewer validation to accept both external HTTP(S) URLs and internal feedcraft:// URIs with specific resource types and IDs.
- Load and display available recipes, topics, and inboxes in the Feed Viewer, showing the resolved input URI and surfacing partial resource load failures via user-friendly messages.
- Keep Feed Viewer preview state in sync with route query parameters, automatically applying and re-running previews on navigation changes.

Tests:
- Add controller tests covering recipe, topic, and inbox internal URIs and validation of craft_name usage for Feed Viewer previews.
- Add feedruntime tests ensuring inbox URIs are resolved using the builder DB and produce feeds with inbox metadata and items.