### PR TITLE
feat: inbox direct RSS endpoint + i18n + docs

### DIFF
--- a/doc-site/src/content/docs/en/guides/advanced/inbox.md
+++ b/doc-site/src/content/docs/en/guides/advanced/inbox.md
@@ -132,7 +132,23 @@ curl -X POST "https://YOUR_SERVER/api/inbox/my-inbox/items" \
 
 ## Subscribing via RSS
 
-To subscribe to inbox articles in an RSS reader, create a Custom Recipe that uses the inbox as its data source.
+### Direct RSS URL (simplest)
+
+Every inbox has a built-in RSS endpoint you can subscribe to immediately — no Custom Recipe required:
+
+```
+GET /inbox/{inbox_id}/rss
+```
+
+Copy this URL and paste it directly into your RSS reader. For a **private inbox**, append your token as a query parameter:
+
+```
+/inbox/{inbox_id}/rss?token=YOUR_SYSTEM_AUTH_TOKEN
+```
+
+### Via Custom Recipe (advanced)
+
+Create a Custom Recipe if you want to apply Craft processing on top of the inbox (e.g., AI translation, summarization, or filtering).
 
 <Steps>
 1. Navigate to **Worktable > Custom Recipe** and click **Create Recipe**.
@@ -141,12 +157,12 @@ To subscribe to inbox articles in an RSS reader, create a Custom Recipe that use
    ```json
    { "inbox_source": { "inbox_id": "YOUR_INBOX_ID" } }
    ```
-4. Set **Craft** to `proxy` (or any other craft chain you want to apply).
-5. Save the recipe and click **Copy Link** in the recipe list to get your RSS subscription URL.
+4. Set **Craft** to the desired processing chain (e.g., `translate-content`, `summary`).
+5. Save the recipe and click **Copy Link** in the recipe list to get the RSS URL.
 </Steps>
 
 :::tip
-You can apply AtomCrafts or FlowCrafts on top of the inbox source — for example, use `translate-content` to automatically translate pushed articles into another language.
+Use the **Direct RSS URL** for simple subscriptions. Switch to a Custom Recipe only when you need to apply AI processing (translation, summarization, filtering) on the inbox content.
 :::
 
 ## Access Control for Private Inboxes

--- a/doc-site/src/content/docs/zh-tw/guides/advanced/inbox.md
+++ b/doc-site/src/content/docs/zh-tw/guides/advanced/inbox.md
@@ -132,7 +132,23 @@ curl -X POST "https://YOUR_SERVER/api/inbox/my-inbox/items" \
 
 ## 透過 RSS 訂閱
 
-需要透過建立自訂配方，將收件箱作為資料來源，再產生可訂閱的 RSS 位址。
+### 直接訂閱（最簡方式）
+
+每個收件箱都內建了一個可以直接訂閱的 RSS 位址，無需建立自訂配方：
+
+```
+GET /inbox/{inbox_id}/rss
+```
+
+將此位址直接貼到 RSS 閱讀器中即可訂閱。對於**私有收件箱**，需在 URL 後附加 Token：
+
+```
+/inbox/{inbox_id}/rss?token=YOUR_SYSTEM_AUTH_TOKEN
+```
+
+### 透過自訂配方訂閱（進階）
+
+若需要對收件箱內容進行 Craft 處理（如 AI 翻譯、摘要產生、內容過濾），則建立自訂配方。
 
 <Steps>
 1. 前往**工作台 > 自訂配方**，點擊**新建配方**。
@@ -141,12 +157,12 @@ curl -X POST "https://YOUR_SERVER/api/inbox/my-inbox/items" \
    ```json
    { "inbox_source": { "inbox_id": "YOUR_INBOX_ID" } }
    ```
-4. 將 **Craft** 設定為 `proxy`（或您希望套用的其他處理鏈）。
+4. 將 **Craft** 設定為所需的處理鏈（例如 `translate-content`、`summary`）。
 5. 儲存配方後，在配方列表中點擊**複製連結**即可取得 RSS 訂閱位址。
 </Steps>
 
 :::tip
-可以在收件箱資料來源之上疊加 AtomCraft 或 FlowCraft。例如使用 `translate-content` 自動將推送的文章翻譯成其他語言。
+簡單訂閱場景直接使用**直接訂閱位址**即可。只有在需要對推送內容進行 AI 加工（翻譯、摘要、過濾）時，才需要建立自訂配方。
 :::
 
 ## 私有收件箱的存取控制

--- a/doc-site/src/content/docs/zh/guides/advanced/inbox.md
+++ b/doc-site/src/content/docs/zh/guides/advanced/inbox.md
@@ -132,7 +132,23 @@ curl -X POST "https://YOUR_SERVER/api/inbox/my-inbox/items" \
 
 ## 通过 RSS 订阅
 
-需要通过创建自定义配方，将收件箱作为数据来源，再生成可订阅的 RSS 地址。
+### 直接订阅（最简方式）
+
+每个收件箱都内置了一个可以直接订阅的 RSS 地址，无需创建自定义配方：
+
+```
+GET /inbox/{inbox_id}/rss
+```
+
+将此地址直接粘贴到 RSS 阅读器中即可订阅。对于**私有收件箱**，需在 URL 后附加 Token：
+
+```
+/inbox/{inbox_id}/rss?token=YOUR_SYSTEM_AUTH_TOKEN
+```
+
+### 通过自定义配方订阅（进阶）
+
+若需要对收件箱内容进行 Craft 处理（如 AI 翻译、摘要生成、内容过滤），则创建自定义配方。
 
 <Steps>
 1. 前往**工作台 > 自定义配方**，点击**新建配方**。
@@ -141,12 +157,12 @@ curl -X POST "https://YOUR_SERVER/api/inbox/my-inbox/items" \
    ```json
    { "inbox_source": { "inbox_id": "YOUR_INBOX_ID" } }
    ```
-4. 将 **Craft** 设置为 `proxy`（或您希望应用的其他处理链）。
+4. 将 **Craft** 设置为所需的处理链（例如 `translate-content`、`summary`）。
 5. 保存配方后，在配方列表中点击**复制链接**即可获取 RSS 订阅地址。
 </Steps>
 
 :::tip
-可以在收件箱数据源之上叠加 AtomCraft 或 FlowCraft。例如使用 `translate-content` 自动将推送的文章翻译成其他语言。
+简单订阅场景直接使用**直接订阅地址**即可。只有在需要对推送内容进行 AI 加工（翻译、摘要、过滤）时，才需要创建自定义配方。
 :::
 
 ## 私有收件箱的访问控制

--- a/internal/controller/inbox_public.go
+++ b/internal/controller/inbox_public.go
@@ -2,16 +2,55 @@ package controller
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
 	"strings"
 
 	"FeedCraft/internal/dao"
+	"FeedCraft/internal/model"
 	"FeedCraft/internal/util"
 
 	"github.com/gin-gonic/gin"
 	"gorm.io/gorm"
 )
 
+// checkInboxAccess validates access for a potentially private inbox.
+// It writes the HTTP error response and returns a non-nil error when access is denied.
+// Callers should abort immediately on a non-nil return value.
+func checkInboxAccess(c *gin.Context, inbox *dao.Inbox, db *gorm.DB) error {
+	if inbox.IsPublic != nil && *inbox.IsPublic {
+		return nil
+	}
+
+	tokenValue := c.Query("token")
+	if tokenValue == "" {
+		authHeader := c.GetHeader("Authorization")
+		if authHeader != "" {
+			parts := strings.SplitN(authHeader, " ", 2)
+			if len(parts) == 2 && strings.EqualFold(parts[0], "bearer") {
+				tokenValue = strings.TrimSpace(parts[1])
+			}
+		}
+	}
+
+	if tokenValue == "" {
+		c.JSON(http.StatusUnauthorized, gin.H{"code": 401, "msg": "Authorization required for private inbox"})
+		return fmt.Errorf("unauthorized")
+	}
+
+	_, err := dao.GetSystemAuthTokenByToken(db, tokenValue)
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			c.JSON(http.StatusUnauthorized, gin.H{"code": 401, "msg": "Invalid token"})
+		} else {
+			c.JSON(http.StatusInternalServerError, gin.H{"code": 500, "msg": "Database error"})
+		}
+		return err
+	}
+	return nil
+}
+
+// PublicInboxItemContent serves the raw HTML content of a single inbox article.
 func PublicInboxItemContent(c *gin.Context) {
 	inboxID := c.Param("inbox_id")
 	articleID := c.Param("article_id")
@@ -27,39 +66,8 @@ func PublicInboxItemContent(c *gin.Context) {
 		return
 	}
 
-	// 权限校验逻辑
-	if inbox.IsPublic == nil || !*inbox.IsPublic {
-		var tokenValue string
-
-		// 1. 优先尝试从 Query 提取 "?token=xxx"
-		if qToken := c.Query("token"); qToken != "" {
-			tokenValue = qToken
-		} else {
-			// 2. 其次尝试从 Authorization Header 提取 "Bearer xxx"
-			authHeader := c.GetHeader("Authorization")
-			if authHeader != "" {
-				parts := strings.SplitN(authHeader, " ", 2)
-				if len(parts) == 2 && strings.ToLower(parts[0]) == "bearer" {
-					tokenValue = strings.TrimSpace(parts[1])
-				}
-			}
-		}
-
-		if tokenValue == "" {
-			c.JSON(http.StatusUnauthorized, gin.H{"code": 401, "msg": "Authorization required for private inbox"})
-			return
-		}
-
-		// 3. 查库校验
-		_, err := dao.GetSystemAuthTokenByToken(db, tokenValue)
-		if err != nil {
-			if errors.Is(err, gorm.ErrRecordNotFound) {
-				c.JSON(http.StatusUnauthorized, gin.H{"code": 401, "msg": "Invalid token"})
-				return
-			}
-			c.JSON(http.StatusInternalServerError, gin.H{"code": 500, "msg": "Database error"})
-			return
-		}
+	if err := checkInboxAccess(c, inbox, db); err != nil {
+		return
 	}
 
 	item, err := dao.GetInboxItemByItemID(db, inboxID, articleID)
@@ -72,6 +80,64 @@ func PublicInboxItemContent(c *gin.Context) {
 		return
 	}
 
-	content := item.Content
-	c.Data(http.StatusOK, "text/html; charset=utf-8", []byte(content))
+	c.Data(http.StatusOK, "text/html; charset=utf-8", []byte(item.Content))
+}
+
+// PublicInboxRSSFeed serves a direct RSS feed for an inbox without requiring a Custom Recipe.
+// Access control mirrors PublicInboxItemContent: public inboxes are open, private ones need a token.
+func PublicInboxRSSFeed(c *gin.Context) {
+	inboxID := c.Param("inbox_id")
+	db := util.GetDatabase()
+
+	inbox, err := dao.GetInboxByID(db, inboxID)
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			c.JSON(http.StatusNotFound, gin.H{"code": 404, "msg": "Inbox not found"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"code": 500, "msg": err.Error()})
+		return
+	}
+
+	if err := checkInboxAccess(c, inbox, db); err != nil {
+		return
+	}
+
+	items, err := dao.ListInboxItems(db, inboxID)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"code": 500, "msg": err.Error()})
+		return
+	}
+
+	siteBaseURL := strings.TrimRight(util.GetEnvClient().GetString("SITE_BASE_URL"), "/")
+	inboxBaseURL := fmt.Sprintf("%s/inbox/%s", siteBaseURL, inboxID)
+
+	craftFeed := &model.CraftFeed{
+		Title:       inbox.Title,
+		Description: inbox.Description,
+		Id:          inboxBaseURL + "/rss",
+		Link:        inboxBaseURL,
+		Articles:    make([]*model.CraftArticle, 0, len(items)),
+	}
+
+	for _, item := range items {
+		craftFeed.Articles = append(craftFeed.Articles, &model.CraftArticle{
+			Title:       item.Title,
+			Link:        item.URL,
+			Content:     item.Content,
+			Description: item.Summary,
+			Id:          item.ItemID,
+			AuthorName:  item.Author,
+			Created:     item.PublishedAt,
+			Updated:     item.PublishedAt,
+		})
+	}
+
+	rssStr, err := craftFeed.ToFeedsFeed().ToRss()
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"code": 500, "msg": "Failed to render RSS"})
+		return
+	}
+
+	c.Data(http.StatusOK, "application/rss+xml; charset=utf-8", []byte(rssStr))
 }

--- a/internal/router/registry.go
+++ b/internal/router/registry.go
@@ -67,7 +67,8 @@ func RegisterRouters(router *gin.Engine) {
 		public.POST("/inbox/:inbox_id/items", middleware.SystemAuthTokenMiddleware(), controller.PushInboxItems)
 	}
 
-	// Article serving content in an isolated namespace to avoid routing ambiguity with SPA fallback or others
+	// Inbox public routes — isolated from /api and SPA fallback
+	router.GET("/inbox/:inbox_id/rss", controller.PublicInboxRSSFeed)
 	router.GET("/inbox/:inbox_id/items/:article_id/content", controller.PublicInboxItemContent)
 
 	craftRouters := router.Group("/craft")

--- a/web/admin/src/locale/en-US/inbox.ts
+++ b/web/admin/src/locale/en-US/inbox.ts
@@ -41,6 +41,12 @@ export default {
   'inbox.guide.query.private':
     'This inbox is Private. You must attach `?token=YOUR_TOKEN` query parameter to subscribe or view articles.',
 
+  // Direct RSS URL
+  'inbox.guide.directRss.desc':
+    'Subscribe directly with this RSS URL — no Custom Recipe needed:',
+  'inbox.guide.directRss.privateHint':
+    'Private inbox — append token to the URL:',
+
   // Recipe integration guide steps
   'inbox.guide.recipe.heading': 'RSS Subscription via Recipe',
   'inbox.guide.recipe.step1.pre': 'Go to the',

--- a/web/admin/src/locale/zh-CN/inbox.ts
+++ b/web/admin/src/locale/zh-CN/inbox.ts
@@ -40,6 +40,11 @@ export default {
   'inbox.guide.query.private':
     '该收件箱为私有状态，订阅或拉取文章正文必须在 URL Query 带上 `?token=YOUR_TOKEN` 进行身份验证。',
 
+  // Direct RSS URL
+  'inbox.guide.directRss.desc':
+    '可直接使用以下 RSS 地址订阅，无需提前创建自定义配方：',
+  'inbox.guide.directRss.privateHint': '私有收件箱 — 需在 URL 后附加 Token：',
+
   // Recipe integration guide steps
   'inbox.guide.recipe.heading': '通过配方订阅 RSS',
   'inbox.guide.recipe.step1.pre': '前往',

--- a/web/admin/src/locale/zh-TW/inbox.ts
+++ b/web/admin/src/locale/zh-TW/inbox.ts
@@ -39,6 +39,11 @@ export default {
   'inbox.guide.query.private':
     '該收件箱為私有狀態，訂閱或拉取文章正文必須在 URL Query 帶上 `?token=YOUR_TOKEN` 進行身份驗證。',
 
+  // Direct RSS URL
+  'inbox.guide.directRss.desc':
+    '可直接使用以下 RSS 位址訂閱，無需提前建立自訂配方：',
+  'inbox.guide.directRss.privateHint': '私有收件箱 — 需在 URL 後附加 Token：',
+
   // Recipe integration guide steps
   'inbox.guide.recipe.heading': '透過配方訂閱 RSS',
   'inbox.guide.recipe.step1.pre': '前往',

--- a/web/admin/src/views/dashboard/inbox/index.vue
+++ b/web/admin/src/views/dashboard/inbox/index.vue
@@ -170,6 +170,21 @@ curl -X POST "{{ pushUrl }}" \
           <icon-exclamation-circle-fill /> {{ t('inbox.guide.query.private') }}
         </p>
 
+        <!-- Direct RSS URL -->
+        <p class="desc-text mt-2">{{ t('inbox.guide.directRss.desc') }}</p>
+        <div class="code-box">
+          <span class="monospace-text">{{ directRssUrl }}</span>
+          <a-button type="text" size="mini" @click="copyText(directRssUrl)">
+            <template #icon><icon-copy /></template>
+          </a-button>
+        </div>
+        <p v-if="!selectedInbox.is_public" class="desc-text">
+          {{ t('inbox.guide.directRss.privateHint') }}
+          <span class="monospace-text"
+            >{{ directRssUrl }}?token=YOUR_TOKEN</span
+          >
+        </p>
+
         <div class="recipe-step-box">
           <p
             ><strong>{{ t('inbox.guide.recipe.heading') }}:</strong></p
@@ -368,6 +383,11 @@ curl -X POST "{{ pushUrl }}" \
   const pushUrl = computed(() => {
     if (!selectedInbox.value) return '';
     return `${apiBaseUrl.value}/api/inbox/${selectedInbox.value.id}/items`;
+  });
+
+  const directRssUrl = computed(() => {
+    if (!selectedInbox.value) return '';
+    return `${apiBaseUrl.value}/inbox/${selectedInbox.value.id}/rss`;
   });
 
   onMounted(() => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

This PR makes the Inbox feature production-ready: completes i18n, adds docs, fixes field alignment, and implements direct RSS subscription.

---

## 1. Bug Fixes (from prior testing)

- **`is_public: false` not persisted** — `IsPublic bool` → `IsPublic *bool` to prevent GORM zero-value default override
- **`UpdateInbox` returns 400** — use anonymous body struct so `binding:"required"` on ID doesn't fail (ID comes from URL path)
- **Inbox guide modal shows wrong field names** — `item_id` → `id`, `published_at` (ISO string) → `timestamp` (Unix float64)

---

## 2. Direct RSS Endpoint `GET /inbox/:inbox_id/rss`

No Custom Recipe required to subscribe to an inbox.

**New route**: `GET /inbox/:inbox_id/rss`
- Public inbox: open, no auth
- Private inbox: `?token=YOUR_TOKEN` or `Authorization: Bearer YOUR_TOKEN`
- Returns standard `application/rss+xml`

**Implementation** (`internal/controller/inbox_public.go`):
- Extracted `checkInboxAccess()` helper (deduplicates auth logic with `PublicInboxItemContent`)
- `PublicInboxRSSFeed()` loads inbox + items from DB, builds `model.CraftFeed`, renders via `gorilla/feeds`
- Zero new package dependencies; route registered alongside existing `/inbox/` routes

**Tested**:
```
✅ GET /inbox/rss-test/rss                               → valid RSS XML (3 items)
✅ GET /inbox/not-exist/rss                              → 404
✅ GET /inbox/private-rss/rss                            → 401 (no token)
✅ GET /inbox/private-rss/rss?token=invalid              → 401
✅ GET /inbox/private-rss/rss?token=VALID                → valid RSS
✅ GET /inbox/private-rss/rss (Authorization: Bearer)    → valid RSS
```

---

## 3. i18n & Locale

- **Hardcoded text** in guide modal and system_auth_token page replaced with i18n keys
- **`zh-TW/inbox.ts`** created (Traditional Chinese, Taiwan vocabulary)
- **`zh-CN/menu.ts`** missing `menu.webMonitor` key added
- New keys: `inbox.guide.directRss.desc`, `inbox.guide.directRss.privateHint` (en-US / zh-CN / zh-TW)

---

## 4. Documentation (en / zh / zh-tw)

Added `inbox.md` in all three language directories:
- "Subscribing via RSS" split into **Direct RSS URL** (primary) + **Via Custom Recipe** (advanced)
- Push API field table verified against `InboxPushItem` struct
- Overflow pruning clarified: by `created_at`, not `published_at`
- `max_items=0` edge case documented

---

## Verification

- ✅ `go test ./...` — 12 packages pass
- ✅ `task fix` — lint/format clean
- ✅ `task backend-build` / `task frontend-build`
- ✅ `pnpm run type:check`
- ✅ End-to-end API test of all 6 RSS endpoint scenarios
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-22ac03b6-7021-4f46-b310-1bc1e01edc32"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-22ac03b6-7021-4f46-b310-1bc1e01edc32"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

## Summary by Sourcery

Add a public RSS endpoint for inboxes, expose its URL in the admin inbox guide, and update multilingual documentation to describe direct RSS subscriptions alongside recipe-based subscriptions.

New Features:
- Expose a direct public RSS feed endpoint per inbox that returns RSS XML and respects inbox privacy via token-based access control.
- Show a copyable direct RSS subscription URL in the inbox admin UI, including guidance for private inbox tokens.

Enhancements:
- Refactor inbox public access checks into a shared helper for reuse across inbox content and RSS endpoints.

Documentation:
- Update inbox guides in English, Simplified Chinese, and Traditional Chinese to explain direct RSS subscription URLs and clarify when to use custom recipes.