### PR TITLE
feat: unhide topic feed admin page

### DIFF
--- a/web/admin/src/router/routes/modules/worktable.ts
+++ b/web/admin/src/router/routes/modules/worktable.ts
@@ -12,26 +12,25 @@ const WORKTABLE: AppRouteRecordRaw = {
     order: 1,
   },
   children: [
-    // TopicFeed 功能当前仍在开发完善中，先隐藏入口；待功能 ready 后再重新开放。
-    // {
-    //   path: 'topic_feed',
-    //   name: 'TopicFeed',
-    //   component: () => import('@/views/dashboard/topic_feed/topic_feed.vue'),
-    //   meta: {
-    //     requiresAuth: true,
-    //     locale: 'menu.topicFeed',
-    //   },
-    // },
-    // {
-    //   path: 'topic_feed/:id',
-    //   name: 'TopicFeedDetail',
-    //   component: () => import('@/views/dashboard/topic_feed/detail.vue'),
-    //   meta: {
-    //     requiresAuth: true,
-    //     locale: 'menu.topicFeed',
-    //     hideInMenu: true,
-    //   },
-    // },
+    {
+      path: 'topic_feed',
+      name: 'TopicFeed',
+      component: () => import('@/views/dashboard/topic_feed/topic_feed.vue'),
+      meta: {
+        requiresAuth: true,
+        locale: 'menu.topicFeed',
+      },
+    },
+    {
+      path: 'topic_feed/:id',
+      name: 'TopicFeedDetail',
+      component: () => import('@/views/dashboard/topic_feed/detail.vue'),
+      meta: {
+        requiresAuth: true,
+        locale: 'menu.topicFeed',
+        hideInMenu: true,
+      },
+    },
     {
       path: 'custom_recipe',
       name: 'CustomRecipe',

--- a/web/admin/src/views/dashboard/observability/index.vue
+++ b/web/admin/src/views/dashboard/observability/index.vue
@@ -93,9 +93,8 @@
                     >
                       {{ t('observability.link') }}
                     </a-link>
-                    <!-- TopicFeed 功能当前仍在开发完善中，先隐藏详情入口；待功能 ready 后再重新开放。 -->
                     <a-button
-                      v-if="false && record.resource_type === 'topic'"
+                      v-if="record.resource_type === 'topic'"
                       type="text"
                       size="small"
                       @click="goToTopicDetail(record.resource_id)"
@@ -377,7 +376,6 @@
     }
   };
 
-  // TopicFeed 功能当前仍在开发完善中，先隐藏详情跳转；待功能 ready 后再重新开放。
   const goToTopicDetail = (id: string) => {
     router.push({ name: 'TopicFeedDetail', params: { id } });
   };


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 变更说明

Topic Feed 功能的后端实现和前端视图已完整，之前仅因入口路由被注释而隐藏。本 PR 重新开放该功能的访问入口。

### 改动内容

- **`web/admin/src/router/routes/modules/worktable.ts`**：取消 `TopicFeed` 和 `TopicFeedDetail` 两条路由的注释，使其重新出现在侧边栏菜单中
- **`web/admin/src/views/dashboard/observability/index.vue`**：将 `v-if="false && record.resource_type === 'topic'"` 恢复为 `v-if="record.resource_type === 'topic'"`，重新启用 Observability 页面中指向 Topic 详情的跳转按钮；同时移除相关的"开发中"注释

### 测试结果

手动测试验证了以下全部 CRUD 功能均正常：

- ✅ 侧边栏"工作台"菜单下正常显示"主题订阅"条目
- ✅ 创建：填写 ID、标题、描述、RSS 输入源、聚合规则，配置校验通过后保存成功
- ✅ 列表：主题列表正常展示
- ✅ 详情：跳转到详情页，显示输入源数量、最近执行记录等信息
- ✅ 编辑：修改标题并保存，列表数据即时刷新
- ✅ 删除：确认气泡弹出，确认后删除成功

[topic_feed_full_test.mp4](https://cursor.com/agents/bc-8e6dcf04-ec5b-4a74-b578-72020b34aeca/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftopic_feed_full_test.mp4)

[侧边栏显示主题订阅菜单项](https://cursor.com/agents/bc-8e6dcf04-ec5b-4a74-b578-72020b34aeca/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftopic_feed_sidebar_menu.webp)
[创建主题对话框](https://cursor.com/agents/bc-8e6dcf04-ec5b-4a74-b578-72020b34aeca/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftopic_feed_create_dialog.webp)
[主题详情页](https://cursor.com/agents/bc-8e6dcf04-ec5b-4a74-b578-72020b34aeca/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftopic_feed_detail_page.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8e6dcf04-ec5b-4a74-b578-72020b34aeca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8e6dcf04-ec5b-4a74-b578-72020b34aeca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

## Summary by Sourcery

Unhide the Topic Feed admin functionality and re-enable navigation to topic details from the observability dashboard.

New Features:
- Expose Topic Feed and Topic Feed Detail routes in the Worktable sidebar menu to make the Topic Feed UI accessible.

Enhancements:
- Re-enable the observability page button that links to Topic Feed detail pages for topic-type resources and clean up related placeholder comments.