### PR TITLE
Make embedding model configuration mandatory

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,7 +32,8 @@ FC_DEFAULT_TARGET_LANG=zh-CN
 FC_EMBEDDING_API_TYPE=openai
 FC_EMBEDDING_API_BASE=https://api.openai.com/v1
 FC_EMBEDDING_API_KEY=sk-your-api-key-here
-FC_EMBEDDING_API_MODEL=text-embedding-3-small
+# Required: The embedding model name (e.g., text-embedding-3-small, nomic-embed-text)
+FC_EMBEDDING_API_MODEL=
 FC_EMBEDDING_INSTRUCTION=
 # Max texts per batch sent to embedding service. Adjust based on model size and hardware. (default: 5)
 FC_EMBEDDING_BATCH_SIZE=5

--- a/doc-site/src/content/docs/en/guides/advanced/system-craft-atoms.md
+++ b/doc-site/src/content/docs/en/guides/advanced/system-craft-atoms.md
@@ -180,7 +180,7 @@ Set a dedicated embedding endpoint when possible:
 FC_EMBEDDING_API_TYPE=openai
 FC_EMBEDDING_API_BASE=https://api.openai.com/v1
 FC_EMBEDDING_API_KEY=sk-your-api-key
-FC_EMBEDDING_API_MODEL=text-embedding-3-small
+FC_EMBEDDING_API_MODEL=text-embedding-3-small # Required
 FC_EMBEDDING_BATCH_SIZE=5
 FC_EMBEDDING_MAX_INPUT_CHARS=8000
 ```
@@ -191,7 +191,7 @@ Supported `FC_EMBEDDING_API_TYPE` values:
 - `gemini`: Gemini through its OpenAI-compatible embedding endpoint. Set `FC_EMBEDDING_API_BASE` and `FC_EMBEDDING_API_MODEL` explicitly.
 - `ollama`: Local Ollama embedding model. Set `FC_EMBEDDING_API_BASE`, for example `http://localhost:11434`, and an embedding model such as `nomic-embed-text` or `bge-m3`.
 
-If `FC_EMBEDDING_API_TYPE`, `FC_EMBEDDING_API_BASE`, and `FC_EMBEDDING_API_KEY` are not set, FeedCraft falls back to the matching `FC_LLM_API_TYPE`, `FC_LLM_API_BASE`, and `FC_LLM_API_KEY` values. The embedding model name is independent: set `FC_EMBEDDING_API_MODEL` to a real embedding model, or FeedCraft uses its OpenAI default when the API type is `openai`. FeedCraft does not reuse `FC_LLM_API_MODEL` because that value is usually a chat model.
+If `FC_EMBEDDING_API_TYPE`, `FC_EMBEDDING_API_BASE`, and `FC_EMBEDDING_API_KEY` are not set, FeedCraft falls back to the matching `FC_LLM_API_TYPE`, `FC_LLM_API_BASE`, and `FC_LLM_API_KEY` values. The embedding model name is independent: **you must explicitly set `FC_EMBEDDING_API_MODEL` to a valid embedding model.** FeedCraft does not provide a default embedding model and does not reuse `FC_LLM_API_MODEL` because that value is usually a chat model.
 
 `FC_EMBEDDING_MAX_INPUT_CHARS` is a final safety cap applied to every text sent to the embedding service, including any `instruction` prefix. It is a character budget, not an exact tokenizer count. Keep it at or below a conservative value for your model's token window, for example `8000` for an 8k-token embedding model.
 

--- a/doc-site/src/content/docs/zh-tw/guides/advanced/system-craft-atoms.md
+++ b/doc-site/src/content/docs/zh-tw/guides/advanced/system-craft-atoms.md
@@ -181,7 +181,7 @@ FeedCraft 內建了一系列「原子工藝 (AtomCrafts)」，用於對訂閱源
 FC_EMBEDDING_API_TYPE=openai
 FC_EMBEDDING_API_BASE=https://api.openai.com/v1
 FC_EMBEDDING_API_KEY=sk-your-api-key
-FC_EMBEDDING_API_MODEL=text-embedding-3-small
+FC_EMBEDDING_API_MODEL=text-embedding-3-small # 必填
 FC_EMBEDDING_BATCH_SIZE=5
 FC_EMBEDDING_MAX_INPUT_CHARS=8000
 ```
@@ -192,7 +192,7 @@ FC_EMBEDDING_MAX_INPUT_CHARS=8000
 - `gemini`: 透過 Gemini 的 OpenAI 相容 Embedding 介面呼叫。請明確設定 `FC_EMBEDDING_API_BASE` 和 `FC_EMBEDDING_API_MODEL`。
 - `ollama`: 本機 Ollama Embedding 模型。請設定 `FC_EMBEDDING_API_BASE`，例如 `http://localhost:11434`，並使用 `nomic-embed-text` 或 `bge-m3` 這類 Embedding 模型。
 
-如果 `FC_EMBEDDING_API_TYPE`、`FC_EMBEDDING_API_BASE`、`FC_EMBEDDING_API_KEY` 都沒有設定，FeedCraft 會回退到對應的 `FC_LLM_API_TYPE`、`FC_LLM_API_BASE`、`FC_LLM_API_KEY`。Embedding 模型名是獨立的：請將 `FC_EMBEDDING_API_MODEL` 設定為真正的 Embedding 模型；如果 API 類型是 `openai` 且未設定該變數，FeedCraft 會使用預設 Embedding 模型。FeedCraft 不會複用 `FC_LLM_API_MODEL`，因為它通常是聊天模型。
+如果 `FC_EMBEDDING_API_TYPE`、`FC_EMBEDDING_API_BASE`、`FC_EMBEDDING_API_KEY` 都沒有設定，FeedCraft 會回退到對應的 `FC_LLM_API_TYPE`、`FC_LLM_API_BASE`、`FC_LLM_API_KEY`。Embedding 模型名是獨立的：**你必須顯式設定 `FC_EMBEDDING_API_MODEL` 為有效的 Embedding 模型。** FeedCraft 不再提供預設 Embedding 模型，也不會複用 `FC_LLM_API_MODEL`，因為它通常是聊天模型。
 
 `FC_EMBEDDING_MAX_INPUT_CHARS` 是傳送給 Embedding 服務前的最終安全上限，包含 `instruction` 前綴。它是字元預算，不是精確的 tokenizer token 數。建議按模型 token 視窗設定保守值，例如 8k token 的 Embedding 模型可從 `8000` 開始。
 

--- a/doc-site/src/content/docs/zh/guides/advanced/system-craft-atoms.md
+++ b/doc-site/src/content/docs/zh/guides/advanced/system-craft-atoms.md
@@ -181,7 +181,7 @@ FeedCraft 内置了一系列“原子工艺 (AtomCrafts)”，用于对订阅源
 FC_EMBEDDING_API_TYPE=openai
 FC_EMBEDDING_API_BASE=https://api.openai.com/v1
 FC_EMBEDDING_API_KEY=sk-your-api-key
-FC_EMBEDDING_API_MODEL=text-embedding-3-small
+FC_EMBEDDING_API_MODEL=text-embedding-3-small # 必填
 FC_EMBEDDING_BATCH_SIZE=5
 FC_EMBEDDING_MAX_INPUT_CHARS=8000
 ```
@@ -192,7 +192,7 @@ FC_EMBEDDING_MAX_INPUT_CHARS=8000
 - `gemini`: 通过 Gemini 的 OpenAI 兼容 Embedding 接口调用。请显式设置 `FC_EMBEDDING_API_BASE` 和 `FC_EMBEDDING_API_MODEL`。
 - `ollama`: 本地 Ollama Embedding 模型。请设置 `FC_EMBEDDING_API_BASE`，例如 `http://localhost:11434`，并使用 `nomic-embed-text` 或 `bge-m3` 这类 Embedding 模型。
 
-如果 `FC_EMBEDDING_API_TYPE`、`FC_EMBEDDING_API_BASE`、`FC_EMBEDDING_API_KEY` 都没有设置，FeedCraft 会回退到对应的 `FC_LLM_API_TYPE`、`FC_LLM_API_BASE`、`FC_LLM_API_KEY`。Embedding 模型名是独立的：请将 `FC_EMBEDDING_API_MODEL` 设置为真正的 Embedding 模型；如果 API 类型是 `openai` 且未设置该变量，FeedCraft 会使用默认 Embedding 模型。FeedCraft 不会复用 `FC_LLM_API_MODEL`，因为它通常是聊天模型。
+如果 `FC_EMBEDDING_API_TYPE`、`FC_EMBEDDING_API_BASE`、`FC_EMBEDDING_API_KEY` 都没有设置，FeedCraft 会回退到对应的 `FC_LLM_API_TYPE`、`FC_LLM_API_BASE`、`FC_LLM_API_KEY`。Embedding 模型名是独立的：**你必须显式设置 `FC_EMBEDDING_API_MODEL` 为有效的 Embedding 模型。** FeedCraft 不再提供默认 Embedding 模型，也不会复用 `FC_LLM_API_MODEL`，因为它通常是聊天模型。
 
 `FC_EMBEDDING_MAX_INPUT_CHARS` 是发送给 Embedding 服务前的最终安全上限，包含 `instruction` 前缀。它是字符预算，不是精确的 tokenizer token 数。建议按模型 token 窗口设置保守值，例如 8k token 的 Embedding 模型可从 `8000` 开始。
 

--- a/internal/adapter/embedding.go
+++ b/internal/adapter/embedding.go
@@ -23,7 +23,6 @@ import (
  */
 
 const (
-	defaultEmbeddingModel         = "text-embedding-3-small"
 	embeddingCallTimeout          = 2 * time.Minute
 	embeddingTotalTimeout         = 5 * time.Minute // 全局超时预算，所有重试在此预算内执行
 	defaultEmbeddingBatchSize     = 5               // 每批发送给 Embedding 服务的默认最大文本数
@@ -109,18 +108,8 @@ func loadEmbeddingConfig() (embeddingConfig, error) {
 		cfg.apiType = "openai"
 	}
 
-	if strings.Contains(cfg.apiModel, ",") {
+	if cfg.apiModel == "" || strings.Contains(cfg.apiModel, ",") {
 		return embeddingConfig{}, fmt.Errorf("FC_EMBEDDING_API_MODEL must be set to a single embedding model")
-	}
-
-	if cfg.apiModel == "" {
-		switch cfg.apiType {
-		case "ollama", "gemini":
-			return embeddingConfig{}, fmt.Errorf("FC_EMBEDDING_API_MODEL must be set when using FC_EMBEDDING_API_TYPE='%s'", cfg.apiType)
-		default: // "openai" 及其他 OpenAI 兼容服务
-			cfg.apiModel = defaultEmbeddingModel
-			logrus.Debugf("FC_EMBEDDING_API_MODEL not set, using default: %s", defaultEmbeddingModel)
-		}
 	}
 
 	return cfg, nil

--- a/internal/adapter/embedding_test.go
+++ b/internal/adapter/embedding_test.go
@@ -11,15 +11,16 @@ import (
 // --- loadEmbeddingConfig 测试 ---
 
 func TestLoadEmbeddingConfig_Defaults(t *testing.T) {
+	t.Setenv("FC_EMBEDDING_API_MODEL", "text-embedding-3-small")
 	cfg, err := loadEmbeddingConfig()
 	assert.NoError(t, err)
 	// 默认 apiType 应为 "openai"
 	assert.Equal(t, "openai", cfg.apiType)
-	// 默认模型应为 defaultEmbeddingModel
-	assert.Equal(t, defaultEmbeddingModel, cfg.apiModel)
+	assert.Equal(t, "text-embedding-3-small", cfg.apiModel)
 }
 
 func TestLoadEmbeddingConfig_ApiTypeDefault(t *testing.T) {
+	t.Setenv("FC_EMBEDDING_API_MODEL", "text-embedding-3-small")
 	cfg, err := loadEmbeddingConfig()
 	assert.NoError(t, err)
 	// 未设置 FC_EMBEDDING_API_TYPE 时应默认为 "openai"
@@ -27,6 +28,7 @@ func TestLoadEmbeddingConfig_ApiTypeDefault(t *testing.T) {
 }
 
 func TestLoadEmbeddingConfig_ReturnsNoFatal(t *testing.T) {
+	t.Setenv("FC_EMBEDDING_API_MODEL", "text-embedding-3-small")
 	// 确保 loadEmbeddingConfig 不会 panic 或 fatal
 	cfg, err := loadEmbeddingConfig()
 	assert.NoError(t, err)
@@ -34,12 +36,14 @@ func TestLoadEmbeddingConfig_ReturnsNoFatal(t *testing.T) {
 }
 
 func TestLoadEmbeddingConfig_DefaultMaxInputChars(t *testing.T) {
+	t.Setenv("FC_EMBEDDING_API_MODEL", "text-embedding-3-small")
 	cfg, err := loadEmbeddingConfig()
 	assert.NoError(t, err)
 	assert.Equal(t, defaultEmbeddingMaxInputChars, cfg.maxInputChars)
 }
 
 func TestLoadEmbeddingConfig_CustomMaxInputChars(t *testing.T) {
+	t.Setenv("FC_EMBEDDING_API_MODEL", "text-embedding-3-small")
 	t.Setenv("FC_EMBEDDING_MAX_INPUT_CHARS", "4096")
 
 	cfg, err := loadEmbeddingConfig()
@@ -183,9 +187,9 @@ func TestLoadEmbeddingConfig_GeminiEmptyModel(t *testing.T) {
 func TestLoadEmbeddingConfig_OpenAIDefaultModel(t *testing.T) {
 	t.Setenv("FC_EMBEDDING_API_TYPE", "openai")
 	t.Setenv("FC_EMBEDDING_API_MODEL", "")
-	cfg, err := loadEmbeddingConfig()
-	assert.NoError(t, err)
-	assert.Equal(t, defaultEmbeddingModel, cfg.apiModel, "openai should use default model when not set")
+	_, err := loadEmbeddingConfig()
+	assert.Error(t, err, "openai with empty model should return error")
+	assert.Contains(t, err.Error(), "FC_EMBEDDING_API_MODEL")
 }
 
 func TestLoadEmbeddingConfig_FallsBackToLLMEndpointWithDedicatedEmbeddingModel(t *testing.T) {
@@ -217,13 +221,10 @@ func TestLoadEmbeddingConfig_DoesNotUseLLMChatModelAsEmbeddingModel(t *testing.T
 	t.Setenv("FC_EMBEDDING_API_KEY", "")
 	t.Setenv("FC_EMBEDDING_API_MODEL", "")
 
-	cfg, err := loadEmbeddingConfig()
+	_, err := loadEmbeddingConfig()
 
-	assert.NoError(t, err)
-	assert.Equal(t, "openai", cfg.apiType)
-	assert.Equal(t, "https://api.openai.com/v1", cfg.apiBase)
-	assert.Equal(t, "test-key", cfg.apiKey)
-	assert.Equal(t, defaultEmbeddingModel, cfg.apiModel)
+	assert.Error(t, err, "should return error when embedding model is not set, even if LLM model is set")
+	assert.Contains(t, err.Error(), "FC_EMBEDDING_API_MODEL")
 }
 
 func TestLoadEmbeddingConfig_DoesNotFallbackLLMKeyWhenEmbeddingEndpointIsSet(t *testing.T) {
@@ -247,10 +248,10 @@ func TestLoadEmbeddingConfig_IgnoresCommaSeparatedLLMModelWhenEmbeddingModelUses
 	t.Setenv("FC_EMBEDDING_API_TYPE", "")
 	t.Setenv("FC_EMBEDDING_API_MODEL", "")
 
-	cfg, err := loadEmbeddingConfig()
+	_, err := loadEmbeddingConfig()
 
-	assert.NoError(t, err)
-	assert.Equal(t, defaultEmbeddingModel, cfg.apiModel)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "FC_EMBEDDING_API_MODEL")
 }
 
 func TestBuildAnchorVectorCacheKeyIncludesProviderAndBase(t *testing.T) {

--- a/internal/controller/dependency_monitor.go
+++ b/internal/controller/dependency_monitor.go
@@ -190,9 +190,6 @@ func checkEmbedding(activeCheck bool) DependencyStatus {
 	if embeddingType == "" {
 		embeddingType = "openai"
 	}
-	if embeddingModel == "" && embeddingType == "openai" {
-		embeddingModel = "text-embedding-3-small"
-	}
 
 	details := fmt.Sprintf("Type: %s, Model: %s, Base: %s", embeddingType, embeddingModel, embeddingBase)
 	if embeddingKey != "" {

--- a/internal/controller/dependency_monitor_test.go
+++ b/internal/controller/dependency_monitor_test.go
@@ -19,7 +19,7 @@ func TestCheckEmbeddingFallsBackToLLMEndpointForConfiguredStatus(t *testing.T) {
 	t.Setenv("FC_EMBEDDING_API_TYPE", "")
 	t.Setenv("FC_EMBEDDING_API_BASE", "")
 	t.Setenv("FC_EMBEDDING_API_KEY", "")
-	t.Setenv("FC_EMBEDDING_API_MODEL", "")
+	t.Setenv("FC_EMBEDDING_API_MODEL", "text-embedding-3-small")
 
 	status := checkEmbedding(false)
 


### PR DESCRIPTION
The embedding model name (`FC_EMBEDDING_API_MODEL`) is now mandatory and has no hardcoded defaults. This prevents accidental use of non-existent models when falling back to LLM credentials. `loadEmbeddingConfig` in `internal/adapter/embedding.go` now returns an error if the model name is empty or contains commas. Documentation and example environment files have been updated to reflect this requirement.

---
*PR created automatically by Jules for task [10276284733730034307](https://jules.google.com/task/10276284733730034307) started by @Colin-XKL*

## Summary by Sourcery

Require explicit configuration of the embedding model and remove all default fallbacks.

Bug Fixes:
- Prevent accidental use of non-existent embedding models when falling back to LLM credentials by enforcing an explicit embedding model.

Enhancements:
- Update embedding configuration validation to error when FC_EMBEDDING_API_MODEL is empty or comma-separated.
- Adjust dependency monitoring and tests to assume a required embedding model instead of applying an OpenAI-specific default.
- Clarify English and Chinese documentation that FC_EMBEDDING_API_MODEL is mandatory and no default embedding model is provided.

Tests:
- Update embedding and dependency monitor tests to set FC_EMBEDDING_API_MODEL explicitly and assert error behavior when it is missing.