### PR TITLE
Refactor relative imports to @/ alias in web/admin

### DIFF
--- a/web/admin/src/api/auth-expired.test.ts
+++ b/web/admin/src/api/auth-expired.test.ts
@@ -6,7 +6,7 @@ import {
   isSessionExpiredAPIResponse,
   isSessionExpiredHTTPStatus,
   SessionExpiredError,
-} from './auth-expired';
+} from '@/api/auth-expired';
 
 describe('auth expired helpers', () => {
   it('identifies unauthorized responses as session expiration', () => {

--- a/web/admin/src/views/dashboard/craft_atom/craft_atom.vue
+++ b/web/admin/src/views/dashboard/craft_atom/craft_atom.vue
@@ -248,7 +248,7 @@
     isEmbeddingFilterThresholdParam,
     serializeCraftParamValue,
     toCraftParamFormValue,
-  } from './paramOptions';
+  } from '@/views/dashboard/craft_atom/paramOptions';
 
   const { t } = useI18n();
 

--- a/web/admin/src/views/dashboard/craft_atom/paramOptions.test.ts
+++ b/web/admin/src/views/dashboard/craft_atom/paramOptions.test.ts
@@ -5,7 +5,7 @@ import {
   isAIContentProcessPlacementParam,
   serializeCraftParamValue,
   toCraftParamFormValue,
-} from './paramOptions';
+} from '@/views/dashboard/craft_atom/paramOptions';
 
 describe('craft atom param options', () => {
   it('treats ai-content-process extra-payload like ai-filter extra-payload', () => {


### PR DESCRIPTION
Converted all relative imports in `web/admin/src` to use the `@/` alias. This change affects both TypeScript and Vue files, ensuring a consistent import style across the frontend codebase. Reverted accidental changes to `package-lock.json` and ensured no temporary scripts were committed.

---
*PR created automatically by Jules for task [12301023542661714015](https://jules.google.com/task/12301023542661714015) started by @Colin-XKL*

## Summary by Sourcery

Standardize import paths in web/admin to use the @/ alias instead of relative paths.

Enhancements:
- Update auth-expired tests to import via the @/ API alias.
- Update craft atom Vue component and paramOptions tests to use @/ view aliases for shared modules.