### PR TITLE
feat: optimistic caching for topic sub-feeds with per-URI health tracking

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -137,6 +137,19 @@ The system includes numerous built-in craft templates in `internal/craft/entry.g
 - Use `go test ./...` to run all tests
 - The frontend project currently does not have test scripts configured. If tests are added, they would be located in `web/admin/`.
 
+## Utility Guidelines
+
+### Hash Functions
+
+Use the existing helpers in `internal/util/hash.go` — do not import `crypto/md5`, `crypto/sha256`, or `hash/fnv` directly.
+
+| Function | Algorithm | Use case |
+|---|---|---|
+| `util.GetTextContentHash(text)` | FNV-64a | General-purpose cache keys, content fingerprinting (efficiency-focused) |
+| `util.GetPasswordMD5Hash(text)` | MD5 | Password hashing flows only (security-semantic alias) |
+
+`GetMD5Hash` is intentionally unexported. New code should use `GetTextContentHash` for cache key derivation and similar non-security purposes.
+
 ## Common Development Tasks
 
 ### Adding New Craft Template

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -148,8 +148,6 @@ Use the existing helpers in `internal/util/hash.go` — do not import `crypto/md
 | `util.GetTextContentHash(text)` | FNV-64a | General-purpose cache keys, content fingerprinting (efficiency-focused) |
 | `util.GetPasswordMD5Hash(text)` | MD5 | Password hashing flows only (security-semantic alias) |
 
-`GetMD5Hash` is intentionally unexported. New code should use `GetTextContentHash` for cache key derivation and similar non-security purposes.
-
 ## Common Development Tasks
 
 ### Adding New Craft Template

--- a/internal/adapter/embedding.go
+++ b/internal/adapter/embedding.go
@@ -121,8 +121,8 @@ func buildAnchorVectorCacheKey(anchor string, cfg embeddingConfig, effectiveInst
 		cfg.apiType,
 		cfg.apiBase,
 		cfg.apiModel,
-		util.GetMD5Hash(effectiveInstruction),
-		util.GetMD5Hash(anchor),
+		util.GetTextContentHash(effectiveInstruction),
+		util.GetTextContentHash(anchor),
 	)
 }
 

--- a/internal/constant/cache_namespace.go
+++ b/internal/constant/cache_namespace.go
@@ -3,3 +3,9 @@ package constant
 const PrefixWebContent = "web_content"
 const PrefixSearchSource = "search_source"
 const KeySearchProviderConfig = "sys:config:search_provider"
+
+// PrefixSubFeedResult is the cache key prefix for sub-feed result snapshots.
+const PrefixSubFeedResult = "sub_feed_result"
+
+// PrefixSubFeedHealth is the cache key prefix for sub-feed health metadata.
+const PrefixSubFeedHealth = "sub_feed_health"

--- a/internal/constant/ttl.go
+++ b/internal/constant/ttl.go
@@ -5,3 +5,10 @@ import "time"
 const FEED_EXPIRE = 3 * time.Minute
 const WebContentExpire = 7 * 24 * time.Hour
 const SearchCacheExpire = 10 * time.Minute
+
+// SubFeedCacheTTL is the TTL for cached sub-feed results under topic aggregation.
+// When a sub-feed fails to fetch, the cached result is used as a fallback for up to this duration.
+const SubFeedCacheTTL = 14 * 24 * time.Hour
+
+// SubFeedHealthTTL is the TTL for per-URI health metadata stored in Redis.
+const SubFeedHealthTTL = 30 * 24 * time.Hour

--- a/internal/controller/topic_feed.go
+++ b/internal/controller/topic_feed.go
@@ -1,20 +1,22 @@
 package controller
 
 import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
 	"FeedCraft/internal/dao"
 	"FeedCraft/internal/feedruntime"
 	"FeedCraft/internal/model"
 	"FeedCraft/internal/observability"
 	"FeedCraft/internal/util"
-	"context"
-	"encoding/json"
-	"errors"
-	"fmt"
+
 	"github.com/gin-gonic/gin"
 	"gorm.io/gorm"
-	"net/http"
-	"strings"
-	"time"
 )
 
 const topicDetailLogLimit = 20
@@ -38,6 +40,8 @@ type TopicDetailResponse struct {
 	Health               ResourceHealthView        `json:"health"`
 	RecentExecutions     []TopicExecutionLogView   `json:"recent_executions"`
 	RelatedNotifications []*dao.SystemNotification `json:"related_notifications"`
+	// SubFeedHealth provides per-input-URI health metadata powered by optimistic caching.
+	SubFeedHealth []feedruntime.SubFeedHealth `json:"sub_feed_health"`
 }
 
 type TopicExecutionLogView struct {
@@ -207,12 +211,18 @@ func GetTopicFeedDetail(c *gin.Context) {
 		return
 	}
 
+	subFeedHealth := make([]feedruntime.SubFeedHealth, 0, len(topicData.InputURIs))
+	for _, uri := range topicData.InputURIs {
+		subFeedHealth = append(subFeedHealth, feedruntime.GetSubFeedHealth(uri))
+	}
+
 	detail := TopicDetailResponse{
 		Topic:                *topicData,
 		PublicURL:            "/topic/" + topicData.ID,
 		Health:               mergeResourceHealth(dao.ResourceTypeTopic, topicData.ID, topicData.Title, health),
 		RecentExecutions:     buildTopicExecutionViews(executions),
 		RelatedNotifications: notifications,
+		SubFeedHealth:        subFeedHealth,
 	}
 
 	c.JSON(http.StatusOK, util.APIResponse[any]{Data: detail})

--- a/internal/feedruntime/builder.go
+++ b/internal/feedruntime/builder.go
@@ -162,7 +162,9 @@ func (b *Builder) BuildTopic(ctx context.Context, topic *dao.TopicFeed, stack []
 		if buildErr != nil {
 			return nil, fmt.Errorf("build topic input %q: %w", inputURI, buildErr)
 		}
-		inputs = append(inputs, provider)
+		// Wrap every input with optimistic caching so that a failing sub-feed
+		// falls back to its last known good snapshot (up to SubFeedCacheTTL).
+		inputs = append(inputs, &CachedFeedProvider{URI: inputURI, Inner: provider})
 	}
 
 	aggregator, err := buildAggregator(topic.AggregatorConfig)

--- a/internal/feedruntime/builder_test.go
+++ b/internal/feedruntime/builder_test.go
@@ -384,7 +384,10 @@ func TestBuildTopicProvider_NestedTopics(t *testing.T) {
 	require.True(t, ok)
 	assert.Equal(t, "parent", topicProvider.ID)
 	assert.Len(t, topicProvider.Inputs, 1)
-	_, ok = topicProvider.Inputs[0].(*engine.TopicFeed)
+	// Each input is wrapped in a CachedFeedProvider; the inner provider is a nested TopicFeed.
+	cached, ok := topicProvider.Inputs[0].(*CachedFeedProvider)
+	require.True(t, ok)
+	_, ok = cached.Inner.(*engine.TopicFeed)
 	assert.True(t, ok)
 	require.NotNil(t, topicProvider.Aggregator)
 

--- a/internal/feedruntime/cached_provider.go
+++ b/internal/feedruntime/cached_provider.go
@@ -2,7 +2,6 @@ package feedruntime
 
 import (
 	"context"
-	"crypto/sha256"
 	"encoding/json"
 	"fmt"
 	"time"
@@ -140,11 +139,9 @@ func GetSubFeedHealth(uri string) SubFeedHealth {
 }
 
 func subFeedResultKey(uri string) string {
-	h := sha256.Sum256([]byte(uri))
-	return fmt.Sprintf("%s:%x", constant.PrefixSubFeedResult, h)
+	return fmt.Sprintf("%s:%s", constant.PrefixSubFeedResult, util.GetMD5Hash(uri))
 }
 
 func subFeedHealthKey(uri string) string {
-	h := sha256.Sum256([]byte(uri))
-	return fmt.Sprintf("%s:%x", constant.PrefixSubFeedHealth, h)
+	return fmt.Sprintf("%s:%s", constant.PrefixSubFeedHealth, util.GetMD5Hash(uri))
 }

--- a/internal/feedruntime/cached_provider.go
+++ b/internal/feedruntime/cached_provider.go
@@ -139,9 +139,9 @@ func GetSubFeedHealth(uri string) SubFeedHealth {
 }
 
 func subFeedResultKey(uri string) string {
-	return fmt.Sprintf("%s:%s", constant.PrefixSubFeedResult, util.GetMD5Hash(uri))
+	return fmt.Sprintf("%s:%s", constant.PrefixSubFeedResult, util.GetTextContentHash(uri))
 }
 
 func subFeedHealthKey(uri string) string {
-	return fmt.Sprintf("%s:%s", constant.PrefixSubFeedHealth, util.GetMD5Hash(uri))
+	return fmt.Sprintf("%s:%s", constant.PrefixSubFeedHealth, util.GetTextContentHash(uri))
 }

--- a/internal/feedruntime/cached_provider.go
+++ b/internal/feedruntime/cached_provider.go
@@ -1,0 +1,150 @@
+package feedruntime
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"FeedCraft/internal/constant"
+	"FeedCraft/internal/engine"
+	"FeedCraft/internal/model"
+	"FeedCraft/internal/util"
+
+	"github.com/sirupsen/logrus"
+)
+
+// SubFeedHealth records health metadata for a single topic sub-feed URI, persisted in Redis.
+type SubFeedHealth struct {
+	URI           string     `json:"uri"`
+	LastSuccessAt *time.Time `json:"last_success_at"`
+	LastFailureAt *time.Time `json:"last_failure_at"`
+	LastError     string     `json:"last_error"`
+	// CachedAt is when the last successful result was written to the cache.
+	CachedAt *time.Time `json:"cached_at"`
+}
+
+// CachedFeedProvider wraps any FeedProvider with optimistic caching for topic aggregation.
+// On a successful fetch the result is stored in Redis (SubFeedCacheTTL = 14 days).
+// On failure the last cached result is returned instead so the parent TopicFeed stays
+// available, and the failure is recorded in the health metadata.
+type CachedFeedProvider struct {
+	// URI is used as the stable identifier for cache key derivation and health tracking.
+	URI   string
+	Inner engine.FeedProvider
+}
+
+// Fetch implements engine.FeedProvider.
+func (p *CachedFeedProvider) Fetch(ctx context.Context) (*model.CraftFeed, error) {
+	feed, err := p.Inner.Fetch(ctx)
+	if err == nil {
+		p.cacheResult(feed)
+		p.recordSuccess()
+		return feed, nil
+	}
+
+	// Live fetch failed — try the cached snapshot.
+	cached := p.loadCachedResult()
+	p.recordFailure(err)
+	if cached != nil {
+		logrus.Infof("CachedFeedProvider [%s]: live fetch failed (%v), returning cached snapshot", p.URI, err)
+		return cached, nil
+	}
+
+	// No cache available; propagate the original error.
+	return nil, err
+}
+
+// cacheResult writes feed to Redis with SubFeedCacheTTL.
+func (p *CachedFeedProvider) cacheResult(feed *model.CraftFeed) {
+	data, err := json.Marshal(feed)
+	if err != nil {
+		logrus.Warnf("CachedFeedProvider [%s]: marshal failed: %v", p.URI, err)
+		return
+	}
+	if err := util.TryCacheSetString(subFeedResultKey(p.URI), string(data), constant.SubFeedCacheTTL); err != nil {
+		logrus.Warnf("CachedFeedProvider [%s]: cache write failed: %v", p.URI, err)
+	}
+}
+
+// loadCachedResult reads the most recent cached feed from Redis.
+func (p *CachedFeedProvider) loadCachedResult() *model.CraftFeed {
+	raw, err := util.TryCacheGetString(subFeedResultKey(p.URI))
+	if err != nil || raw == "" {
+		return nil
+	}
+	var feed model.CraftFeed
+	if err := json.Unmarshal([]byte(raw), &feed); err != nil {
+		logrus.Warnf("CachedFeedProvider [%s]: unmarshal cached feed failed: %v", p.URI, err)
+		return nil
+	}
+	return &feed
+}
+
+// recordSuccess updates the health metadata after a live successful fetch.
+func (p *CachedFeedProvider) recordSuccess() {
+	now := time.Now()
+	h := p.loadHealth()
+	h.URI = p.URI
+	h.LastSuccessAt = &now
+	h.CachedAt = &now
+	h.LastError = ""
+	p.saveHealth(h)
+}
+
+// recordFailure updates the health metadata after a fetch error.
+func (p *CachedFeedProvider) recordFailure(err error) {
+	now := time.Now()
+	h := p.loadHealth()
+	h.URI = p.URI
+	h.LastFailureAt = &now
+	h.LastError = err.Error()
+	p.saveHealth(h)
+}
+
+func (p *CachedFeedProvider) loadHealth() SubFeedHealth {
+	raw, err := util.TryCacheGetString(subFeedHealthKey(p.URI))
+	if err != nil || raw == "" {
+		return SubFeedHealth{URI: p.URI}
+	}
+	var h SubFeedHealth
+	if err := json.Unmarshal([]byte(raw), &h); err != nil {
+		return SubFeedHealth{URI: p.URI}
+	}
+	return h
+}
+
+func (p *CachedFeedProvider) saveHealth(h SubFeedHealth) {
+	data, err := json.Marshal(h)
+	if err != nil {
+		return
+	}
+	if err := util.TryCacheSetString(subFeedHealthKey(p.URI), string(data), constant.SubFeedHealthTTL); err != nil {
+		logrus.Warnf("CachedFeedProvider [%s]: health write failed: %v", p.URI, err)
+	}
+}
+
+// GetSubFeedHealth returns the stored health metadata for a given sub-feed URI.
+// Returns an empty SubFeedHealth (URI only) if no data has been recorded yet.
+func GetSubFeedHealth(uri string) SubFeedHealth {
+	raw, err := util.TryCacheGetString(subFeedHealthKey(uri))
+	if err != nil || raw == "" {
+		return SubFeedHealth{URI: uri}
+	}
+	var h SubFeedHealth
+	if err := json.Unmarshal([]byte(raw), &h); err != nil {
+		return SubFeedHealth{URI: uri}
+	}
+	return h
+}
+
+func subFeedResultKey(uri string) string {
+	h := sha256.Sum256([]byte(uri))
+	return fmt.Sprintf("%s:%x", constant.PrefixSubFeedResult, h)
+}
+
+func subFeedHealthKey(uri string) string {
+	h := sha256.Sum256([]byte(uri))
+	return fmt.Sprintf("%s:%x", constant.PrefixSubFeedHealth, h)
+}

--- a/internal/util/cache.go
+++ b/internal/util/cache.go
@@ -3,6 +3,9 @@ package util
 import (
 	"FeedCraft/internal/constant"
 	"context"
+	"errors"
+	"strings"
+
 	"github.com/redis/go-redis/v9"
 	"github.com/sirupsen/logrus"
 	"log"
@@ -27,6 +30,48 @@ func GetRedisClient() *redis.Client {
 		log.Fatalf("create redis client error.")
 	}
 	return rdb
+}
+
+// tryGetRedisClient returns a Redis client or an error without fatally crashing.
+// It is safe to call in environments where Redis may not be configured (e.g. tests).
+func tryGetRedisClient() (*redis.Client, error) {
+	envClient := GetEnvClient()
+	if envClient == nil {
+		return nil, errors.New("env client not available")
+	}
+	redisURI := strings.TrimSpace(envClient.GetString("REDIS_URI"))
+	if redisURI == "" {
+		return nil, errors.New("REDIS_URI is not configured")
+	}
+	opts, err := redis.ParseURL(redisURI)
+	if err != nil {
+		return nil, err
+	}
+	rdb := redis.NewClient(opts)
+	if rdb == nil {
+		return nil, errors.New("failed to create redis client")
+	}
+	return rdb, nil
+}
+
+// TryCacheSetString is like CacheSetString but returns an error instead of crashing
+// when Redis is not configured. Safe to call in environments without Redis.
+func TryCacheSetString(key string, value string, ttl time.Duration) error {
+	rdb, err := tryGetRedisClient()
+	if err != nil {
+		return err
+	}
+	return rdb.Set(context.Background(), key, value, ttl).Err()
+}
+
+// TryCacheGetString is like CacheGetString but returns an error instead of crashing
+// when Redis is not configured. Safe to call in environments without Redis.
+func TryCacheGetString(key string) (string, error) {
+	rdb, err := tryGetRedisClient()
+	if err != nil {
+		return "", err
+	}
+	return rdb.Get(context.Background(), key).Result()
 }
 
 func CacheSetString(key string, value string, ttl time.Duration) error {

--- a/internal/util/hash.go
+++ b/internal/util/hash.go
@@ -12,12 +12,13 @@ func GetTextContentHash(text string) string {
 	return hex.EncodeToString(h.Sum(nil))
 }
 
-func GetMD5Hash(text string) string {
+func getMD5Hash(text string) string {
 	h := md5.New()
 	_, _ = h.Write([]byte(text))
 	return hex.EncodeToString(h.Sum(nil))
 }
 
+// GetPasswordMD5Hash returns the MD5 hex digest of text, intended for password hashing flows.
 func GetPasswordMD5Hash(text string) string {
-	return GetMD5Hash(text)
+	return getMD5Hash(text)
 }

--- a/internal/util/hash_test.go
+++ b/internal/util/hash_test.go
@@ -2,10 +2,10 @@ package util
 
 import "testing"
 
-func TestGetMD5HashReturnsHexEncodedMD5(t *testing.T) {
-	got := GetMD5Hash("FeedCraft")
+func TestGetPasswordMD5HashReturnsHexEncodedMD5(t *testing.T) {
+	got := GetPasswordMD5Hash("FeedCraft")
 	const want = "01ec1a92ca7590baf10433c270707cd5"
 	if got != want {
-		t.Fatalf("GetMD5Hash() = %q, want %q", got, want)
+		t.Fatalf("GetPasswordMD5Hash() = %q, want %q", got, want)
 	}
 }

--- a/web/admin/src/api/topic.ts
+++ b/web/admin/src/api/topic.ts
@@ -30,12 +30,21 @@ export interface TopicValidationResult {
   warnings: TopicValidationIssue[];
 }
 
+export interface SubFeedHealth {
+  uri: string;
+  last_success_at?: string;
+  last_failure_at?: string;
+  last_error?: string;
+  cached_at?: string;
+}
+
 export interface TopicDetail {
   topic: TopicFeed;
   public_url: string;
   health: ObservableResource;
   recent_executions: ExecutionLog[];
   related_notifications: SystemNotification[];
+  sub_feed_health: SubFeedHealth[];
 }
 
 const adminApiBase = '/api/admin';

--- a/web/admin/src/locale/en-US/topic.ts
+++ b/web/admin/src/locale/en-US/topic.ts
@@ -101,4 +101,18 @@ export default {
   'topic.detail.executionDetails': 'Execution Details',
   'topic.detail.noExecutionDetails': 'No structured execution details',
   'topic.validation.field.runtime': 'Runtime Build',
+  'topic.detail.subFeedHealth': 'Sub-Feed Cache Health',
+  'topic.detail.subFeedHealth.uri': 'Input Source',
+  'topic.detail.subFeedHealth.lastSuccess': 'Last Success',
+  'topic.detail.subFeedHealth.lastFailure': 'Last Failure',
+  'topic.detail.subFeedHealth.lastError': 'Last Error',
+  'topic.detail.subFeedHealth.cachedAt': 'Cache Written',
+  'topic.detail.subFeedHealth.status': 'Status',
+  'topic.detail.subFeedHealth.status.ok': 'OK',
+  'topic.detail.subFeedHealth.status.stale': 'Using Cache',
+  'topic.detail.subFeedHealth.status.unknown': 'Unknown',
+  'topic.detail.subFeedHealth.noData':
+    'No sub-feed data yet (topic has not been accessed).',
+  'topic.detail.subFeedHealth.hint':
+    'When a sub-feed fails to fetch, the last cached snapshot is used (up to 14 days). This section shows the recent health of each input source.',
 };

--- a/web/admin/src/locale/zh-CN/topic.ts
+++ b/web/admin/src/locale/zh-CN/topic.ts
@@ -98,4 +98,17 @@ export default {
   'topic.detail.executionDetails': '执行详情',
   'topic.detail.noExecutionDetails': '没有可展示的结构化详情',
   'topic.validation.field.runtime': '运行时构建',
+  'topic.detail.subFeedHealth': '子源缓存状态',
+  'topic.detail.subFeedHealth.uri': '输入源',
+  'topic.detail.subFeedHealth.lastSuccess': '最近成功',
+  'topic.detail.subFeedHealth.lastFailure': '最近失败',
+  'topic.detail.subFeedHealth.lastError': '最近错误',
+  'topic.detail.subFeedHealth.cachedAt': '缓存时间',
+  'topic.detail.subFeedHealth.status': '状态',
+  'topic.detail.subFeedHealth.status.ok': '正常',
+  'topic.detail.subFeedHealth.status.stale': '使用缓存',
+  'topic.detail.subFeedHealth.status.unknown': '未知',
+  'topic.detail.subFeedHealth.noData': '暂无子源状态数据（尚未被访问过）',
+  'topic.detail.subFeedHealth.hint':
+    '子源拉取失败时会自动回退到最近缓存（最长 14 天）。此处显示每个子源的最近健康情况。',
 };

--- a/web/admin/src/locale/zh-CN/topic.ts
+++ b/web/admin/src/locale/zh-CN/topic.ts
@@ -98,7 +98,7 @@ export default {
   'topic.detail.executionDetails': '执行详情',
   'topic.detail.noExecutionDetails': '没有可展示的结构化详情',
   'topic.validation.field.runtime': '运行时构建',
-  'topic.detail.subFeedHealth': '子源缓存状态',
+  'topic.detail.subFeedHealth': '子 RSS 源缓存状态',
   'topic.detail.subFeedHealth.uri': '输入源',
   'topic.detail.subFeedHealth.lastSuccess': '最近成功',
   'topic.detail.subFeedHealth.lastFailure': '最近失败',
@@ -108,7 +108,7 @@ export default {
   'topic.detail.subFeedHealth.status.ok': '正常',
   'topic.detail.subFeedHealth.status.stale': '使用缓存',
   'topic.detail.subFeedHealth.status.unknown': '未知',
-  'topic.detail.subFeedHealth.noData': '暂无子源状态数据（尚未被访问过）',
+  'topic.detail.subFeedHealth.noData': '暂无子 RSS 源状态数据（尚未被访问过）',
   'topic.detail.subFeedHealth.hint':
-    '子源拉取失败时会自动回退到最近缓存（最长 14 天）。此处显示每个子源的最近健康情况。',
+    '子 RSS 源拉取失败时会自动回退到最近缓存（最长 14 天）。此处显示每个子 RSS 源的最近健康情况。',
 };

--- a/web/admin/src/views/dashboard/topic_feed/detail.vue
+++ b/web/admin/src/views/dashboard/topic_feed/detail.vue
@@ -106,6 +106,91 @@
           </a-row>
         </a-card>
 
+        <!-- Sub-Feed Health Card -->
+        <a-card
+          v-if="detail"
+          class="general-card"
+          :title="t('topic.detail.subFeedHealth')"
+        >
+          <a-alert
+            type="info"
+            :title="t('topic.detail.subFeedHealth.hint')"
+            style="margin-bottom: 16px"
+          />
+          <a-empty
+            v-if="
+              !detail.sub_feed_health || detail.sub_feed_health.length === 0
+            "
+            :description="t('topic.detail.subFeedHealth.noData')"
+          />
+          <a-table
+            v-else
+            :data="detail.sub_feed_health"
+            :pagination="false"
+            row-key="uri"
+          >
+            <template #columns>
+              <a-table-column
+                :title="t('topic.detail.subFeedHealth.status')"
+                :width="110"
+              >
+                <template #cell="{ record }">
+                  <a-tag :color="subFeedStatusColor(record)">
+                    {{ subFeedStatusLabel(record) }}
+                  </a-tag>
+                </template>
+              </a-table-column>
+              <a-table-column
+                :title="t('topic.detail.subFeedHealth.uri')"
+                :ellipsis="true"
+              >
+                <template #cell="{ record }">
+                  <span class="sub-feed-uri" :title="record.uri">{{
+                    record.uri
+                  }}</span>
+                </template>
+              </a-table-column>
+              <a-table-column
+                :title="t('topic.detail.subFeedHealth.lastSuccess')"
+                :width="160"
+              >
+                <template #cell="{ record }">
+                  {{ formatTime(record.last_success_at) }}
+                </template>
+              </a-table-column>
+              <a-table-column
+                :title="t('topic.detail.subFeedHealth.lastFailure')"
+                :width="160"
+              >
+                <template #cell="{ record }">
+                  {{ formatTime(record.last_failure_at) }}
+                </template>
+              </a-table-column>
+              <a-table-column
+                :title="t('topic.detail.subFeedHealth.lastError')"
+                :ellipsis="true"
+              >
+                <template #cell="{ record }">
+                  <span
+                    :class="{ 'error-text': record.last_error }"
+                    :title="record.last_error"
+                  >
+                    {{ record.last_error || '-' }}
+                  </span>
+                </template>
+              </a-table-column>
+              <a-table-column
+                :title="t('topic.detail.subFeedHealth.cachedAt')"
+                :width="160"
+              >
+                <template #cell="{ record }">
+                  {{ formatTime(record.cached_at) }}
+                </template>
+              </a-table-column>
+            </template>
+          </a-table>
+        </a-card>
+
         <a-card
           v-if="detail"
           class="general-card"
@@ -216,7 +301,12 @@
     formatObservabilityTrigger,
   } from '@/utils/observability';
   import buildPublicFeedUrl from '@/utils/publicFeedUrl';
-  import { AggregatorStep, TopicDetail, getTopicFeedDetail } from '@/api/topic';
+  import {
+    AggregatorStep,
+    SubFeedHealth,
+    TopicDetail,
+    getTopicFeedDetail,
+  } from '@/api/topic';
 
   const { t } = useI18n();
   const route = useRoute();
@@ -276,6 +366,33 @@
       return `${t('topic.stepType.limit')} · ${step.option?.max || '-'}`;
     }
     return step.type;
+  };
+
+  // Returns a colour for the sub-feed status tag.
+  // "stale" (using cache) = orange; "ok" (last_failure is absent or last_success is more recent) = green; unknown = gray.
+  const subFeedStatusColor = (record: SubFeedHealth) => {
+    if (!record.last_success_at && !record.last_failure_at) return 'gray';
+    if (record.last_failure_at && !record.last_success_at) return 'red';
+    if (record.last_failure_at && record.last_success_at) {
+      const failedAt = new Date(record.last_failure_at).getTime();
+      const succeededAt = new Date(record.last_success_at).getTime();
+      if (failedAt > succeededAt) return 'orange';
+    }
+    return 'green';
+  };
+
+  const subFeedStatusLabel = (record: SubFeedHealth) => {
+    if (!record.last_success_at && !record.last_failure_at)
+      return t('topic.detail.subFeedHealth.status.unknown');
+    if (record.last_failure_at && !record.last_success_at)
+      return t('topic.detail.subFeedHealth.status.stale');
+    if (record.last_failure_at && record.last_success_at) {
+      const failedAt = new Date(record.last_failure_at).getTime();
+      const succeededAt = new Date(record.last_success_at).getTime();
+      if (failedAt > succeededAt)
+        return t('topic.detail.subFeedHealth.status.stale');
+    }
+    return t('topic.detail.subFeedHealth.status.ok');
   };
 
   const copyPublicUrl = async () => {
@@ -357,5 +474,16 @@
     background: var(--color-fill-2);
     white-space: pre-wrap;
     word-break: break-word;
+  }
+
+  .sub-feed-uri {
+    font-family: monospace;
+    font-size: 12px;
+    word-break: break-all;
+  }
+
+  .error-text {
+    color: var(--color-danger-6, #f53f3f);
+    font-size: 12px;
   }
 </style>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Overview

When a sub-feed inside a TopicFeed fails to fetch, the topic feed now automatically falls back to the last cached result (stored in Redis for up to 14 days), keeping the aggregated feed available even during partial upstream failures.

A new "Sub-Feed Cache Health" section in the admin topic detail page gives operators visibility into per-URI success/failure history, last successful update time, and recent error messages.

## Changes

### Backend
- **`internal/constant/ttl.go`**: Add `SubFeedCacheTTL` (14 days) and `SubFeedHealthTTL` (30 days)
- **`internal/constant/cache_namespace.go`**: Add `PrefixSubFeedResult` and `PrefixSubFeedHealth` Redis key prefixes
- **`internal/feedruntime/cached_provider.go`** _(new)_: `CachedFeedProvider` wraps any `FeedProvider`; on successful fetch caches the `CraftFeed` in Redis; on failure returns the last cached snapshot. Health metadata (`last_success_at`, `last_failure_at`, `last_error`, `cached_at`) is stored per URI in Redis.
- **`internal/feedruntime/builder.go`**: Wrap every topic input with `CachedFeedProvider` during `BuildTopic`
- **`internal/util/cache.go`**: Add `TryCacheSetString` / `TryCacheGetString` — safe variants that return errors instead of calling `log.Fatalf` when Redis is unconfigured (required for test environments)
- **`internal/controller/topic_feed.go`**: Add `sub_feed_health []SubFeedHealth` to `TopicDetailResponse`; populated from Redis via `feedruntime.GetSubFeedHealth`

### Frontend
- **`web/admin/src/api/topic.ts`**: Add `SubFeedHealth` type; extend `TopicDetail`
- **`web/admin/src/views/dashboard/topic_feed/detail.vue`**: New "Sub-Feed Cache Health" card in the topic detail page — shows per-URI status (green/orange/red), last success time, last failure time, last error text, and cache timestamp
- **`web/admin/src/locale/zh-CN/topic.ts`** & **`en-US/topic.ts`**: i18n keys for the new section

### Tests
- **`internal/feedruntime/builder_test.go`**: Update `TestBuildTopicProvider_NestedTopics` to unwrap `CachedFeedProvider` before asserting inner type

## Demo

[topic_subfeed_health_demo.mp4](https://cursor.com/agents/bc-c654fc93-af83-4b34-97dc-0a54865f9d65/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftopic_subfeed_health_demo.mp4)

**Topic detail page — sub-feed health with one OK feed and one failing feed:**
[Topic detail sub-feed health section](https://cursor.com/agents/bc-c654fc93-af83-4b34-97dc-0a54865f9d65/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftopic_detail_subfeed_health.webp)

**Topic with fully-failing feed served from cache:**
[Topic cache fallback detail](https://cursor.com/agents/bc-c654fc93-af83-4b34-97dc-0a54865f9d65/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftopic_cache_fallback_detail.webp)

## Behavior Notes

- **Optimistic strategy**: The `CachedFeedProvider` is transparent — if live fetch fails but cache exists, the parent `TopicFeed` sees a successful result (no error propagation). The degraded state is visible only via the per-URI health section in admin.
- **Cache TTL**: 14 days for feed content, 30 days for health metadata.
- **No DB changes**: All health data lives in Redis. Naturally expires; no migration required.
- **Test safety**: `TryCacheSetString` / `TryCacheGetString` never crash in environments without Redis — existing controller tests continue to pass.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c654fc93-af83-4b34-97dc-0a54865f9d65"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c654fc93-af83-4b34-97dc-0a54865f9d65"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

## Summary by Sourcery

Add optimistic caching and per-URI health tracking for topic sub-feeds and expose this metadata in the admin topic detail view.

New Features:
- Introduce a CachedFeedProvider that wraps topic sub-feeds with Redis-backed optimistic caching and per-URI health metadata.
- Expose sub-feed health data on the admin topic detail page, including status, last success/failure times, last error, and cache timestamp.

Enhancements:
- Add Redis TTL constants and cache key namespaces for sub-feed results and health metadata.
- Extend the topic detail API and frontend types to include sub-feed health information.
- Introduce non-fatal Redis cache helpers that are safe to use in environments without Redis and update topic builder tests to account for the new caching wrapper.

Tests:
- Adjust topic feed builder tests to unwrap the CachedFeedProvider when asserting nested topic inputs.