### PR TITLE
fix(util): 修复 Markdown/HTML 转换中的段落换行丢失

### DIFF
--- a/internal/craft/ai_content_process.go
+++ b/internal/craft/ai_content_process.go
@@ -135,7 +135,7 @@ func parseAIContentProcessPlacement(raw string) aiContentProcessPlacement {
 }
 
 func applyAIContentProcessPlacement(originalHTML string, generatedMarkdown string, placement aiContentProcessPlacement) string {
-	generatedHTML := util.Markdown2HTML(generatedMarkdown)
+	generatedHTML := util.MarkdownToHTML(generatedMarkdown)
 	switch placement {
 	case aiContentProcessPlacementReplace:
 		return generatedHTML

--- a/internal/craft/ai_filter.go
+++ b/internal/craft/ai_filter.go
@@ -248,7 +248,7 @@ func generateAIFilterArticleSummary(item *feeds.Item) (string, error) {
 		if item.Link != nil {
 			domain, _ = util.ParseDomainFromUrl(item.Link.Href)
 		}
-		cleanedContent := util.Html2Markdown(content, &domain)
+		cleanedContent := util.HTMLToMarkdown(content, domain)
 		if strings.TrimSpace(cleanedContent) != "" {
 			processedContent = cleanedContent
 		}

--- a/internal/craft/beautify.go
+++ b/internal/craft/beautify.go
@@ -2,12 +2,10 @@ package craft
 
 import (
 	"FeedCraft/internal/adapter"
+	"FeedCraft/internal/util"
 	"fmt"
 	"strings"
 
-	"github.com/gomarkdown/markdown"
-	"github.com/gomarkdown/markdown/html"
-	"github.com/gomarkdown/markdown/parser"
 	"github.com/gorilla/feeds"
 )
 
@@ -41,18 +39,7 @@ func beautifyArticleContent(content string, prompt string) (string, error) {
 		return "", err
 	}
 
-	// 3. Convert Beautified Markdown back to HTML
-	extensions := parser.CommonExtensions | parser.AutoHeadingIDs | parser.NoEmptyLineBeforeBlock
-	p := parser.NewWithExtensions(extensions)
-	doc := p.Parse([]byte(beautifiedMd))
-
-	htmlFlags := html.CommonFlags | html.HrefTargetBlank
-	opts := html.RendererOptions{Flags: htmlFlags}
-	renderer := html.NewRenderer(opts)
-
-	beautifiedHtml := markdown.Render(doc, renderer)
-
-	return string(beautifiedHtml), nil
+	return util.Markdown2HTML(beautifiedMd), nil
 }
 
 // GetBeautifyContentCraftOptions returns the craft options for beautification

--- a/internal/craft/beautify.go
+++ b/internal/craft/beautify.go
@@ -39,7 +39,7 @@ func beautifyArticleContent(content string, prompt string) (string, error) {
 		return "", err
 	}
 
-	return util.Markdown2HTML(beautifiedMd), nil
+	return util.MarkdownToHTML(beautifiedMd), nil
 }
 
 // GetBeautifyContentCraftOptions returns the craft options for beautification

--- a/internal/craft/cleanup.go
+++ b/internal/craft/cleanup.go
@@ -7,10 +7,9 @@ import (
 
 func CleanupContent(htmlContent string, domain string) (string, error) {
 	// First convert HTML to Markdown to strip unnecessary elements
-	markdown := util.Html2Markdown(htmlContent, &domain)
+	markdown := util.HTMLToMarkdown(htmlContent, domain)
 
-	// Then convert back to HTML for clean, semantic markup
-	cleanHtml := util.Markdown2HTML(markdown)
+	cleanHtml := util.MarkdownToHTML(markdown)
 	return cleanHtml, nil
 }
 

--- a/internal/craft/introduction.go
+++ b/internal/craft/introduction.go
@@ -29,7 +29,7 @@ func (p *LLMTextProcessor) Process(original string) (string, error) {
 	return adapter.CallLLMUsingContext(p.prompt, original, util.ContentProcessOption{})
 }
 func (p *LLMTextProcessor) Combine(original, processed string) string {
-	processedHTML := util.Markdown2HTML(processed)
+	processedHTML := util.MarkdownToHTML(processed)
 	return fmt.Sprintf(`<div><div>%s</div><hr/><br/><div>%s</div></div>`, processedHTML, original)
 }
 func (p *LLMTextProcessor) GetName() string {
@@ -49,7 +49,7 @@ func processItemContent(item *feeds.Item, processor TextProcessor) string {
 	}
 
 	domain, _ := util.ParseDomainFromUrl(item.Link.Href)
-	cleanedContent := util.Html2Markdown(originalContent, &domain)
+	cleanedContent := util.HTMLToMarkdown(originalContent, domain)
 
 	var processedContent string
 	var err error

--- a/internal/craft/llm_processors.go
+++ b/internal/craft/llm_processors.go
@@ -374,7 +374,7 @@ func getPrimaryArticleContent(article *model.CraftArticle) string {
 
 func getArticleContentForPrompt(article *model.CraftArticle, original string) string {
 	domain, _ := util.ParseDomainFromUrl(article.Link)
-	cleaned := util.Html2Markdown(original, &domain)
+	cleaned := util.HTMLToMarkdown(original, domain)
 	if strings.TrimSpace(cleaned) != "" {
 		return cleaned
 	}
@@ -382,7 +382,7 @@ func getArticleContentForPrompt(article *model.CraftArticle, original string) st
 }
 
 func combineArticleHTMLWithGeneratedMarkdown(originalHTML string, generatedMarkdown string) string {
-	processedHTML := util.Markdown2HTML(generatedMarkdown)
+	processedHTML := util.MarkdownToHTML(generatedMarkdown)
 	return combineArticleHTMLFragments(processedHTML, originalHTML)
 }
 

--- a/internal/util/content_processor.go
+++ b/internal/util/content_processor.go
@@ -2,9 +2,6 @@ package util
 
 import (
 	"regexp"
-
-	htmltomarkdown "github.com/JohannesKaufmann/html-to-markdown/v2"
-	"github.com/sirupsen/logrus"
 )
 
 var (
@@ -34,13 +31,10 @@ func ProcessContent(content string, option ContentProcessOption) string {
 		content = imgRegex.ReplaceAllString(content, "")
 	}
 	if option.ConvertToMd {
-		markdown, err := htmltomarkdown.ConvertString(content)
-		if err != nil {
-			logrus.Errorf("Error converting HTML to Markdown: %v", err)
-			// fallback to original content
-			return content
+		if md := HTMLToMarkdown(content, ""); md != "" {
+			return md
 		}
-		return markdown
+		return content
 	}
 	return content
 }

--- a/internal/util/markdown_convert.go
+++ b/internal/util/markdown_convert.go
@@ -17,16 +17,16 @@ import (
 var (
 	paragraphTagRE = regexp.MustCompile(`(?is)<p(\s[^>]*)?>(.*?)</p>`)
 
-	// consecutiveBlankLinesRE collapses 3+ line breaks (optional whitespace-only lines) to one blank line.
 	consecutiveBlankLinesRE = regexp.MustCompile(`(?:\r?\n[ \t]*){3,}`)
 
-	// Prefix match: next line starts a new block (list, heading, quote, fence, table).
 	blockStartRE = regexp.MustCompile("^(?:#{1,6}\\s|(?:\\*|-|\\+)\\s|\\d+\\.\\s|>|```|\\|)")
 
 	orderedListItemRE = regexp.MustCompile(`^\d+\.\s`)
 )
 
-func Markdown2HTML(md string) string {
+// MarkdownToHTML is the canonical Markdown → HTML converter for FeedCraft.
+// It normalizes LLM-oriented markdown (single newlines as breaks, collapsed blank runs) before rendering.
+func MarkdownToHTML(md string) string {
 	md = normalizeMarkdownForRender(md)
 
 	extensions := parser.CommonExtensions | parser.AutoHeadingIDs | parser.NoEmptyLineBeforeBlock
@@ -40,8 +40,10 @@ func Markdown2HTML(md string) string {
 	return string(markdown.Render(doc, renderer))
 }
 
-func Html2Markdown(text string, domain *string) string {
-	text = insertLineBreaksInParagraphHTML(text)
+// HTMLToMarkdown is the canonical HTML → Markdown converter for FeedCraft.
+// Pass domain when relative URLs should be resolved against an article origin (e.g. cleanup, LLM prompts).
+func HTMLToMarkdown(htmlContent string, domain string) string {
+	htmlContent = insertLineBreaksInParagraphHTML(htmlContent)
 
 	conv := converter.NewConverter(
 		converter.WithPlugins(
@@ -51,19 +53,17 @@ func Html2Markdown(text string, domain *string) string {
 		),
 	)
 	var convertOptions []converter.ConvertOptionFunc
-	if domain != nil {
-		convertOptions = append(convertOptions, converter.WithDomain(*domain))
+	if domain != "" {
+		convertOptions = append(convertOptions, converter.WithDomain(domain))
 	}
 
-	mdStr, err := conv.ConvertString(text, convertOptions...)
+	mdStr, err := conv.ConvertString(htmlContent, convertOptions...)
 	if err != nil {
 		logrus.Errorf("convert html to markdown err: %v", err)
 	}
 	return collapseConsecutiveBlankLines(mdStr)
 }
 
-// normalizeMarkdownForRender prepares LLM- and cleanup-oriented markdown before HTML rendering.
-// Single newlines become visible line breaks; runs of blank lines are collapsed for readability.
 func normalizeMarkdownForRender(md string) string {
 	return processOutsideFencedCodeBlocks(md, func(segment string) string {
 		segment = collapseConsecutiveBlankLines(segment)
@@ -75,8 +75,6 @@ func collapseConsecutiveBlankLines(md string) string {
 	return consecutiveBlankLinesRE.ReplaceAllString(md, "\n\n")
 }
 
-// applySingleNewlineHardBreaks turns single newlines into CommonMark hard breaks ("  \n")
-// without using HardLineBreak globally, so list items and block boundaries stay intact.
 func applySingleNewlineHardBreaks(md string) string {
 	if md == "" {
 		return md
@@ -103,10 +101,7 @@ func applySingleNewlineHardBreaks(md string) string {
 func isSameBlockContinuation(prev, next string) bool {
 	prevTrim := strings.TrimSpace(prev)
 	nextTrim := strings.TrimSpace(next)
-	if strings.HasPrefix(prevTrim, "> ") && strings.HasPrefix(nextTrim, "> ") {
-		return true
-	}
-	return false
+	return strings.HasPrefix(prevTrim, "> ") && strings.HasPrefix(nextTrim, "> ")
 }
 
 func isListContinuation(prev, next string) bool {
@@ -151,8 +146,6 @@ func processOutsideFencedCodeBlocks(md string, process func(string) string) stri
 	return result.String()
 }
 
-// insertLineBreaksInParagraphHTML converts literal newlines inside <p> tags into <br>,
-// so soft line breaks survive browser rendering and HTML↔Markdown round-trips.
 func insertLineBreaksInParagraphHTML(html string) string {
 	return paragraphTagRE.ReplaceAllStringFunc(html, func(match string) string {
 		subs := paragraphTagRE.FindStringSubmatch(match)

--- a/internal/util/markdown_convert.go
+++ b/internal/util/markdown_convert.go
@@ -15,21 +15,15 @@ import (
 )
 
 var (
-	paragraphTagRE = regexp.MustCompile(`(?is)<p(\s[^>]*)?>(.*?)</p>`)
-
+	paragraphTagRE          = regexp.MustCompile(`(?is)<p(\s[^>]*)?>(.*?)</p>`)
 	consecutiveBlankLinesRE = regexp.MustCompile(`(?:\r?\n[ \t]*){3,}`)
+	brTagSuffixRE           = regexp.MustCompile(`(?i)<br\b[^>]*>\s*$`)
+	brTagPrefixRE           = regexp.MustCompile(`(?i)^\s*<br\b[^>]*>`)
 
-	blockStartRE = regexp.MustCompile("^(?:#{1,6}\\s|(?:\\*|-|\\+)\\s|\\d+\\.\\s|>|```|\\|)")
-
+	blockStartRE      = regexp.MustCompile("^(?:#{1,6}\\s|(?:\\*|-|\\+)\\s|\\d+\\.\\s|>|```|\\|)")
 	orderedListItemRE = regexp.MustCompile(`^\d+\.\s`)
-
-	// brTagSuffixRE / brTagPrefixRE detect <br> variants adjacent to a newline (with optional whitespace).
-	brTagSuffixRE = regexp.MustCompile(`(?i)<br\b[^>]*>\s*$`)
-	brTagPrefixRE = regexp.MustCompile(`(?i)^\s*<br\b[^>]*>`)
 )
 
-// MarkdownToHTML is the canonical Markdown → HTML converter for FeedCraft.
-// It normalizes LLM-oriented markdown (single newlines as breaks, collapsed blank runs) before rendering.
 func MarkdownToHTML(md string) string {
 	md = normalizeMarkdownForRender(md)
 
@@ -44,8 +38,6 @@ func MarkdownToHTML(md string) string {
 	return string(markdown.Render(doc, renderer))
 }
 
-// HTMLToMarkdown is the canonical HTML → Markdown converter for FeedCraft.
-// Pass domain when relative URLs should be resolved against an article origin (e.g. cleanup, LLM prompts).
 func HTMLToMarkdown(htmlContent string, domain string) string {
 	htmlContent = insertLineBreaksInParagraphHTML(htmlContent)
 

--- a/internal/util/markdown_convert.go
+++ b/internal/util/markdown_convert.go
@@ -22,6 +22,10 @@ var (
 	blockStartRE = regexp.MustCompile("^(?:#{1,6}\\s|(?:\\*|-|\\+)\\s|\\d+\\.\\s|>|```|\\|)")
 
 	orderedListItemRE = regexp.MustCompile(`^\d+\.\s`)
+
+	// brTagSuffixRE / brTagPrefixRE detect <br> variants adjacent to a newline (with optional whitespace).
+	brTagSuffixRE = regexp.MustCompile(`(?i)<br\b[^>]*>\s*$`)
+	brTagPrefixRE = regexp.MustCompile(`(?i)^\s*<br\b[^>]*>`)
 )
 
 // MarkdownToHTML is the canonical Markdown → HTML converter for FeedCraft.
@@ -187,6 +191,5 @@ func shouldInsertLineBreak(before, after string) bool {
 	if before == "" || after == "" {
 		return false
 	}
-	lower := strings.ToLower(before)
-	return !strings.HasSuffix(lower, "<br>") && !strings.HasSuffix(lower, "<br/>") && !strings.HasSuffix(lower, "<br />")
+	return !brTagSuffixRE.MatchString(before) && !brTagPrefixRE.MatchString(after)
 }

--- a/internal/util/markdown_convert_test.go
+++ b/internal/util/markdown_convert_test.go
@@ -8,45 +8,45 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestMarkdown2HTML_SingleNewlineBecomesBreak(t *testing.T) {
-	html := Markdown2HTML("line1\nline2")
+func TestMarkdownToHTML_SingleNewlineBecomesBreak(t *testing.T) {
+	html := MarkdownToHTML("line1\nline2")
 	assert.Contains(t, html, "line1<br>")
 	assert.Contains(t, html, "line2")
 }
 
-func TestMarkdown2HTML_DoubleNewlineCreatesParagraphs(t *testing.T) {
-	html := Markdown2HTML("line1\n\nline2")
+func TestMarkdownToHTML_DoubleNewlineCreatesParagraphs(t *testing.T) {
+	html := MarkdownToHTML("line1\n\nline2")
 	assert.Contains(t, html, "<p>line1</p>")
 	assert.Contains(t, html, "<p>line2</p>")
 }
 
-func TestMarkdown2HTML_TwoSpacesNewlineStillBreaks(t *testing.T) {
-	html := Markdown2HTML("line1  \nline2")
+func TestMarkdownToHTML_TwoSpacesNewlineStillBreaks(t *testing.T) {
+	html := MarkdownToHTML("line1  \nline2")
 	assert.Contains(t, html, "line1<br>")
 	assert.Contains(t, html, "line2")
 }
 
-func TestMarkdown2HTML_ExplicitBreakTagPreserved(t *testing.T) {
-	html := Markdown2HTML("line1<br>line2")
+func TestMarkdownToHTML_ExplicitBreakTagPreserved(t *testing.T) {
+	html := MarkdownToHTML("line1<br>line2")
 	assert.Contains(t, html, "line1<br>")
 	assert.Contains(t, html, "line2")
 }
 
-func TestMarkdown2HTML_ListItemsUnchanged(t *testing.T) {
-	html := Markdown2HTML("- item1\n- item2")
+func TestMarkdownToHTML_ListItemsUnchanged(t *testing.T) {
+	html := MarkdownToHTML("- item1\n- item2")
 	assert.Contains(t, html, "<li>item1</li>")
 	assert.Contains(t, html, "<li>item2</li>")
 	assert.NotRegexp(t, `<li>item1<br>`, html)
 }
 
-func TestMarkdown2HTML_BlockquotePreservesLineBreaks(t *testing.T) {
-	html := Markdown2HTML("> quote line1\n> quote line2")
+func TestMarkdownToHTML_BlockquotePreservesLineBreaks(t *testing.T) {
+	html := MarkdownToHTML("> quote line1\n> quote line2")
 	assert.Contains(t, html, "quote line1<br>")
 	assert.Contains(t, html, "quote line2")
 }
 
-func TestMarkdown2HTML_CodeBlockPreservesNewlines(t *testing.T) {
-	html := Markdown2HTML("```\ncode line1\ncode line2\n```")
+func TestMarkdownToHTML_CodeBlockPreservesNewlines(t *testing.T) {
+	html := MarkdownToHTML("```\ncode line1\ncode line2\n```")
 	assert.Contains(t, html, "<pre>")
 	assert.Contains(t, html, "code line1")
 	assert.Contains(t, html, "code line2")
@@ -72,45 +72,42 @@ line2</p>`)
 	assert.Contains(t, html, "line1<br>")
 }
 
-func TestHtml2Markdown_ParagraphNewlineRoundTrip(t *testing.T) {
-	domain := "example.com"
+func TestHTMLToMarkdown_ParagraphNewlineRoundTrip(t *testing.T) {
 	original := "<p>line1\nline2</p>"
 
-	md := Html2Markdown(original, &domain)
+	md := HTMLToMarkdown(original, "example.com")
 	require.NotEmpty(t, md)
 	assert.Contains(t, md, "line1")
 	assert.Contains(t, md, "line2")
 
-	back := Markdown2HTML(md)
+	back := MarkdownToHTML(md)
 	assert.Contains(t, back, "line1<br>")
 	assert.Contains(t, back, "line2")
 }
 
-func TestHtml2Markdown_BreakTagRoundTrip(t *testing.T) {
-	domain := "example.com"
+func TestHTMLToMarkdown_BreakTagRoundTrip(t *testing.T) {
 	original := "<p>line1<br>line2</p>"
 
-	md := Html2Markdown(original, &domain)
-	back := Markdown2HTML(md)
+	md := HTMLToMarkdown(original, "example.com")
+	back := MarkdownToHTML(md)
 
 	assert.Contains(t, back, "line1<br>")
 	assert.Contains(t, back, "line2")
 }
 
-func TestHtml2Markdown_SeparateParagraphsRoundTrip(t *testing.T) {
-	domain := "example.com"
+func TestHTMLToMarkdown_SeparateParagraphsRoundTrip(t *testing.T) {
 	original := "<p>line1</p><p>line2</p>"
 
-	md := Html2Markdown(original, &domain)
-	back := Markdown2HTML(md)
+	md := HTMLToMarkdown(original, "example.com")
+	back := MarkdownToHTML(md)
 
 	assert.Contains(t, back, "<p>line1</p>")
 	assert.Contains(t, back, "<p>line2</p>")
 }
 
-func TestMarkdown2HTML_TableUnaffected(t *testing.T) {
+func TestMarkdownToHTML_TableUnaffected(t *testing.T) {
 	md := "| a | b |\n|---|---|\n| 1 | 2 |"
-	html := Markdown2HTML(md)
+	html := MarkdownToHTML(md)
 	assert.Contains(t, html, "<table>")
 	assert.Contains(t, html, ">1<")
 	assert.Contains(t, html, ">2<")
@@ -152,22 +149,21 @@ func TestNormalizeMarkdownForRender_PreservesCodeFenceBlankLines(t *testing.T) {
 	assert.Contains(t, normalized, "```\n\noutro")
 }
 
-func TestMarkdown2HTML_CollapsesExcessiveBlankLines(t *testing.T) {
-	html := Markdown2HTML("line1\n\n\n\nline2")
+func TestMarkdownToHTML_CollapsesExcessiveBlankLines(t *testing.T) {
+	html := MarkdownToHTML("line1\n\n\n\nline2")
 	assert.Contains(t, html, "<p>line1</p>")
 	assert.Contains(t, html, "<p>line2</p>")
 	assert.NotContains(t, html, "<p></p>")
 }
 
-func TestHtml2Markdown_CollapsesExcessiveBlankLines(t *testing.T) {
-	domain := "example.com"
-	md := Html2Markdown("<p>line1</p><p>line2</p>", &domain)
+func TestHTMLToMarkdown_CollapsesExcessiveBlankLines(t *testing.T) {
+	md := HTMLToMarkdown("<p>line1</p><p>line2</p>", "example.com")
 	assert.NotContains(t, md, "\n\n\n")
 }
 
-func TestMarkdown2HTML_MultiLineParagraph(t *testing.T) {
+func TestMarkdownToHTML_MultiLineParagraph(t *testing.T) {
 	md := "first line\nsecond line\n\nnew paragraph"
-	html := Markdown2HTML(md)
+	html := MarkdownToHTML(md)
 
 	firstP := strings.Index(html, "<p>")
 	secondP := strings.Index(html[firstP+len("<p>"):], "<p>")

--- a/internal/util/markdown_convert_test.go
+++ b/internal/util/markdown_convert_test.go
@@ -150,29 +150,6 @@ func TestCollapseConsecutiveBlankLines(t *testing.T) {
 	assert.Equal(t, "line1\n\nline2", collapseConsecutiveBlankLines("line1\n   \n  \nline2"))
 }
 
-func TestApplySingleNewlineHardBreaks_ListBoundaryUnchanged(t *testing.T) {
-	md := applySingleNewlineHardBreaks("- item1\n- item2")
-	assert.Equal(t, "- item1\n- item2", md)
-}
-
-func TestApplySingleNewlineHardBreaks_BlockquoteContinuationGetsHardBreak(t *testing.T) {
-	md := applySingleNewlineHardBreaks("> quote line1\n> quote line2")
-	assert.Contains(t, md, "quote line1  \n> quote line2")
-}
-
-func TestApplySingleNewlineHardBreaks_ParagraphGetsHardBreak(t *testing.T) {
-	md := applySingleNewlineHardBreaks("line1\nline2")
-	assert.Equal(t, "line1  \nline2", md)
-}
-
-func TestNormalizeMarkdownForRender_PreservesCodeFenceBlankLines(t *testing.T) {
-	input := "intro\n\n\n\n```\nkeep\n\n\nspacing\n```\n\n\n\noutro"
-	normalized := normalizeMarkdownForRender(input)
-	assert.Contains(t, normalized, "keep\n\n\nspacing")
-	assert.Contains(t, normalized, "intro\n\n```")
-	assert.Contains(t, normalized, "```\n\noutro")
-}
-
 func TestMarkdownToHTML_CollapsesExcessiveBlankLines(t *testing.T) {
 	html := MarkdownToHTML("line1\n\n\n\nline2")
 	assert.Contains(t, html, "<p>line1</p>")

--- a/internal/util/markdown_convert_test.go
+++ b/internal/util/markdown_convert_test.go
@@ -65,6 +65,26 @@ func TestInsertLineBreaksInParagraphHTML_DoesNotDuplicateExistingBreak(t *testin
 	assert.Equal(t, "<p>line1<br>\nline2</p>", html)
 }
 
+func TestInsertLineBreaksInParagraphHTML_DoesNotDuplicateBreakBeforeExistingBr(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+	}{
+		{"newline before br", "<p>line1\n<br>line2</p>"},
+		{"newline before br slash", "<p>line1\n<br/>line2</p>"},
+		{"newline before br spaced", "<p>line1\n<br />line2</p>"},
+		{"newline before br with attrs", "<p>line1\n<br class=\"x\">line2</p>"},
+		{"newline before uppercase br", "<p>line1\n<BR>line2</p>"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			html := insertLineBreaksInParagraphHTML(tc.in)
+			assert.NotContains(t, html, "<br>\n<br")
+			assert.NotContains(t, html, "<br>\n<BR")
+		})
+	}
+}
+
 func TestInsertLineBreaksInParagraphHTML_HandlesAttributes(t *testing.T) {
 	html := insertLineBreaksInParagraphHTML(`<p class="note">line1
 line2</p>`)
@@ -119,6 +139,10 @@ func TestShouldInsertLineBreak(t *testing.T) {
 	assert.False(t, shouldInsertLineBreak("line1", ""))
 	assert.False(t, shouldInsertLineBreak("line1<br>", "line2"))
 	assert.False(t, shouldInsertLineBreak("line1<br/>", "line2"))
+	assert.False(t, shouldInsertLineBreak("line1", "<br>line2"))
+	assert.False(t, shouldInsertLineBreak("line1", "<br/>line2"))
+	assert.False(t, shouldInsertLineBreak("line1", "<br />line2"))
+	assert.False(t, shouldInsertLineBreak("line1", `<br class="x">line2`))
 }
 
 func TestCollapseConsecutiveBlankLines(t *testing.T) {

--- a/internal/util/md2html.go
+++ b/internal/util/md2html.go
@@ -1,6 +1,9 @@
 package util
 
 import (
+	"regexp"
+	"strings"
+
 	"github.com/JohannesKaufmann/html-to-markdown/v2/converter"
 	"github.com/JohannesKaufmann/html-to-markdown/v2/plugin/base"
 	"github.com/JohannesKaufmann/html-to-markdown/v2/plugin/commonmark"
@@ -11,22 +14,25 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+// paragraphTagRE matches <p> elements so we can normalize line breaks inside them.
+var paragraphTagRE = regexp.MustCompile(`(?is)<p(\s[^>]*)?>(.*?)</p>`)
+
 func Markdown2HTML(md string) string {
-	// create Markdown parser with extensions
 	extensions := parser.CommonExtensions | parser.AutoHeadingIDs | parser.NoEmptyLineBeforeBlock
 	p := parser.NewWithExtensions(extensions)
 	doc := p.Parse([]byte(md))
 
-	// create HTML renderer with extensions
 	htmlFlags := html.CommonFlags | html.HrefTargetBlank
 	opts := html.RendererOptions{Flags: htmlFlags}
 	renderer := html.NewRenderer(opts)
 
 	renderResult := markdown.Render(doc, renderer)
-	return string(renderResult)
+	return insertLineBreaksInParagraphHTML(string(renderResult))
 }
 
 func Html2Markdown(text string, domain *string) string {
+	text = insertLineBreaksInParagraphHTML(text)
+
 	conv := converter.NewConverter(
 		converter.WithPlugins(
 			base.NewBasePlugin(),
@@ -45,4 +51,51 @@ func Html2Markdown(text string, domain *string) string {
 		logrus.Errorf("convert html to markdown err: %v", err)
 	}
 	return mdStr
+}
+
+// insertLineBreaksInParagraphHTML converts literal newlines inside <p> tags into <br>,
+// so soft line breaks survive browser rendering and HTML↔Markdown round-trips.
+func insertLineBreaksInParagraphHTML(html string) string {
+	return paragraphTagRE.ReplaceAllStringFunc(html, func(match string) string {
+		subs := paragraphTagRE.FindStringSubmatch(match)
+		attrs := subs[1]
+		inner := subs[2]
+		return "<p" + attrs + ">" + insertLineBreaksInHTMLFragment(inner) + "</p>"
+	})
+}
+
+func insertLineBreaksInHTMLFragment(fragment string) string {
+	if !strings.Contains(fragment, "\n") {
+		return fragment
+	}
+
+	var b strings.Builder
+	b.Grow(len(fragment) + 16)
+	segmentStart := 0
+
+	for i := 0; i < len(fragment); i++ {
+		if fragment[i] != '\n' {
+			continue
+		}
+		before := fragment[segmentStart:i]
+		after := fragment[i+1:]
+		if shouldInsertLineBreak(before, after) {
+			b.WriteString(before)
+			b.WriteString("<br>\n")
+			segmentStart = i + 1
+		}
+	}
+
+	b.WriteString(fragment[segmentStart:])
+	return b.String()
+}
+
+func shouldInsertLineBreak(before, after string) bool {
+	before = strings.TrimRight(before, " \t\r\n")
+	after = strings.TrimLeft(after, " \t\r\n")
+	if before == "" || after == "" {
+		return false
+	}
+	lower := strings.ToLower(before)
+	return !strings.HasSuffix(lower, "<br>") && !strings.HasSuffix(lower, "<br/>") && !strings.HasSuffix(lower, "<br />")
 }

--- a/internal/util/md2html.go
+++ b/internal/util/md2html.go
@@ -14,10 +14,21 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// paragraphTagRE matches <p> elements so we can normalize line breaks inside them.
-var paragraphTagRE = regexp.MustCompile(`(?is)<p(\s[^>]*)?>(.*?)</p>`)
+var (
+	paragraphTagRE = regexp.MustCompile(`(?is)<p(\s[^>]*)?>(.*?)</p>`)
+
+	// consecutiveBlankLinesRE collapses 3+ line breaks (optional whitespace-only lines) to one blank line.
+	consecutiveBlankLinesRE = regexp.MustCompile(`(?:\r?\n[ \t]*){3,}`)
+
+	// Prefix match: next line starts a new block (list, heading, quote, fence, table).
+	blockStartRE = regexp.MustCompile("^(?:#{1,6}\\s|(?:\\*|-|\\+)\\s|\\d+\\.\\s|>|```|\\|)")
+
+	orderedListItemRE = regexp.MustCompile(`^\d+\.\s`)
+)
 
 func Markdown2HTML(md string) string {
+	md = normalizeMarkdownForRender(md)
+
 	extensions := parser.CommonExtensions | parser.AutoHeadingIDs | parser.NoEmptyLineBeforeBlock
 	p := parser.NewWithExtensions(extensions)
 	doc := p.Parse([]byte(md))
@@ -26,8 +37,7 @@ func Markdown2HTML(md string) string {
 	opts := html.RendererOptions{Flags: htmlFlags}
 	renderer := html.NewRenderer(opts)
 
-	renderResult := markdown.Render(doc, renderer)
-	return insertLineBreaksInParagraphHTML(string(renderResult))
+	return string(markdown.Render(doc, renderer))
 }
 
 func Html2Markdown(text string, domain *string) string {
@@ -46,11 +56,99 @@ func Html2Markdown(text string, domain *string) string {
 	}
 
 	mdStr, err := conv.ConvertString(text, convertOptions...)
-
 	if err != nil {
 		logrus.Errorf("convert html to markdown err: %v", err)
 	}
-	return mdStr
+	return collapseConsecutiveBlankLines(mdStr)
+}
+
+// normalizeMarkdownForRender prepares LLM- and cleanup-oriented markdown before HTML rendering.
+// Single newlines become visible line breaks; runs of blank lines are collapsed for readability.
+func normalizeMarkdownForRender(md string) string {
+	return processOutsideFencedCodeBlocks(md, func(segment string) string {
+		segment = collapseConsecutiveBlankLines(segment)
+		return applySingleNewlineHardBreaks(segment)
+	})
+}
+
+func collapseConsecutiveBlankLines(md string) string {
+	return consecutiveBlankLinesRE.ReplaceAllString(md, "\n\n")
+}
+
+// applySingleNewlineHardBreaks turns single newlines into CommonMark hard breaks ("  \n")
+// without using HardLineBreak globally, so list items and block boundaries stay intact.
+func applySingleNewlineHardBreaks(md string) string {
+	if md == "" {
+		return md
+	}
+
+	lines := strings.Split(md, "\n")
+	for i := 0; i < len(lines)-1; i++ {
+		current := lines[i]
+		next := lines[i+1]
+		if current == "" || next == "" {
+			continue
+		}
+		if isListContinuation(current, next) {
+			continue
+		}
+		if blockStartRE.MatchString(next) && !isSameBlockContinuation(current, next) {
+			continue
+		}
+		lines[i] = strings.TrimRight(current, " ") + "  "
+	}
+	return strings.Join(lines, "\n")
+}
+
+func isSameBlockContinuation(prev, next string) bool {
+	prevTrim := strings.TrimSpace(prev)
+	nextTrim := strings.TrimSpace(next)
+	if strings.HasPrefix(prevTrim, "> ") && strings.HasPrefix(nextTrim, "> ") {
+		return true
+	}
+	return false
+}
+
+func isListContinuation(prev, next string) bool {
+	if strings.TrimSpace(next) == "" {
+		return false
+	}
+	indent := len(next) - len(strings.TrimLeft(next, " \t"))
+	if indent < 2 {
+		return false
+	}
+	prevTrim := strings.TrimSpace(prev)
+	if strings.HasPrefix(prevTrim, "- ") || strings.HasPrefix(prevTrim, "* ") || strings.HasPrefix(prevTrim, "+ ") {
+		return true
+	}
+	return orderedListItemRE.MatchString(prevTrim)
+}
+
+func processOutsideFencedCodeBlocks(md string, process func(string) string) string {
+	var result strings.Builder
+	remaining := md
+
+	for {
+		open := strings.Index(remaining, "```")
+		if open == -1 {
+			result.WriteString(process(remaining))
+			break
+		}
+
+		result.WriteString(process(remaining[:open]))
+		rest := remaining[open+3:]
+		close := strings.Index(rest, "```")
+		if close == -1 {
+			result.WriteString(remaining[open:])
+			break
+		}
+
+		closeEnd := open + 3 + close + 3
+		result.WriteString(remaining[open:closeEnd])
+		remaining = remaining[closeEnd:]
+	}
+
+	return result.String()
 }
 
 // insertLineBreaksInParagraphHTML converts literal newlines inside <p> tags into <br>,

--- a/internal/util/md2html_test.go
+++ b/internal/util/md2html_test.go
@@ -124,6 +124,47 @@ func TestShouldInsertLineBreak(t *testing.T) {
 	assert.False(t, shouldInsertLineBreak("line1<br/>", "line2"))
 }
 
+func TestCollapseConsecutiveBlankLines(t *testing.T) {
+	assert.Equal(t, "line1\n\nline2", collapseConsecutiveBlankLines("line1\n\n\n\nline2"))
+	assert.Equal(t, "line1\n\nline2", collapseConsecutiveBlankLines("line1\n   \n  \nline2"))
+}
+
+func TestApplySingleNewlineHardBreaks_ListBoundaryUnchanged(t *testing.T) {
+	md := applySingleNewlineHardBreaks("- item1\n- item2")
+	assert.Equal(t, "- item1\n- item2", md)
+}
+
+func TestApplySingleNewlineHardBreaks_BlockquoteContinuationGetsHardBreak(t *testing.T) {
+	md := applySingleNewlineHardBreaks("> quote line1\n> quote line2")
+	assert.Contains(t, md, "quote line1  \n> quote line2")
+}
+
+func TestApplySingleNewlineHardBreaks_ParagraphGetsHardBreak(t *testing.T) {
+	md := applySingleNewlineHardBreaks("line1\nline2")
+	assert.Equal(t, "line1  \nline2", md)
+}
+
+func TestNormalizeMarkdownForRender_PreservesCodeFenceBlankLines(t *testing.T) {
+	input := "intro\n\n\n\n```\nkeep\n\n\nspacing\n```\n\n\n\noutro"
+	normalized := normalizeMarkdownForRender(input)
+	assert.Contains(t, normalized, "keep\n\n\nspacing")
+	assert.Contains(t, normalized, "intro\n\n```")
+	assert.Contains(t, normalized, "```\n\noutro")
+}
+
+func TestMarkdown2HTML_CollapsesExcessiveBlankLines(t *testing.T) {
+	html := Markdown2HTML("line1\n\n\n\nline2")
+	assert.Contains(t, html, "<p>line1</p>")
+	assert.Contains(t, html, "<p>line2</p>")
+	assert.NotContains(t, html, "<p></p>")
+}
+
+func TestHtml2Markdown_CollapsesExcessiveBlankLines(t *testing.T) {
+	domain := "example.com"
+	md := Html2Markdown("<p>line1</p><p>line2</p>", &domain)
+	assert.NotContains(t, md, "\n\n\n")
+}
+
 func TestMarkdown2HTML_MultiLineParagraph(t *testing.T) {
 	md := "first line\nsecond line\n\nnew paragraph"
 	html := Markdown2HTML(md)

--- a/internal/util/md2html_test.go
+++ b/internal/util/md2html_test.go
@@ -1,0 +1,141 @@
+package util
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMarkdown2HTML_SingleNewlineBecomesBreak(t *testing.T) {
+	html := Markdown2HTML("line1\nline2")
+	assert.Contains(t, html, "line1<br>")
+	assert.Contains(t, html, "line2")
+}
+
+func TestMarkdown2HTML_DoubleNewlineCreatesParagraphs(t *testing.T) {
+	html := Markdown2HTML("line1\n\nline2")
+	assert.Contains(t, html, "<p>line1</p>")
+	assert.Contains(t, html, "<p>line2</p>")
+}
+
+func TestMarkdown2HTML_TwoSpacesNewlineStillBreaks(t *testing.T) {
+	html := Markdown2HTML("line1  \nline2")
+	assert.Contains(t, html, "line1<br>")
+	assert.Contains(t, html, "line2")
+}
+
+func TestMarkdown2HTML_ExplicitBreakTagPreserved(t *testing.T) {
+	html := Markdown2HTML("line1<br>line2")
+	assert.Contains(t, html, "line1<br>")
+	assert.Contains(t, html, "line2")
+}
+
+func TestMarkdown2HTML_ListItemsUnchanged(t *testing.T) {
+	html := Markdown2HTML("- item1\n- item2")
+	assert.Contains(t, html, "<li>item1</li>")
+	assert.Contains(t, html, "<li>item2</li>")
+	assert.NotRegexp(t, `<li>item1<br>`, html)
+}
+
+func TestMarkdown2HTML_BlockquotePreservesLineBreaks(t *testing.T) {
+	html := Markdown2HTML("> quote line1\n> quote line2")
+	assert.Contains(t, html, "quote line1<br>")
+	assert.Contains(t, html, "quote line2")
+}
+
+func TestMarkdown2HTML_CodeBlockPreservesNewlines(t *testing.T) {
+	html := Markdown2HTML("```\ncode line1\ncode line2\n```")
+	assert.Contains(t, html, "<pre>")
+	assert.Contains(t, html, "code line1")
+	assert.Contains(t, html, "code line2")
+	assert.NotContains(t, html, "code line1<br>")
+}
+
+func TestInsertLineBreaksInParagraphHTML_SkipsLeadingAndTrailingNewlines(t *testing.T) {
+	html := insertLineBreaksInParagraphHTML("<p>\nline1\nline2\n</p>")
+	assert.Contains(t, html, "line1<br>")
+	assert.Contains(t, html, "line2")
+	assert.NotContains(t, html, "<br>\n\n")
+}
+
+func TestInsertLineBreaksInParagraphHTML_DoesNotDuplicateExistingBreak(t *testing.T) {
+	html := insertLineBreaksInParagraphHTML("<p>line1<br>\nline2</p>")
+	assert.Equal(t, "<p>line1<br>\nline2</p>", html)
+}
+
+func TestInsertLineBreaksInParagraphHTML_HandlesAttributes(t *testing.T) {
+	html := insertLineBreaksInParagraphHTML(`<p class="note">line1
+line2</p>`)
+	assert.Contains(t, html, `class="note"`)
+	assert.Contains(t, html, "line1<br>")
+}
+
+func TestHtml2Markdown_ParagraphNewlineRoundTrip(t *testing.T) {
+	domain := "example.com"
+	original := "<p>line1\nline2</p>"
+
+	md := Html2Markdown(original, &domain)
+	require.NotEmpty(t, md)
+	assert.Contains(t, md, "line1")
+	assert.Contains(t, md, "line2")
+
+	back := Markdown2HTML(md)
+	assert.Contains(t, back, "line1<br>")
+	assert.Contains(t, back, "line2")
+}
+
+func TestHtml2Markdown_BreakTagRoundTrip(t *testing.T) {
+	domain := "example.com"
+	original := "<p>line1<br>line2</p>"
+
+	md := Html2Markdown(original, &domain)
+	back := Markdown2HTML(md)
+
+	assert.Contains(t, back, "line1<br>")
+	assert.Contains(t, back, "line2")
+}
+
+func TestHtml2Markdown_SeparateParagraphsRoundTrip(t *testing.T) {
+	domain := "example.com"
+	original := "<p>line1</p><p>line2</p>"
+
+	md := Html2Markdown(original, &domain)
+	back := Markdown2HTML(md)
+
+	assert.Contains(t, back, "<p>line1</p>")
+	assert.Contains(t, back, "<p>line2</p>")
+}
+
+func TestMarkdown2HTML_TableUnaffected(t *testing.T) {
+	md := "| a | b |\n|---|---|\n| 1 | 2 |"
+	html := Markdown2HTML(md)
+	assert.Contains(t, html, "<table>")
+	assert.Contains(t, html, ">1<")
+	assert.Contains(t, html, ">2<")
+}
+
+func TestShouldInsertLineBreak(t *testing.T) {
+	assert.True(t, shouldInsertLineBreak("line1", "line2"))
+	assert.False(t, shouldInsertLineBreak("", "line2"))
+	assert.False(t, shouldInsertLineBreak("line1", ""))
+	assert.False(t, shouldInsertLineBreak("line1<br>", "line2"))
+	assert.False(t, shouldInsertLineBreak("line1<br/>", "line2"))
+}
+
+func TestMarkdown2HTML_MultiLineParagraph(t *testing.T) {
+	md := "first line\nsecond line\n\nnew paragraph"
+	html := Markdown2HTML(md)
+
+	firstP := strings.Index(html, "<p>")
+	secondP := strings.Index(html[firstP+len("<p>"):], "<p>")
+	require.NotEqual(t, -1, secondP)
+	secondP += firstP + len("<p>")
+	require.NotEqual(t, -1, firstP)
+	require.NotEqual(t, -1, secondP)
+
+	firstParagraph := html[firstP:secondP]
+	assert.Contains(t, firstParagraph, "first line<br>")
+	assert.Contains(t, firstParagraph, "second line")
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 问题

检查了 `internal/util/md2html.go` 中的 Markdown ↔ HTML 转换逻辑，发现两处换行丢失：

1. **Markdown → HTML**：LLM 等场景常见的「单换行」在 gomarkdown 中会渲染为 `<p>line1\nline2</p>`，字面换行在浏览器中会被折叠，视觉上等同于丢失换行。
2. **HTML → Markdown**：`<p>line1\nline2</p>` 经 html-to-markdown 会变成 `line1 line2`，往返后无法恢复换行；而 `<br>` 标签路径本身是正常的。

## 方案

在 `<p>` 标签内、非首尾位置的字面换行处插入 `<br>`，并在 `Markdown2HTML` 输出与 `Html2Markdown` 输入两侧统一应用，避免影响列表、代码块、表格等块级结构。

同时将 `beautify.go` 中重复的 gomarkdown 渲染逻辑收敛为 `util.Markdown2HTML`。

## 测试

新增 `internal/util/md2html_test.go`，覆盖：

- 单换行、双换行、两空格硬换行
- 列表、引用、代码块、表格
- HTML↔Markdown 往返（含 `<br>` 与段落内换行）
- 辅助函数边界条件

## 验证

- `go test ./...`
- `task fix`
- `task backend-build`
- `task frontend-build`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5e429b32-28d3-40c8-b9ab-63001ac7d496"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5e429b32-28d3-40c8-b9ab-63001ac7d496"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

## Summary by Sourcery

Unify Markdown↔HTML conversion through new utility helpers that preserve paragraph line breaks and normalize LLM-style markdown, and update callers to use them.

New Features:
- Introduce canonical MarkdownToHTML and HTMLToMarkdown utilities that handle LLM-style single newlines, paragraph line breaks, and excessive blank lines consistently across the app.

Bug Fixes:
- Preserve single line breaks inside HTML paragraphs during Markdown↔HTML round trips so paragraph-internal newlines are not visually lost.
- Ensure HTML-to-Markdown conversion failures in content processing gracefully fall back to the original HTML without breaking behavior.

Enhancements:
- Refactor existing call sites to replace ad hoc markdown/HTML conversion logic with the new shared utilities for consistent behavior.
- Improve Markdown normalization by collapsing excessive blank lines while preserving spacing inside fenced code blocks.

Tests:
- Add comprehensive tests for Markdown/HTML conversion, including line-break semantics, lists, blockquotes, code blocks, tables, and round-trip behavior.