### PR TITLE
Add link flatten atom craft

### DIFF
--- a/internal/craft/entry.go
+++ b/internal/craft/entry.go
@@ -60,6 +60,12 @@ func GetSysCraftTemplateDict() map[string]CraftTemplate {
 			return GetRelativeLinkFixCraftOptions()
 		},
 	}
+	sysCraftTempList["link-flatten"] = CraftTemplate{
+		Name:                "link-flatten",
+		Description:         "提取 RSS 文章中的链接并打平成新的 RSS 条目",
+		ParamTemplateDefine: linkFlattenParamTmpl,
+		OptionFunc:          linkFlattenCraftLoadParam,
+	}
 	sysCraftTempList["fulltext"] = CraftTemplate{
 		Name:                "fulltext",
 		Description:         "提取 RSS 订阅源的全文",

--- a/internal/craft/link_flatten.go
+++ b/internal/craft/link_flatten.go
@@ -74,10 +74,12 @@ func OptionLinkFlatten(config LinkFlattenConfig) LegacyCraftOption {
 			}
 			sourceLink = resolveArticleLink(payload.originalFeedUrl, feedLink, sourceLink)
 			for _, candidate := range extractFlattenedLinks(item.Content, item.Description, sourceLink, config.ExternalOnly) {
+				description := buildFlattenedLinkDescription(item.Title, sourceLink)
 				flattened = append(flattened, &feeds.Item{
 					Title:       candidate.Title,
 					Link:        &feeds.Link{Href: candidate.URL},
-					Description: buildFlattenedLinkDescription(item.Title, sourceLink),
+					Description: description,
+					Content:     description,
 					Id:          buildFlattenedLinkID(item.Id, sourceLink, candidate.URL),
 					Updated:     item.Updated,
 					Created:     item.Created,

--- a/internal/craft/link_flatten.go
+++ b/internal/craft/link_flatten.go
@@ -1,0 +1,264 @@
+package craft
+
+import (
+	"context"
+	"fmt"
+	"html"
+	"net/url"
+	"strconv"
+	"strings"
+
+	"FeedCraft/internal/engine"
+	"FeedCraft/internal/model"
+	"FeedCraft/internal/util"
+
+	"github.com/PuerkitoBio/goquery"
+	"github.com/gorilla/feeds"
+	"github.com/sirupsen/logrus"
+)
+
+type LinkFlattenConfig struct {
+	KeepOriginal bool
+	ExternalOnly bool
+}
+
+type linkCandidate struct {
+	Title string
+	URL   string
+}
+
+var linkFlattenParamTmpl = []ParamTemplate{
+	{
+		Key:         "keep-original",
+		Description: "`true` to keep original RSS articles before extracted link items, `false` to output extracted links only",
+		Default:     "true",
+	},
+	{
+		Key:         "external-only",
+		Description: "`true` to extract only links whose domain differs from the source article URL, `false` to include same-domain links too",
+		Default:     "true",
+	},
+}
+
+func linkFlattenCraftLoadParam(m map[string]string) []LegacyCraftOption {
+	return GetLinkFlattenCraftOptions(parseLinkFlattenConfig(m))
+}
+
+func GetLinkFlattenCraftOptions(config LinkFlattenConfig) []LegacyCraftOption {
+	return []LegacyCraftOption{OptionLinkFlatten(config)}
+}
+
+func OptionLinkFlatten(config LinkFlattenConfig) LegacyCraftOption {
+	return func(feed *feeds.Feed, payload ExtraPayload) error {
+		if feed == nil || len(feed.Items) == 0 {
+			return nil
+		}
+
+		feedLink := ""
+		if feed.Link != nil {
+			feedLink = feed.Link.Href
+		}
+
+		flattened := make([]*feeds.Item, 0, len(feed.Items))
+		for _, item := range feed.Items {
+			if item == nil {
+				continue
+			}
+			if config.KeepOriginal {
+				flattened = append(flattened, item)
+			}
+
+			sourceLink := ""
+			if item.Link != nil {
+				sourceLink = item.Link.Href
+			}
+			sourceLink = resolveArticleLink(payload.originalFeedUrl, feedLink, sourceLink)
+			for _, candidate := range extractFlattenedLinks(item.Content, item.Description, sourceLink, config.ExternalOnly) {
+				flattened = append(flattened, &feeds.Item{
+					Title:       candidate.Title,
+					Link:        &feeds.Link{Href: candidate.URL},
+					Description: buildFlattenedLinkDescription(item.Title, sourceLink),
+					Id:          buildFlattenedLinkID(item.Id, sourceLink, candidate.URL),
+					Updated:     item.Updated,
+					Created:     item.Created,
+				})
+			}
+		}
+
+		feed.Items = flattened
+		return nil
+	}
+}
+
+type linkFlattenProcessor struct {
+	feedURL string
+	config  LinkFlattenConfig
+}
+
+func newLinkFlattenProcessor(feedURL string, config LinkFlattenConfig) *linkFlattenProcessor {
+	return &linkFlattenProcessor{feedURL: feedURL, config: config}
+}
+
+func (p *linkFlattenProcessor) Process(ctx context.Context, feed *model.CraftFeed) (*model.CraftFeed, error) {
+	_ = ctx
+	if feed == nil || len(feed.Articles) == 0 {
+		return feed, nil
+	}
+
+	cloned := cloneCraftFeed(feed)
+	flattened := make([]*model.CraftArticle, 0, len(cloned.Articles))
+	for _, article := range cloned.Articles {
+		if article == nil {
+			continue
+		}
+		if p.config.KeepOriginal {
+			flattened = append(flattened, article)
+		}
+
+		sourceLink := resolveArticleLink(p.feedURL, cloned.Link, article.Link)
+		for _, candidate := range extractFlattenedLinks(article.Content, article.Description, sourceLink, p.config.ExternalOnly) {
+			flattened = append(flattened, &model.CraftArticle{
+				Title:       candidate.Title,
+				Link:        candidate.URL,
+				Description: buildFlattenedLinkDescription(article.Title, sourceLink),
+				Content:     buildFlattenedLinkDescription(article.Title, sourceLink),
+				Id:          buildFlattenedLinkID(article.Id, sourceLink, candidate.URL),
+				Updated:     article.Updated,
+				Created:     article.Created,
+				AuthorName:  article.AuthorName,
+				AuthorEmail: article.AuthorEmail,
+			})
+		}
+	}
+	cloned.Articles = flattened
+	return cloned, nil
+}
+
+func buildNativeLinkFlattenProcessor(atom ResolvedCraftAtom, feedURL string) (engine.CraftOption, error) {
+	return wrapLocalProcessor(newLinkFlattenProcessor(feedURL, parseLinkFlattenConfig(atom.Params))), nil
+}
+
+func parseLinkFlattenConfig(params map[string]string) LinkFlattenConfig {
+	return LinkFlattenConfig{
+		KeepOriginal: parseBoolParamWithDefault(params["keep-original"], true, "keep-original"),
+		ExternalOnly: parseBoolParamWithDefault(params["external-only"], true, "external-only"),
+	}
+}
+
+func parseBoolParamWithDefault(raw string, defaultValue bool, paramName string) bool {
+	if strings.TrimSpace(raw) == "" {
+		return defaultValue
+	}
+	parsed, err := strconv.ParseBool(strings.TrimSpace(raw))
+	if err != nil {
+		logrus.Warnf("invalid bool param [%s]=[%s], using default [%v]", paramName, raw, defaultValue)
+		return defaultValue
+	}
+	return parsed
+}
+
+func extractFlattenedLinks(content, description, sourceArticleURL string, externalOnly bool) []linkCandidate {
+	htmlContent := content
+	if strings.TrimSpace(description) != "" && description != content {
+		htmlContent += description
+	}
+	if strings.TrimSpace(htmlContent) == "" {
+		return nil
+	}
+
+	doc, err := goquery.NewDocumentFromReader(strings.NewReader(htmlContent))
+	if err != nil {
+		logrus.Warnf("failed to parse article html for link flatten: %v", err)
+		return nil
+	}
+
+	seen := make(map[string]struct{})
+	candidates := make([]linkCandidate, 0)
+	doc.Find("a[href]").Each(func(i int, selection *goquery.Selection) {
+		rawHref, exists := selection.Attr("href")
+		if !exists {
+			return
+		}
+
+		absURL, ok := normalizeHTTPURL(sourceArticleURL, rawHref)
+		if !ok {
+			return
+		}
+		if externalOnly && !isExternalLink(sourceArticleURL, absURL) {
+			return
+		}
+		if _, exists := seen[absURL]; exists {
+			return
+		}
+		seen[absURL] = struct{}{}
+
+		title := strings.TrimSpace(selection.Text())
+		if title == "" {
+			title = absURL
+		}
+		candidates = append(candidates, linkCandidate{Title: title, URL: absURL})
+	})
+	return candidates
+}
+
+func normalizeHTTPURL(baseURL, rawHref string) (string, bool) {
+	trimmed := strings.TrimSpace(rawHref)
+	if trimmed == "" {
+		return "", false
+	}
+
+	parsedHref, err := url.Parse(trimmed)
+	if err != nil {
+		return "", false
+	}
+
+	var resolved *url.URL
+	if parsedHref.IsAbs() {
+		resolved = parsedHref
+	} else {
+		parsedBase, err := url.Parse(baseURL)
+		if err != nil || parsedBase == nil || !parsedBase.IsAbs() {
+			return "", false
+		}
+		resolved = parsedBase.ResolveReference(parsedHref)
+	}
+
+	if resolved == nil || (resolved.Scheme != "http" && resolved.Scheme != "https") || resolved.Hostname() == "" {
+		return "", false
+	}
+	return resolved.String(), true
+}
+
+func isExternalLink(sourceArticleURL, targetURL string) bool {
+	source, err := url.Parse(sourceArticleURL)
+	if err != nil || source == nil {
+		return false
+	}
+	target, err := url.Parse(targetURL)
+	if err != nil || target == nil {
+		return false
+	}
+	return !strings.EqualFold(source.Hostname(), target.Hostname())
+}
+
+func resolveArticleLink(feedURL, feedLink, articleLink string) string {
+	if strings.TrimSpace(articleLink) != "" {
+		return getAbsLinkForFeedItem(feedURL, feedLink, articleLink)
+	}
+	if strings.TrimSpace(feedLink) != "" {
+		return getAbsFeedLink(feedURL, feedLink)
+	}
+	return feedURL
+}
+
+func buildFlattenedLinkDescription(sourceTitle, sourceURL string) string {
+	return fmt.Sprintf(
+		`Extracted from <a href="%s">%s</a>`,
+		html.EscapeString(sourceURL),
+		html.EscapeString(sourceTitle),
+	)
+}
+
+func buildFlattenedLinkID(sourceID, sourceURL, targetURL string) string {
+	return util.GetTextContentHash(sourceID + "|" + sourceURL + "|" + targetURL)
+}

--- a/internal/craft/link_flatten_test.go
+++ b/internal/craft/link_flatten_test.go
@@ -101,4 +101,5 @@ func TestLinkFlattenLegacyOptionUsesTemplateDefaults(t *testing.T) {
 	assert.Equal(t, "Elsewhere", feed.Items[1].Title)
 	require.NotNil(t, feed.Items[1].Link)
 	assert.Equal(t, "https://elsewhere.test/path", feed.Items[1].Link.Href)
+	assert.Contains(t, feed.Items[1].Content, "Legacy Source")
 }

--- a/internal/craft/link_flatten_test.go
+++ b/internal/craft/link_flatten_test.go
@@ -1,0 +1,104 @@
+package craft
+
+import (
+	"context"
+	"testing"
+
+	"FeedCraft/internal/dao"
+	"FeedCraft/internal/model"
+
+	"github.com/gorilla/feeds"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLinkFlattenDefaultsKeepOriginalAndExtractExternalLinksOnly(t *testing.T) {
+	db := newCraftRuntimeTestDB(t)
+
+	processor, err := BuildOptionChain(db, "link-flatten", "https://example.com/feed.xml")
+	require.NoError(t, err)
+
+	feed := &model.CraftFeed{
+		Title: "Feed",
+		Link:  "https://example.com",
+		Articles: []*model.CraftArticle{
+			{
+				Title:   "Source Article",
+				Link:    "https://example.com/posts/1",
+				Content: `<p>Read <a href="https://external.test/a">External A</a>, <a href="/internal">Internal</a>, and <a href="mailto:hello@example.com">Mail</a>.</p>`,
+			},
+		},
+	}
+
+	result, err := processor(context.Background(), feed)
+	require.NoError(t, err)
+
+	require.Len(t, result.Articles, 2)
+	assert.Equal(t, "Source Article", result.Articles[0].Title)
+	assert.Equal(t, "https://example.com/posts/1", result.Articles[0].Link)
+	assert.Equal(t, "External A", result.Articles[1].Title)
+	assert.Equal(t, "https://external.test/a", result.Articles[1].Link)
+	assert.Contains(t, result.Articles[1].Description, "Source Article")
+	assert.Contains(t, result.Articles[1].Description, "https://example.com/posts/1")
+}
+
+func TestLinkFlattenCanDropOriginalAndIncludeSameDomainLinks(t *testing.T) {
+	db := newCraftRuntimeTestDB(t)
+	require.NoError(t, dao.CreateCraftAtom(db, &dao.CraftAtom{
+		Name:         "link-flatten-all",
+		TemplateName: "link-flatten",
+		Params: map[string]string{
+			"keep-original": "false",
+			"external-only": "false",
+		},
+	}))
+
+	processor, err := BuildOptionChain(db, "link-flatten-all", "https://example.com/feed.xml")
+	require.NoError(t, err)
+
+	feed := &model.CraftFeed{
+		Title: "Feed",
+		Link:  "https://example.com",
+		Articles: []*model.CraftArticle{
+			{
+				Title:       "Source Article",
+				Link:        "https://example.com/posts/1",
+				Description: `<a href="/same">Same Domain</a><a href="https://external.test/b">External B</a>`,
+			},
+		},
+	}
+
+	result, err := processor(context.Background(), feed)
+	require.NoError(t, err)
+
+	require.Len(t, result.Articles, 2)
+	assert.Equal(t, "Same Domain", result.Articles[0].Title)
+	assert.Equal(t, "https://example.com/same", result.Articles[0].Link)
+	assert.Equal(t, "External B", result.Articles[1].Title)
+	assert.Equal(t, "https://external.test/b", result.Articles[1].Link)
+}
+
+func TestLinkFlattenLegacyOptionUsesTemplateDefaults(t *testing.T) {
+	options := GetSysCraftTemplateDict()["link-flatten"].GetOptions(map[string]string{})
+	require.Len(t, options, 1)
+
+	feed := &feeds.Feed{
+		Link: &feeds.Link{Href: "https://example.com"},
+		Items: []*feeds.Item{
+			{
+				Title:       "Legacy Source",
+				Link:        &feeds.Link{Href: "https://example.com/post"},
+				Description: `<a href="https://elsewhere.test/path">Elsewhere</a><a href="/same">Same</a>`,
+			},
+		},
+	}
+
+	err := options[0](feed, ExtraPayload{originalFeedUrl: "https://example.com/feed.xml"})
+	require.NoError(t, err)
+
+	require.Len(t, feed.Items, 2)
+	assert.Equal(t, "Legacy Source", feed.Items[0].Title)
+	assert.Equal(t, "Elsewhere", feed.Items[1].Title)
+	require.NotNil(t, feed.Items[1].Link)
+	assert.Equal(t, "https://elsewhere.test/path", feed.Items[1].Link.Href)
+}

--- a/internal/craft/runtime.go
+++ b/internal/craft/runtime.go
@@ -53,6 +53,7 @@ var nativeProcessorBuilders = map[string]nativeProcessorBuilder{
 	"keyword":                     buildNativeKeywordProcessor,
 	"guid-fix":                    buildNativeGUIDFixProcessor,
 	"relative-link-fix":           buildNativeRelativeLinkFixProcessor,
+	"link-flatten":                buildNativeLinkFlattenProcessor,
 	"cleanup":                     buildZeroArg(func() localProcessor { return newCleanupProcessor() }),
 	"fulltext":                    buildWithFeedURL(func(u string) localProcessor { return newFulltextProcessor(u) }),
 	"fulltext-plus":               buildNativeFulltextPlusProcessor,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Adds the built-in `link-flatten` AtomCraft to extract article hyperlinks into flattened RSS items.
- Supports `keep-original` and `external-only` parameters, both defaulting to `true`.
- Covers both native runtime and legacy craft option paths with focused tests.

### Testing
- `go test ./internal/craft -run 'TestLinkFlatten'`
- `task fix`
- `go test ./...`
- `task backend-build`
- `task --force frontend-build`

### Review
- Addressed code-review feedback by keeping legacy flattened-link `Content` aligned with `Description` for downstream craft chains.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ba5a0619-a050-4259-8cc1-05306f31fc4b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ba5a0619-a050-4259-8cc1-05306f31fc4b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

## Summary by Sourcery

Introduce a new built-in `link-flatten` craft to extract hyperlinks from RSS article content into separate flattened items for both legacy and native runtimes.

New Features:
- Add the `link-flatten` system craft template with parameters for keeping original articles and restricting extraction to external links.
- Support a native `link-flatten` processor that clones craft feeds and emits per-link articles with generated titles, descriptions, and IDs.

Enhancements:
- Align legacy flattened link item `Content` with `Description` to keep downstream craft chains consistent.

Tests:
- Add focused tests covering default behavior, configurable parameters, and legacy option handling for the `link-flatten` craft.