### PR TITLE
Show feed type in RSS preview

### DIFF
--- a/internal/controller/feed_viewer.go
+++ b/internal/controller/feed_viewer.go
@@ -54,6 +54,7 @@ type FeedViewerPreview struct {
 	Description string                  `json:"description"`
 	Link        string                  `json:"link"`
 	FeedURL     string                  `json:"feedUrl"`
+	FeedType    string                  `json:"feedType"`
 	Copyright   string                  `json:"copyright"`
 	Image       *FeedViewerPreviewImage `json:"image,omitempty"`
 	Items       []FeedViewerPreviewItem `json:"items"`
@@ -291,6 +292,7 @@ func buildFeedViewerPreview(feed *model.CraftFeed, inputURL string) FeedViewerPr
 		Description: feed.Description,
 		Link:        feed.Link,
 		FeedURL:     inputURL,
+		FeedType:    feed.FeedType,
 		Copyright:   feed.Copyright,
 		Items:       make([]FeedViewerPreviewItem, 0, len(feed.Articles)),
 	}

--- a/internal/controller/feed_viewer_test.go
+++ b/internal/controller/feed_viewer_test.go
@@ -74,6 +74,124 @@ func TestPreviewFeedViewerAllowsInternalFeedURL(t *testing.T) {
 	}
 }
 
+func TestPreviewFeedViewerDetectsExternalFeedTypes(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	tests := []struct {
+		name        string
+		contentType string
+		body        string
+		wantType    string
+		wantTitle   string
+		wantItem    string
+	}{
+		{
+			name:        "rss",
+			contentType: "application/rss+xml",
+			body: `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+  <channel>
+    <title>RSS Preview Feed</title>
+    <link>https://example.com/rss</link>
+    <description>RSS feed description</description>
+    <item>
+      <title>RSS Preview Item</title>
+      <link>https://example.com/rss/item</link>
+      <guid>rss-item-1</guid>
+      <description>RSS item description</description>
+    </item>
+  </channel>
+</rss>`,
+			wantType:  "rss",
+			wantTitle: "RSS Preview Feed",
+			wantItem:  "RSS Preview Item",
+		},
+		{
+			name:        "atom",
+			contentType: "application/atom+xml",
+			body: `<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>Atom Preview Feed</title>
+  <link href="https://example.com/atom" rel="alternate"/>
+  <link href="https://example.com/atom.xml" rel="self"/>
+  <id>https://example.com/atom</id>
+  <updated>2026-06-29T00:00:00Z</updated>
+  <entry>
+    <title>Atom Preview Item</title>
+    <link href="https://example.com/atom/item"/>
+    <id>atom-item-1</id>
+    <updated>2026-06-29T00:00:00Z</updated>
+    <content type="html">&lt;p&gt;Atom item content&lt;/p&gt;</content>
+  </entry>
+</feed>`,
+			wantType:  "atom",
+			wantTitle: "Atom Preview Feed",
+			wantItem:  "Atom Preview Item",
+		},
+		{
+			name:        "json feed",
+			contentType: "application/feed+json",
+			body: `{
+  "version": "https://jsonfeed.org/version/1.1",
+  "title": "JSON Preview Feed",
+  "home_page_url": "https://example.com/json",
+  "feed_url": "https://example.com/json-feed.json",
+  "items": [
+    {
+      "id": "json-item-1",
+      "url": "https://example.com/json/item",
+      "title": "JSON Preview Item",
+      "content_html": "<p>JSON item content</p>",
+      "date_published": "2026-06-29T00:00:00Z"
+    }
+  ]
+}`,
+			wantType:  "json",
+			wantTitle: "JSON Preview Feed",
+			wantItem:  "JSON Preview Item",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", tt.contentType)
+				_, _ = w.Write([]byte(tt.body))
+			}))
+			defer server.Close()
+
+			recorder := performFeedViewerPreviewRequest(t, http.MethodGet, server.URL)
+
+			var response struct {
+				Code int `json:"code"`
+				Data struct {
+					FeedType string `json:"feedType"`
+					Title    string `json:"title"`
+					Items    []struct {
+						Title string `json:"title"`
+					} `json:"items"`
+				} `json:"data"`
+				Msg string `json:"msg"`
+			}
+			if err := json.Unmarshal(recorder.Body.Bytes(), &response); err != nil {
+				t.Fatalf("failed to decode response: %v", err)
+			}
+			if recorder.Code != http.StatusOK || response.Code != 0 {
+				t.Fatalf("expected preview success, got status %d code %d msg %q body %s", recorder.Code, response.Code, response.Msg, recorder.Body.String())
+			}
+			if response.Data.FeedType != tt.wantType {
+				t.Fatalf("feedType = %q, want %q", response.Data.FeedType, tt.wantType)
+			}
+			if response.Data.Title != tt.wantTitle {
+				t.Fatalf("title = %q, want %q", response.Data.Title, tt.wantTitle)
+			}
+			if len(response.Data.Items) != 1 || response.Data.Items[0].Title != tt.wantItem {
+				t.Fatalf("expected one item titled %q, got %+v", tt.wantItem, response.Data.Items)
+			}
+		})
+	}
+}
+
 func TestPreviewFeedViewerRejectsNonGETRequest(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 

--- a/internal/model/feed.go
+++ b/internal/model/feed.go
@@ -16,6 +16,7 @@ type CraftFeed struct {
 	Updated     time.Time
 	Created     time.Time
 	Id          string // The URL of the feed itself
+	FeedType    string
 	Copyright   string
 	AuthorName  string
 	AuthorEmail string
@@ -68,6 +69,7 @@ func FromGofeed(parsedFeed *gofeed.Feed) *CraftFeed {
 		Updated:     updatedTime,
 		Created:     publishedTime,
 		Id:          parsedFeed.FeedLink,
+		FeedType:    parsedFeed.FeedType,
 		Copyright:   parsedFeed.Copyright,
 	}
 

--- a/web/admin/src/api/feed_viewer.ts
+++ b/web/admin/src/api/feed_viewer.ts
@@ -21,6 +21,7 @@ export interface FeedViewerPreview {
   description: string;
   link: string;
   feedUrl: string;
+  feedType: string;
   copyright: string;
   image?: FeedViewerPreviewImage;
   items: FeedViewerPreviewItem[];

--- a/web/admin/src/views/dashboard/feed_viewer/feed_view_container.vue
+++ b/web/admin/src/views/dashboard/feed_viewer/feed_view_container.vue
@@ -67,9 +67,18 @@
   const { t } = useI18n();
   const viewMode = ref<ViewMode>('normal');
 
+  const feedTypeLabel = computed(() => {
+    const feedType = props.feedData.feedType?.toLowerCase();
+    if (feedType === 'rss') return 'RSS';
+    if (feedType === 'atom') return 'Atom';
+    if (feedType === 'json') return 'JSON Feed';
+    return props.feedData.feedType;
+  });
+
   const feedMetaList = computed(() => {
     const data = props.feedData;
     return [
+      { label: 'type', value: feedTypeLabel.value },
       { label: 'description', value: data.description },
       { label: 'link', value: data.link },
       { label: 'feedUrl', value: data.feedUrl },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Preserve parsed feed type through preview responses.
- Display RSS / Atom / JSON Feed type in the feed preview metadata.
- Add controller coverage for external RSS, Atom, and JSON Feed previews.

### Walkthrough
[feed_preview_rss_atom_json.mp4](https://cursor.com/agents/bc-2142d94a-6d38-4c39-99c9-ff4636b1952c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ffeed_preview_rss_atom_json.mp4)
[JSON Feed preview result](https://cursor.com/agents/bc-2142d94a-6d38-4c39-99c9-ff4636b1952c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ffeed_preview_json_result.webp)

### Testing
- `go test ./internal/controller -run TestPreviewFeedViewerDetectsExternalFeedTypes -count=1`
- `go test ./internal/controller -run 'TestPreviewFeedViewer|TestValidateFeedViewer|TestClassifyFeedViewer' -count=1`
- `pnpm run type:check`
- `task fix`
- `go test ./...`
- `task backend-build`
- `task frontend-build`
- Manual browser test: RSS 2.0, Atom, and JSON Feed previews via Feed Viewer page

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2142d94a-6d38-4c39-99c9-ff4636b1952c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2142d94a-6d38-4c39-99c9-ff4636b1952c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

## Summary by Sourcery

Expose parsed feed type in feed preview responses and surface it in the Feed Viewer UI metadata.

New Features:
- Include feed type in feed preview API responses and the Feed Viewer metadata panel for RSS, Atom, and JSON feeds.

Enhancements:
- Propagate feed type from parsed feeds into the internal CraftFeed model for use by preview endpoints.

Tests:
- Add controller tests to verify external RSS, Atom, and JSON feed previews correctly detect and return feed type, title, and items.