### PR TITLE
feat(craft): 调用 LLM 前的 cleanup 移除 base64 编码图片以节省 token

### DIFF
--- a/internal/craft/ai_filter.go
+++ b/internal/craft/ai_filter.go
@@ -248,7 +248,9 @@ func generateAIFilterArticleSummary(item *feeds.Item) (string, error) {
 		if item.Link != nil {
 			domain, _ = util.ParseDomainFromUrl(item.Link.Href)
 		}
-		cleanedContent := util.HTMLToMarkdown(content, domain)
+		// Drop inline base64 images before converting: they carry no useful signal
+		// for LLM processing but can dominate the token budget.
+		cleanedContent := util.HTMLToMarkdown(util.RemoveBase64Images(content), domain)
 		if strings.TrimSpace(cleanedContent) != "" {
 			processedContent = cleanedContent
 		}

--- a/internal/craft/introduction.go
+++ b/internal/craft/introduction.go
@@ -49,7 +49,9 @@ func processItemContent(item *feeds.Item, processor TextProcessor) string {
 	}
 
 	domain, _ := util.ParseDomainFromUrl(item.Link.Href)
-	cleanedContent := util.HTMLToMarkdown(originalContent, domain)
+	// Drop inline base64 images before converting: they carry no useful signal
+	// for LLM processing but can dominate the token budget.
+	cleanedContent := util.HTMLToMarkdown(util.RemoveBase64Images(originalContent), domain)
 
 	var processedContent string
 	var err error

--- a/internal/craft/llm_processors.go
+++ b/internal/craft/llm_processors.go
@@ -373,6 +373,9 @@ func getPrimaryArticleContent(article *model.CraftArticle) string {
 }
 
 func getArticleContentForPrompt(article *model.CraftArticle, original string) string {
+	// Drop inline base64 images before converting: they carry no useful signal
+	// for LLM processing but can dominate the token budget.
+	original = util.RemoveBase64Images(original)
 	domain, _ := util.ParseDomainFromUrl(article.Link)
 	cleaned := util.HTMLToMarkdown(original, domain)
 	if strings.TrimSpace(cleaned) != "" {

--- a/internal/craft/llm_processors_test.go
+++ b/internal/craft/llm_processors_test.go
@@ -1,0 +1,53 @@
+package craft
+
+import (
+	"strings"
+	"testing"
+
+	"FeedCraft/internal/model"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const testTinyBase64PNG = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg=="
+
+// TestGetArticleContentForPrompt_StripsBase64Images verifies that the LLM
+// preparation path (used by summary, introduction, etc.) strips inline base64
+// images before converting HTML to Markdown for the LLM context.
+func TestGetArticleContentForPrompt_StripsBase64Images(t *testing.T) {
+	article := &model.CraftArticle{
+		Title: "Test Article",
+		Link:  "https://example.com/post/1",
+	}
+	original := `<h1>Weekly Roundup</h1>` +
+		`<p>Read on for details.</p>` +
+		`<img src="data:image/png;base64,` + testTinyBase64PNG + `" alt="cover">` +
+		`<p>End of article.</p>`
+
+	result := getArticleContentForPrompt(article, original)
+
+	assert.NotContains(t, result, "base64", "base64 image data must not be sent to the LLM")
+	assert.NotContains(t, result, "data:image", "base64 data URI must be stripped")
+	assert.Contains(t, result, "Weekly Roundup")
+	assert.Contains(t, result, "Read on for details.")
+	assert.Contains(t, result, "End of article.")
+	// Stripped output should be far smaller than the raw base64 blob.
+	assert.Less(t, len(result), len(testTinyBase64PNG))
+}
+
+// TestGetArticleContentForPrompt_KeepsNormalImages verifies that regular
+// (non-base64) image references are preserved after the cleanup.
+func TestGetArticleContentForPrompt_KeepsNormalImages(t *testing.T) {
+	article := &model.CraftArticle{
+		Title: "Test Article",
+		Link:  "https://example.com/post/2",
+	}
+	original := `<p>See diagram below.</p><img src="https://example.com/pic.png" alt="diagram">`
+
+	result := getArticleContentForPrompt(article, original)
+
+	assert.True(t,
+		strings.Contains(result, "example.com/pic.png") || strings.Contains(result, "diagram"),
+		"normal image reference should be preserved",
+	)
+}

--- a/internal/util/content_processor.go
+++ b/internal/util/content_processor.go
@@ -7,6 +7,16 @@ import (
 var (
 	linkRegex = regexp.MustCompile(`<a\s+(?:[^>]*?\s+)?href="([^"]*)"[^>]*>.*?</a>`)
 	imgRegex  = regexp.MustCompile(`<img\s+(?:[^>]*?\s+)?src="([^"]*)"[^>]*>`)
+
+	// base64ImgTagRegex matches <img>/<source> tags whose attributes embed a
+	// base64-encoded data URI (e.g. src="data:image/png;base64,....").
+	// Quote style and attribute order are irrelevant since we only require the
+	// presence of a base64 data URI inside the tag.
+	base64ImgTagRegex = regexp.MustCompile(`(?is)<(?:img|source)\b[^>]*?\bdata:[^>]*?;base64,[^>]*?>`)
+	// base64MarkdownImgRegex matches Markdown image syntax that embeds a base64
+	// data URI, e.g. ![alt](data:image/png;base64,....). This acts as a safety
+	// net for content that is already in Markdown form.
+	base64MarkdownImgRegex = regexp.MustCompile(`(?is)!\[[^\]]*\]\(\s*data:[^)]*?;base64,[^)]*?\)`)
 )
 
 type ContentProcessOption struct {
@@ -23,12 +33,28 @@ func LowestLLMTemperaturePtr() *float64 {
 	return &temperature
 }
 
+// RemoveBase64Images strips inline base64-encoded images from the given
+// content. Such images carry no useful signal for LLM processing but can
+// dominate the token budget, so we drop them before sending content to the LLM.
+// It handles both HTML (<img>/<source> data URIs) and Markdown image syntax.
+func RemoveBase64Images(content string) string {
+	if content == "" {
+		return content
+	}
+	content = base64ImgTagRegex.ReplaceAllString(content, "")
+	content = base64MarkdownImgRegex.ReplaceAllString(content, "")
+	return content
+}
+
 func ProcessContent(content string, option ContentProcessOption) string {
 	if option.RemoveLinks {
 		content = linkRegex.ReplaceAllString(content, "")
 	}
 	if option.RemoveImage {
 		content = imgRegex.ReplaceAllString(content, "")
+		// imgRegex only matches double-quoted src attributes, so explicitly
+		// drop any remaining base64-encoded images regardless of quote style.
+		content = RemoveBase64Images(content)
 	}
 	if option.ConvertToMd {
 		if md := HTMLToMarkdown(content, ""); md != "" {

--- a/internal/util/content_processor_test.go
+++ b/internal/util/content_processor_test.go
@@ -1,0 +1,84 @@
+package util
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const tinyBase64PNG = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg=="
+
+func TestRemoveBase64Images_DropsDoubleQuotedImgTag(t *testing.T) {
+	content := `<p>hello</p><img src="data:image/png;base64,` + tinyBase64PNG + `" alt="x"><p>world</p>`
+	out := RemoveBase64Images(content)
+	assert.NotContains(t, out, "base64")
+	assert.NotContains(t, out, "<img")
+	assert.Contains(t, out, "<p>hello</p>")
+	assert.Contains(t, out, "<p>world</p>")
+}
+
+func TestRemoveBase64Images_DropsSingleQuotedImgTag(t *testing.T) {
+	content := `<img alt='photo' src='data:image/jpeg;base64,` + tinyBase64PNG + `'/>keep`
+	out := RemoveBase64Images(content)
+	assert.NotContains(t, out, "base64")
+	assert.NotContains(t, out, "<img")
+	assert.Contains(t, out, "keep")
+}
+
+func TestRemoveBase64Images_DropsSourceTag(t *testing.T) {
+	content := `<picture><source srcset="data:image/webp;base64,` + tinyBase64PNG + `"><img src="https://example.com/a.png"></picture>`
+	out := RemoveBase64Images(content)
+	assert.NotContains(t, out, "base64")
+	assert.NotContains(t, out, "<source")
+	// Regular (non-base64) image must be preserved.
+	assert.Contains(t, out, `src="https://example.com/a.png"`)
+}
+
+func TestRemoveBase64Images_DropsMarkdownImage(t *testing.T) {
+	content := "before ![alt](data:image/png;base64," + tinyBase64PNG + ") after"
+	out := RemoveBase64Images(content)
+	assert.NotContains(t, out, "base64")
+	assert.Contains(t, out, "before")
+	assert.Contains(t, out, "after")
+}
+
+func TestRemoveBase64Images_KeepsNormalImages(t *testing.T) {
+	content := `<img src="https://example.com/pic.png" alt="ok">`
+	out := RemoveBase64Images(content)
+	assert.Equal(t, content, out)
+}
+
+func TestRemoveBase64Images_EmptyInput(t *testing.T) {
+	assert.Equal(t, "", RemoveBase64Images(""))
+}
+
+func TestProcessContent_RemoveImageDropsBase64SingleQuote(t *testing.T) {
+	content := `<p>text</p><img src='data:image/png;base64,` + tinyBase64PNG + `'>`
+	out := ProcessContent(content, ContentProcessOption{RemoveImage: true})
+	assert.NotContains(t, out, "base64")
+	assert.NotContains(t, out, "<img")
+	assert.Contains(t, out, "<p>text</p>")
+}
+
+func TestProcessContent_KeepsBase64WhenRemoveImageDisabled(t *testing.T) {
+	content := `<img src="data:image/png;base64,` + tinyBase64PNG + `">`
+	out := ProcessContent(content, ContentProcessOption{})
+	assert.Equal(t, content, out)
+}
+
+func TestHTMLToMarkdown_StripsBase64Image(t *testing.T) {
+	content := `<p>Article body here.</p><img src="data:image/png;base64,` + tinyBase64PNG + `" alt="diagram">`
+	md := HTMLToMarkdown(content, "")
+	assert.NotContains(t, md, "base64")
+	assert.NotContains(t, md, "data:image")
+	assert.Contains(t, md, "Article body here.")
+	// Sanity check: the stripped output is far smaller than the base64 blob.
+	assert.Less(t, len(md), len(tinyBase64PNG))
+}
+
+func TestHTMLToMarkdown_KeepsNormalImageLink(t *testing.T) {
+	content := `<p>text</p><img src="https://example.com/pic.png" alt="ok">`
+	md := HTMLToMarkdown(content, "")
+	assert.Contains(t, strings.ToLower(md), "example.com/pic.png")
+}

--- a/internal/util/content_processor_test.go
+++ b/internal/util/content_processor_test.go
@@ -67,14 +67,14 @@ func TestProcessContent_KeepsBase64WhenRemoveImageDisabled(t *testing.T) {
 	assert.Equal(t, content, out)
 }
 
-func TestHTMLToMarkdown_StripsBase64Image(t *testing.T) {
+func TestHTMLToMarkdown_PreservesBase64Image(t *testing.T) {
+	// HTMLToMarkdown is a general-purpose converter and must NOT strip content
+	// on its own. LLM-specific callers are responsible for calling
+	// RemoveBase64Images before invoking this function.
 	content := `<p>Article body here.</p><img src="data:image/png;base64,` + tinyBase64PNG + `" alt="diagram">`
 	md := HTMLToMarkdown(content, "")
-	assert.NotContains(t, md, "base64")
-	assert.NotContains(t, md, "data:image")
+	assert.Contains(t, md, "base64", "HTMLToMarkdown must preserve base64 images for non-LLM callers")
 	assert.Contains(t, md, "Article body here.")
-	// Sanity check: the stripped output is far smaller than the base64 blob.
-	assert.Less(t, len(md), len(tinyBase64PNG))
 }
 
 func TestHTMLToMarkdown_KeepsNormalImageLink(t *testing.T) {

--- a/internal/util/markdown_convert.go
+++ b/internal/util/markdown_convert.go
@@ -39,6 +39,11 @@ func MarkdownToHTML(md string) string {
 }
 
 func HTMLToMarkdown(htmlContent string, domain string) string {
+	// Strip inline base64 images up front. HTMLToMarkdown is used as the
+	// token-saving cleanup step before LLM calls (summary, introduction,
+	// filters, etc.); base64 images carry no useful signal yet would otherwise
+	// be converted into huge ![](data:...) Markdown blobs that waste tokens.
+	htmlContent = RemoveBase64Images(htmlContent)
 	htmlContent = insertLineBreaksInParagraphHTML(htmlContent)
 
 	conv := converter.NewConverter(
@@ -57,6 +62,9 @@ func HTMLToMarkdown(htmlContent string, domain string) string {
 	if err != nil {
 		logrus.Errorf("convert html to markdown err: %v", err)
 	}
+	// Defense-in-depth: drop any base64 images that survived conversion into
+	// Markdown image syntax.
+	mdStr = RemoveBase64Images(mdStr)
 	return collapseConsecutiveBlankLines(mdStr)
 }
 

--- a/internal/util/markdown_convert.go
+++ b/internal/util/markdown_convert.go
@@ -39,11 +39,6 @@ func MarkdownToHTML(md string) string {
 }
 
 func HTMLToMarkdown(htmlContent string, domain string) string {
-	// Strip inline base64 images up front. HTMLToMarkdown is used as the
-	// token-saving cleanup step before LLM calls (summary, introduction,
-	// filters, etc.); base64 images carry no useful signal yet would otherwise
-	// be converted into huge ![](data:...) Markdown blobs that waste tokens.
-	htmlContent = RemoveBase64Images(htmlContent)
 	htmlContent = insertLineBreaksInParagraphHTML(htmlContent)
 
 	conv := converter.NewConverter(
@@ -62,9 +57,6 @@ func HTMLToMarkdown(htmlContent string, domain string) string {
 	if err != nil {
 		logrus.Errorf("convert html to markdown err: %v", err)
 	}
-	// Defense-in-depth: drop any base64 images that survived conversion into
-	// Markdown image syntax.
-	mdStr = RemoveBase64Images(mdStr)
 	return collapseConsecutiveBlankLines(mdStr)
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 背景

部分 craft 在调用 LLM 前会对文章 HTML 做精简（例如 `summary`、`introduction`、过滤类 craft），以减少 token 消耗。但内联的 base64 编码图片（`data:image/...;base64,...`）此前没有被处理，会被 `HTMLToMarkdown` 转换为 `![](data:...)` 这类 Markdown，整段 base64 原样保留，极大浪费 token。

## 设计决策

`util.HTMLToMarkdown` 是通用工具函数，遵循"最小惊讶原则"，不应在其内部硬编码 LLM 特定的内容优化。将 base64 移除逻辑内置其中，会对未来任何需要完整、忠实进行 HTML→Markdown 转换的非 LLM 调用者（归档、渲染、编辑等场景）造成非预期的内容丢失。

因此，`RemoveBase64Images` 被显式地调用在三个具体的 LLM 内容准备路径上。

## 改动

**新增工具函数** (`internal/util/content_processor.go`)：
- `RemoveBase64Images`：移除 HTML `<img>`/`<source>`（任意引号、任意属性顺序）及 Markdown `![](data:...;base64,...)` 形式的 base64 图片

**LLM 准备路径显式调用**（各自在 `HTMLToMarkdown` 之前）：
- `getArticleContentForPrompt`（`llm_processors.go`）— native summary/introduction 路径
- `processItemContent`（`introduction.go`）— legacy summary/introduction 路径
- `generateAIFilterArticleSummary`（`ai_filter.go`）— ai-filter 摘要子步骤

**`ProcessContent` 的 `RemoveImage` 分支**（`content_processor.go`）：已在首个 commit 中处理，补充了原 `imgRegex` 遗漏的单引号 base64 图片。

**`HTMLToMarkdown` 保持纯粹**：不引入任何 LLM 特定逻辑，归档/渲染/`cleanup` craft 等路径行为完全不变。

**translate/beautify**：使用空 `ContentProcessOption{}` 且不经过任何清理路径，内容完整性不受影响。

## 测试

- `go test ./...` 全部通过
- 新增 `internal/util/content_processor_test.go`：覆盖双/单引号 `<img>`、`<source>`、Markdown 图片、普通图片保留、`ProcessContent` 分支；新增 `TestHTMLToMarkdown_PreservesBase64Image` 验证 `HTMLToMarkdown` 不再过滤 base64
- 新增 `internal/craft/llm_processors_test.go`：`TestGetArticleContentForPrompt_StripsBase64Images` 在 craft 包层面端到端验证 base64 被剥离、正文保留
- `task fix`（gofmt + golangci-lint `0 issues` + eslint）通过
- `task backend-build` / `task frontend-build` 通过

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dc7d09c8-df8d-4f15-a691-bf4bbbf037cb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dc7d09c8-df8d-4f15-a691-bf4bbbf037cb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

## Summary by Sourcery

Strip inline base64-encoded images from content before LLM processing to reduce token usage while preserving textual content.

New Features:
- Introduce a utility to remove inline base64 data URI images from HTML and Markdown content.

Enhancements:
- Apply base64 image removal in HTML-to-Markdown conversion and image-removal processing paths to cover all token-saving cleanup flows.

Tests:
- Add unit tests for base64 image removal across HTML <img>/<source> tags, Markdown images, and integration with ProcessContent and HTMLToMarkdown, ensuring normal images are preserved.