### PR TITLE
Control preheating scheduler concurrency

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,12 @@ FC_DB_SQLITE_PATH=./db
 # Cache Configuration
 FC_REDIS_URI=redis://localhost:6379/
 
+# Background preheating
+# Pending queue size defaults to the maximum concurrency when left unset.
+FC_PREHEATING_MAX_CONCURRENCY=2
+# FC_PREHEATING_QUEUE_SIZE=2
+FC_PREHEATING_TASK_TIMEOUT=10m
+
 # Outbound HTTP User-Agent defaults
 FC_HTTP_USER_AGENT_FEED="FeedCraft/2.0"
 FC_HTTP_USER_AGENT_HTML="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/135.0.0.0 Safari/537.36"

--- a/.env.example
+++ b/.env.example
@@ -15,12 +15,6 @@ FC_DB_SQLITE_PATH=./db
 # Cache Configuration
 FC_REDIS_URI=redis://localhost:6379/
 
-# Background preheating
-# Pending queue size defaults to the maximum concurrency when left unset.
-FC_PREHEATING_MAX_CONCURRENCY=2
-# FC_PREHEATING_QUEUE_SIZE=2
-FC_PREHEATING_TASK_TIMEOUT=10m
-
 # Outbound HTTP User-Agent defaults
 FC_HTTP_USER_AGENT_FEED="FeedCraft/2.0"
 FC_HTTP_USER_AGENT_HTML="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/135.0.0.0 Safari/537.36"

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -97,6 +97,8 @@ func main() {
 }
 
 func startServer() {
+	defer recipe.Scheduler.Close()
+
 	sentryDsn := os.Getenv("SENTRY_DSN")
 	env := os.Getenv("ENV")
 	if len(env) == 0 { // set env to `prod` or `dev`

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -30,10 +30,10 @@ var (
 func init() {
 	logrus.Info("Preheating scheduler starting...")
 	// Set up the preheating task function to use the new, encapsulated logic.
-	taskFunc := func(recipeName string) error {
+	taskFunc := func(ctx context.Context, recipeName string) error {
 		// The second return value (*feeds.Feed) is ignored as we only care about
 		// the side effect of caching, which happens inside ProcessRecipeByID.
-		_, err := recipe.ProcessRecipeByIDWithTrigger(context.Background(), recipeName, observability.TriggerPreheating)
+		_, err := recipe.ProcessRecipeByIDWithTrigger(ctx, recipeName, observability.TriggerPreheating)
 		return err
 	}
 	shouldRun := func(recipeName string) bool {

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -97,8 +97,6 @@ func main() {
 }
 
 func startServer() {
-	defer recipe.Scheduler.Close()
-
 	sentryDsn := os.Getenv("SENTRY_DSN")
 	env := os.Getenv("ENV")
 	if len(env) == 0 { // set env to `prod` or `dev`
@@ -152,6 +150,10 @@ func startServer() {
 	dao.MigrateDatabases()
 	observability.Init(util.GetDatabase())
 	defer observability.Shutdown()
+	defer func() {
+		recipe.Scheduler.Close()
+		recipe.Scheduler.Wait()
+	}()
 	logrus.Info("Database migration done.")
 
 	listenAddr := os.Getenv("LISTEN_ADDR")

--- a/doc-site/src/content/docs/en/guides/advanced/customization.md
+++ b/doc-site/src/content/docs/en/guides/advanced/customization.md
@@ -75,6 +75,9 @@ You can configure FeedCraft using environment variables in `docker-compose.yml`.
 - **FC_LLM_API_TYPE**: (Optional) `openai` (default) or `ollama`.
 - **FC_LLM_MAX_CONCURRENCY**: (Optional) Global maximum concurrency for LLM requests (default: `3`). Limits concurrent API calls to prevent rate limits.
 - **FC_DOMAIN_MAX_CONCURRENCY**: (Optional) Maximum concurrent requests per target domain during web scraping like fulltext extraction (default: `3`). Prevents overwhelming target servers.
+- **FC_PREHEATING_MAX_CONCURRENCY**: (Optional) Maximum concurrent background preheating tasks (default: `2`).
+- **FC_PREHEATING_QUEUE_SIZE**: (Optional) Maximum pending preheating tasks; defaults to the preheating concurrency.
+- **FC_PREHEATING_TASK_TIMEOUT**: (Optional) Timeout for each preheating task as a Go duration such as `5m` (default: `10m`).
 - **LOG_LEVEL**: (Optional) Log level for the backend application (e.g., `info`, `debug`, `trace`). Overrides the default level set by `ENV`.
 
 ### External Services

--- a/doc-site/src/content/docs/zh-tw/guides/advanced/customization.md
+++ b/doc-site/src/content/docs/zh-tw/guides/advanced/customization.md
@@ -75,6 +75,9 @@ sidebar:
 - **FC_LLM_API_TYPE**: (可選) `openai` (預設) 或 `ollama`.
 - **FC_LLM_MAX_CONCURRENCY**: (可選) 全局最大 LLM 併發請求數（預設: `3`）。用於限制併發請求數量以防止觸發 API 速率限制。
 - **FC_DOMAIN_MAX_CONCURRENCY**: (可選) 網頁抓取（如全文提取）時每個目標域名的最大併發數（預設: `3`）。防止抓取目標伺服器負載過高。
+- **FC_PREHEATING_MAX_CONCURRENCY**: （可選）背景預熱工作的最大併發數（預設：`2`）。
+- **FC_PREHEATING_QUEUE_SIZE**: （可選）預熱等候佇列的最大工作數；預設與預熱併發數相同。
+- **FC_PREHEATING_TASK_TIMEOUT**: （可選）單一預熱工作的逾時時間，使用 `5m` 等 Go duration 格式（預設：`10m`）。
 - **LOG_LEVEL**: (可選) 後端應用的日誌級別 (例如 `info`, `debug`, `trace`)。覆蓋 `ENV` 設定的預設級別。
 
 ### 外部服務

--- a/doc-site/src/content/docs/zh/guides/advanced/customization.md
+++ b/doc-site/src/content/docs/zh/guides/advanced/customization.md
@@ -75,6 +75,9 @@ sidebar:
 - **FC_LLM_API_TYPE**: (可选) `openai` (默认) 或 `ollama`.
 - **FC_LLM_MAX_CONCURRENCY**: (可选) 全局最大 LLM 并发请求数（默认: `3`）。用于限制并发请求数量以防止触发 API 速率限制。
 - **FC_DOMAIN_MAX_CONCURRENCY**: (可选) 网页抓取（如全文提取）时每个目标域名的最大并发数（默认: `3`）。防止抓取目标服务器负载过高。
+- **FC_PREHEATING_MAX_CONCURRENCY**: （可选）后台预热任务的最大并发数（默认：`2`）。
+- **FC_PREHEATING_QUEUE_SIZE**: （可选）预热等待队列的最大任务数；默认与预热并发数相同。
+- **FC_PREHEATING_TASK_TIMEOUT**: （可选）单个预热任务的超时时间，使用 `5m` 等 Go duration 格式（默认：`10m`）。
 - **LOG_LEVEL**: (可选) 后端应用的日志级别 (例如 `info`, `debug`, `trace`)。覆盖 `ENV` 设置的默认级别。
 
 ### 外部服务

--- a/internal/util/preheating.go
+++ b/internal/util/preheating.go
@@ -354,8 +354,9 @@ func (s *PreheatingScheduler) finishTask(recipeName string, shouldReschedule boo
 	s.scheduleTask(recipeName, false)
 }
 
-// Close stops all scheduled timers, cancels running tasks, and waits for workers to exit.
-// It is safe to call Close multiple times.
+// Close stops all scheduled timers and signals workers and running tasks to exit.
+// It does not wait for task functions that ignore context cancellation.
+// It is safe to call Close multiple times, including from a task callback.
 func (s *PreheatingScheduler) Close() {
 	s.closeOnce.Do(func() {
 		s.mutex.Lock()
@@ -370,7 +371,6 @@ func (s *PreheatingScheduler) Close() {
 		s.mutex.Unlock()
 
 		s.lifecycleCancel()
-		s.workers.Wait()
 	})
 }
 

--- a/internal/util/preheating.go
+++ b/internal/util/preheating.go
@@ -35,20 +35,25 @@ type preheatingTask struct {
 
 // PreheatingScheduler 预热调度器
 type PreheatingScheduler struct {
-	contexts       map[string]*PreheatingContext
-	mutex          sync.RWMutex
-	taskFunc       func(context.Context, string) error // 实际的长任务函数
-	shouldRun      func(string) bool
-	onSkip         func(string)
-	taskQueue      chan preheatingTask
-	timerVersion   atomic.Uint64
-	maxConcurrency int
-	maxQueueSize   int
-	maxCount       int
-	graceTime      time.Duration
-	interval       time.Duration
-	jitter         time.Duration
-	taskTimeout    time.Duration
+	contexts        map[string]*PreheatingContext
+	mutex           sync.RWMutex
+	taskFunc        func(context.Context, string) error // 实际的长任务函数
+	shouldRun       func(string) bool
+	onSkip          func(string)
+	taskQueue       chan preheatingTask
+	timerVersion    atomic.Uint64
+	maxConcurrency  int
+	maxQueueSize    int
+	maxCount        int
+	graceTime       time.Duration
+	interval        time.Duration
+	jitter          time.Duration
+	taskTimeout     time.Duration
+	lifecycleCtx    context.Context
+	lifecycleCancel context.CancelFunc
+	closeOnce       sync.Once
+	workers         sync.WaitGroup
+	closed          bool
 }
 
 type PreheatingSchedulerOption func(*PreheatingScheduler)
@@ -110,17 +115,20 @@ func WithPreheatingTaskTimeout(taskTimeout time.Duration) PreheatingSchedulerOpt
 }
 
 func NewPreheatingScheduler(taskFunc func(context.Context, string) error, shouldRun func(string) bool, onSkip func(string), options ...PreheatingSchedulerOption) *PreheatingScheduler {
+	lifecycleCtx, lifecycleCancel := context.WithCancel(context.Background())
 	s := &PreheatingScheduler{
-		contexts:       make(map[string]*PreheatingContext),
-		taskFunc:       taskFunc,
-		shouldRun:      shouldRun,
-		onSkip:         onSkip,
-		maxConcurrency: DEFAULT_PREHEATING_MAX_CONCURRENCY,
-		maxCount:       MAX_PREHEATING_COUNT,
-		graceTime:      MAX_PREHEATING_GRACE_TIME,
-		interval:       DEFAULT_PREHEATING_INTERVAL,
-		jitter:         60 * time.Second,
-		taskTimeout:    DEFAULT_PREHEATING_TASK_TIMEOUT,
+		contexts:        make(map[string]*PreheatingContext),
+		taskFunc:        taskFunc,
+		shouldRun:       shouldRun,
+		onSkip:          onSkip,
+		maxConcurrency:  DEFAULT_PREHEATING_MAX_CONCURRENCY,
+		maxCount:        MAX_PREHEATING_COUNT,
+		graceTime:       MAX_PREHEATING_GRACE_TIME,
+		interval:        DEFAULT_PREHEATING_INTERVAL,
+		jitter:          60 * time.Second,
+		taskTimeout:     DEFAULT_PREHEATING_TASK_TIMEOUT,
+		lifecycleCtx:    lifecycleCtx,
+		lifecycleCancel: lifecycleCancel,
 	}
 
 	envClient := GetEnvClient()
@@ -147,6 +155,7 @@ func NewPreheatingScheduler(taskFunc func(context.Context, string) error, should
 		s.maxQueueSize = s.maxConcurrency
 	}
 	s.taskQueue = make(chan preheatingTask, s.maxQueueSize)
+	s.workers.Add(s.maxConcurrency)
 	for i := 0; i < s.maxConcurrency; i++ {
 		go s.worker()
 	}
@@ -161,6 +170,9 @@ func (s *PreheatingScheduler) ScheduleTask(recipeName string) {
 func (s *PreheatingScheduler) scheduleTask(recipeName string, fromUserRequest bool) {
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
+	if s.closed {
+		return
+	}
 
 	ctx, exists := s.contexts[recipeName]
 	now := time.Now()
@@ -217,7 +229,7 @@ func (s *PreheatingScheduler) randomJitter() time.Duration {
 func (s *PreheatingScheduler) enqueueTask(recipeName string, timerVersion uint64) {
 	s.mutex.Lock()
 	ctx, taskExist := s.contexts[recipeName]
-	if !taskExist || ctx.timerVersion != timerVersion {
+	if s.closed || !taskExist || ctx.timerVersion != timerVersion {
 		s.mutex.Unlock()
 		return
 	}
@@ -228,17 +240,22 @@ func (s *PreheatingScheduler) enqueueTask(recipeName string, timerVersion uint64
 		return
 	}
 	ctx.queued = true
-	s.mutex.Unlock()
 
 	task := preheatingTask{
 		recipeName:   recipeName,
 		timerVersion: timerVersion,
 	}
 	select {
+	case <-s.lifecycleCtx.Done():
+		delete(s.contexts, recipeName)
+		s.mutex.Unlock()
+		return
 	case s.taskQueue <- task:
+		s.mutex.Unlock()
 		return
 	default:
-		s.discardQueuedTask(recipeName, timerVersion)
+		delete(s.contexts, recipeName)
+		s.mutex.Unlock()
 		logrus.Debugf(
 			"preheating queue full; dropping task for recipe [%s] (queue: %d/%d)",
 			recipeName,
@@ -260,11 +277,18 @@ func (s *PreheatingScheduler) discardQueuedTask(recipeName string, timerVersion 
 }
 
 func (s *PreheatingScheduler) worker() {
-	for task := range s.taskQueue {
-		if !s.markTaskRunning(task) {
-			continue
+	defer s.workers.Done()
+
+	for {
+		select {
+		case <-s.lifecycleCtx.Done():
+			return
+		case task := <-s.taskQueue:
+			if !s.markTaskRunning(task) {
+				continue
+			}
+			s.runTask(task.recipeName)
 		}
-		s.runTask(task.recipeName)
 	}
 }
 
@@ -304,7 +328,7 @@ func (s *PreheatingScheduler) runTask(recipeName string) {
 		return
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), s.taskTimeout)
+	ctx, cancel := context.WithTimeout(s.lifecycleCtx, s.taskTimeout)
 	defer cancel()
 	err := s.taskFunc(ctx, recipeName)
 	if err != nil {
@@ -328,6 +352,26 @@ func (s *PreheatingScheduler) finishTask(recipeName string, shouldReschedule boo
 	s.mutex.Unlock()
 
 	s.scheduleTask(recipeName, false)
+}
+
+// Close stops all scheduled timers, cancels running tasks, and waits for workers to exit.
+// It is safe to call Close multiple times.
+func (s *PreheatingScheduler) Close() {
+	s.closeOnce.Do(func() {
+		s.mutex.Lock()
+		s.closed = true
+		for _, ctx := range s.contexts {
+			if ctx.timer != nil {
+				ctx.timer.Stop()
+				ctx.timer = nil
+			}
+		}
+		clear(s.contexts)
+		s.mutex.Unlock()
+
+		s.lifecycleCancel()
+		s.workers.Wait()
+	})
 }
 
 type PreheatingTaskInfo struct {

--- a/internal/util/preheating.go
+++ b/internal/util/preheating.go
@@ -1,6 +1,7 @@
 package util
 
 import (
+	"context"
 	"github.com/sirupsen/logrus"
 	"math/rand"
 	"sync"
@@ -16,6 +17,7 @@ const DEFAULT_PREHEATING_INTERVAL = 8 * time.Hour
 const DEFAULT_PREHEATING_MAX_CONCURRENCY = 2
 const DEFAULT_PREHEATING_QUEUE_SIZE = 1000
 const DEFAULT_PREHEATING_JITTER = 60 * time.Second
+const DEFAULT_PREHEATING_TASK_TIMEOUT = 10 * time.Minute
 
 type PreheatingContext struct {
 	taskKey          string
@@ -37,7 +39,7 @@ type preheatingTask struct {
 type PreheatingScheduler struct {
 	contexts       map[string]*PreheatingContext
 	mutex          sync.RWMutex
-	taskFunc       func(string) error // 实际的长任务函数
+	taskFunc       func(context.Context, string) error // 实际的长任务函数
 	shouldRun      func(string) bool
 	onSkip         func(string)
 	taskQueue      chan preheatingTask
@@ -48,6 +50,7 @@ type PreheatingScheduler struct {
 	graceTime      time.Duration
 	interval       time.Duration
 	jitter         time.Duration
+	taskTimeout    time.Duration
 }
 
 type PreheatingSchedulerOption func(*PreheatingScheduler)
@@ -100,7 +103,15 @@ func WithPreheatingGraceTime(graceTime time.Duration) PreheatingSchedulerOption 
 	}
 }
 
-func NewPreheatingScheduler(taskFunc func(payload string) error, shouldRun func(string) bool, onSkip func(string), options ...PreheatingSchedulerOption) *PreheatingScheduler {
+func WithPreheatingTaskTimeout(taskTimeout time.Duration) PreheatingSchedulerOption {
+	return func(s *PreheatingScheduler) {
+		if taskTimeout > 0 {
+			s.taskTimeout = taskTimeout
+		}
+	}
+}
+
+func NewPreheatingScheduler(taskFunc func(context.Context, string) error, shouldRun func(string) bool, onSkip func(string), options ...PreheatingSchedulerOption) *PreheatingScheduler {
 	s := &PreheatingScheduler{
 		contexts:       make(map[string]*PreheatingContext),
 		taskFunc:       taskFunc,
@@ -112,6 +123,7 @@ func NewPreheatingScheduler(taskFunc func(payload string) error, shouldRun func(
 		graceTime:      MAX_PREHEATING_GRACE_TIME,
 		interval:       DEFAULT_PREHEATING_INTERVAL,
 		jitter:         DEFAULT_PREHEATING_JITTER,
+		taskTimeout:    DEFAULT_PREHEATING_TASK_TIMEOUT,
 	}
 
 	envClient := GetEnvClient()
@@ -121,6 +133,14 @@ func NewPreheatingScheduler(taskFunc func(payload string) error, shouldRun func(
 		}
 		if envQueueSize := envClient.GetInt("PREHEATING_QUEUE_SIZE"); envQueueSize > 0 {
 			s.maxQueueSize = envQueueSize
+		}
+		if envTimeout := envClient.GetString("PREHEATING_TASK_TIMEOUT"); envTimeout != "" {
+			timeout, err := time.ParseDuration(envTimeout)
+			if err != nil || timeout <= 0 {
+				logrus.Warnf("Invalid FC_PREHEATING_TASK_TIMEOUT %q; using default %s", envTimeout, s.taskTimeout)
+			} else {
+				s.taskTimeout = timeout
+			}
 		}
 	}
 	for _, option := range options {
@@ -261,7 +281,9 @@ func (s *PreheatingScheduler) runTask(recipeName string) {
 		return
 	}
 
-	err := s.taskFunc(recipeName)
+	ctx, cancel := context.WithTimeout(context.Background(), s.taskTimeout)
+	defer cancel()
+	err := s.taskFunc(ctx, recipeName)
 	if err != nil {
 		logrus.Errorf("preheating task for recipe [%s] exec failed. err: %v", recipeName, err)
 	}

--- a/internal/util/preheating.go
+++ b/internal/util/preheating.go
@@ -16,7 +16,6 @@ const MAX_PREHEATING_GRACE_TIME = 36 * time.Hour
 const DEFAULT_PREHEATING_INTERVAL = 8 * time.Hour
 const DEFAULT_PREHEATING_MAX_CONCURRENCY = 2
 const DEFAULT_PREHEATING_QUEUE_SIZE = 1000
-const DEFAULT_PREHEATING_JITTER = 60 * time.Second
 const DEFAULT_PREHEATING_TASK_TIMEOUT = 10 * time.Minute
 
 type PreheatingContext struct {
@@ -122,7 +121,7 @@ func NewPreheatingScheduler(taskFunc func(context.Context, string) error, should
 		maxCount:       MAX_PREHEATING_COUNT,
 		graceTime:      MAX_PREHEATING_GRACE_TIME,
 		interval:       DEFAULT_PREHEATING_INTERVAL,
-		jitter:         DEFAULT_PREHEATING_JITTER,
+		jitter:         60 * time.Second,
 		taskTimeout:    DEFAULT_PREHEATING_TASK_TIMEOUT,
 	}
 

--- a/internal/util/preheating.go
+++ b/internal/util/preheating.go
@@ -15,7 +15,6 @@ const MAX_PREHEATING_COUNT = 6
 const MAX_PREHEATING_GRACE_TIME = 36 * time.Hour
 const DEFAULT_PREHEATING_INTERVAL = 8 * time.Hour
 const DEFAULT_PREHEATING_MAX_CONCURRENCY = 2
-const DEFAULT_PREHEATING_QUEUE_SIZE = 1000
 const DEFAULT_PREHEATING_TASK_TIMEOUT = 10 * time.Minute
 
 type PreheatingContext struct {
@@ -117,7 +116,6 @@ func NewPreheatingScheduler(taskFunc func(context.Context, string) error, should
 		shouldRun:      shouldRun,
 		onSkip:         onSkip,
 		maxConcurrency: DEFAULT_PREHEATING_MAX_CONCURRENCY,
-		maxQueueSize:   DEFAULT_PREHEATING_QUEUE_SIZE,
 		maxCount:       MAX_PREHEATING_COUNT,
 		graceTime:      MAX_PREHEATING_GRACE_TIME,
 		interval:       DEFAULT_PREHEATING_INTERVAL,
@@ -144,6 +142,9 @@ func NewPreheatingScheduler(taskFunc func(context.Context, string) error, should
 	}
 	for _, option := range options {
 		option(s)
+	}
+	if s.maxQueueSize <= 0 {
+		s.maxQueueSize = s.maxConcurrency
 	}
 	s.taskQueue = make(chan preheatingTask, s.maxQueueSize)
 	for i := 0; i < s.maxConcurrency; i++ {
@@ -229,10 +230,33 @@ func (s *PreheatingScheduler) enqueueTask(recipeName string, timerVersion uint64
 	ctx.queued = true
 	s.mutex.Unlock()
 
-	s.taskQueue <- preheatingTask{
+	task := preheatingTask{
 		recipeName:   recipeName,
 		timerVersion: timerVersion,
 	}
+	select {
+	case s.taskQueue <- task:
+		return
+	default:
+		s.discardQueuedTask(recipeName, timerVersion)
+		logrus.Debugf(
+			"preheating queue full; dropping task for recipe [%s] (queue: %d/%d)",
+			recipeName,
+			len(s.taskQueue),
+			cap(s.taskQueue),
+		)
+	}
+}
+
+func (s *PreheatingScheduler) discardQueuedTask(recipeName string, timerVersion uint64) {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	ctx, taskExist := s.contexts[recipeName]
+	if !taskExist || ctx.timerVersion != timerVersion || !ctx.queued {
+		return
+	}
+	delete(s.contexts, recipeName)
 }
 
 func (s *PreheatingScheduler) worker() {

--- a/internal/util/preheating.go
+++ b/internal/util/preheating.go
@@ -374,6 +374,11 @@ func (s *PreheatingScheduler) Close() {
 	})
 }
 
+// Wait blocks until all workers have exited. Call Close before Wait.
+func (s *PreheatingScheduler) Wait() {
+	s.workers.Wait()
+}
+
 type PreheatingTaskInfo struct {
 	IsActive        bool
 	LastRequestTime time.Time

--- a/internal/util/preheating.go
+++ b/internal/util/preheating.go
@@ -28,6 +28,11 @@ type PreheatingContext struct {
 	running          bool
 }
 
+type preheatingTask struct {
+	recipeName   string
+	timerVersion uint64
+}
+
 // PreheatingScheduler 预热调度器
 type PreheatingScheduler struct {
 	contexts       map[string]*PreheatingContext
@@ -35,7 +40,7 @@ type PreheatingScheduler struct {
 	taskFunc       func(string) error // 实际的长任务函数
 	shouldRun      func(string) bool
 	onSkip         func(string)
-	taskQueue      chan string
+	taskQueue      chan preheatingTask
 	timerVersion   atomic.Uint64
 	maxConcurrency int
 	maxQueueSize   int
@@ -121,7 +126,7 @@ func NewPreheatingScheduler(taskFunc func(payload string) error, shouldRun func(
 	for _, option := range options {
 		option(s)
 	}
-	s.taskQueue = make(chan string, s.maxQueueSize)
+	s.taskQueue = make(chan preheatingTask, s.maxQueueSize)
 	for i := 0; i < s.maxConcurrency; i++ {
 		go s.worker()
 	}
@@ -154,6 +159,7 @@ func (s *PreheatingScheduler) scheduleTask(recipeName string, fromUserRequest bo
 	} else if fromUserRequest {
 		ctx.lastRequestTime = now
 		ctx.preheatingCount = 0
+		ctx.queued = false
 	}
 
 	// 如果存在旧的定时器，先停止
@@ -204,24 +210,27 @@ func (s *PreheatingScheduler) enqueueTask(recipeName string, timerVersion uint64
 	ctx.queued = true
 	s.mutex.Unlock()
 
-	s.taskQueue <- recipeName
-}
-
-func (s *PreheatingScheduler) worker() {
-	for recipeName := range s.taskQueue {
-		if !s.markTaskRunning(recipeName) {
-			continue
-		}
-		s.runTask(recipeName)
+	s.taskQueue <- preheatingTask{
+		recipeName:   recipeName,
+		timerVersion: timerVersion,
 	}
 }
 
-func (s *PreheatingScheduler) markTaskRunning(recipeName string) bool {
+func (s *PreheatingScheduler) worker() {
+	for task := range s.taskQueue {
+		if !s.markTaskRunning(task) {
+			continue
+		}
+		s.runTask(task.recipeName)
+	}
+}
+
+func (s *PreheatingScheduler) markTaskRunning(task preheatingTask) bool {
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 
-	ctx, taskExist := s.contexts[recipeName]
-	if !taskExist {
+	ctx, taskExist := s.contexts[task.recipeName]
+	if !taskExist || ctx.timerVersion != task.timerVersion || !ctx.queued {
 		return false
 	}
 	if ctx.running {

--- a/internal/util/preheating.go
+++ b/internal/util/preheating.go
@@ -4,6 +4,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"math/rand"
 	"sync"
+	"sync/atomic"
 	"time"
 )
 
@@ -12,6 +13,9 @@ import (
 const MAX_PREHEATING_COUNT = 6
 const MAX_PREHEATING_GRACE_TIME = 36 * time.Hour
 const DEFAULT_PREHEATING_INTERVAL = 8 * time.Hour
+const DEFAULT_PREHEATING_MAX_CONCURRENCY = 2
+const DEFAULT_PREHEATING_QUEUE_SIZE = 1000
+const DEFAULT_PREHEATING_JITTER = 60 * time.Second
 
 type PreheatingContext struct {
 	taskKey          string
@@ -19,27 +23,117 @@ type PreheatingContext struct {
 	lastRequestTime  time.Time
 	preheatingCount  int
 	timer            *time.Timer
+	timerVersion     uint64
+	queued           bool
+	running          bool
 }
 
 // PreheatingScheduler 预热调度器
 type PreheatingScheduler struct {
-	contexts  map[string]*PreheatingContext
-	mutex     sync.RWMutex
-	taskFunc  func(string) error // 实际的长任务函数
-	shouldRun func(string) bool
-	onSkip    func(string)
+	contexts       map[string]*PreheatingContext
+	mutex          sync.RWMutex
+	taskFunc       func(string) error // 实际的长任务函数
+	shouldRun      func(string) bool
+	onSkip         func(string)
+	taskQueue      chan string
+	timerVersion   atomic.Uint64
+	maxConcurrency int
+	maxQueueSize   int
+	maxCount       int
+	graceTime      time.Duration
+	interval       time.Duration
+	jitter         time.Duration
 }
 
-func NewPreheatingScheduler(taskFunc func(payload string) error, shouldRun func(string) bool, onSkip func(string)) *PreheatingScheduler {
-	return &PreheatingScheduler{
-		contexts:  make(map[string]*PreheatingContext),
-		taskFunc:  taskFunc,
-		shouldRun: shouldRun,
-		onSkip:    onSkip,
+type PreheatingSchedulerOption func(*PreheatingScheduler)
+
+func WithPreheatingMaxConcurrency(maxConcurrency int) PreheatingSchedulerOption {
+	return func(s *PreheatingScheduler) {
+		if maxConcurrency > 0 {
+			s.maxConcurrency = maxConcurrency
+		}
 	}
 }
 
+func WithPreheatingQueueSize(queueSize int) PreheatingSchedulerOption {
+	return func(s *PreheatingScheduler) {
+		if queueSize > 0 {
+			s.maxQueueSize = queueSize
+		}
+	}
+}
+
+func WithPreheatingInterval(interval time.Duration) PreheatingSchedulerOption {
+	return func(s *PreheatingScheduler) {
+		if interval > 0 {
+			s.interval = interval
+		}
+	}
+}
+
+func WithPreheatingJitter(jitter time.Duration) PreheatingSchedulerOption {
+	return func(s *PreheatingScheduler) {
+		if jitter >= 0 {
+			s.jitter = jitter
+		}
+	}
+}
+
+func WithPreheatingMaxCount(maxCount int) PreheatingSchedulerOption {
+	return func(s *PreheatingScheduler) {
+		if maxCount > 0 {
+			s.maxCount = maxCount
+		}
+	}
+}
+
+func WithPreheatingGraceTime(graceTime time.Duration) PreheatingSchedulerOption {
+	return func(s *PreheatingScheduler) {
+		if graceTime > 0 {
+			s.graceTime = graceTime
+		}
+	}
+}
+
+func NewPreheatingScheduler(taskFunc func(payload string) error, shouldRun func(string) bool, onSkip func(string), options ...PreheatingSchedulerOption) *PreheatingScheduler {
+	s := &PreheatingScheduler{
+		contexts:       make(map[string]*PreheatingContext),
+		taskFunc:       taskFunc,
+		shouldRun:      shouldRun,
+		onSkip:         onSkip,
+		maxConcurrency: DEFAULT_PREHEATING_MAX_CONCURRENCY,
+		maxQueueSize:   DEFAULT_PREHEATING_QUEUE_SIZE,
+		maxCount:       MAX_PREHEATING_COUNT,
+		graceTime:      MAX_PREHEATING_GRACE_TIME,
+		interval:       DEFAULT_PREHEATING_INTERVAL,
+		jitter:         DEFAULT_PREHEATING_JITTER,
+	}
+
+	envClient := GetEnvClient()
+	if envClient != nil {
+		if envLimit := envClient.GetInt("PREHEATING_MAX_CONCURRENCY"); envLimit > 0 {
+			s.maxConcurrency = envLimit
+		}
+		if envQueueSize := envClient.GetInt("PREHEATING_QUEUE_SIZE"); envQueueSize > 0 {
+			s.maxQueueSize = envQueueSize
+		}
+	}
+	for _, option := range options {
+		option(s)
+	}
+	s.taskQueue = make(chan string, s.maxQueueSize)
+	for i := 0; i < s.maxConcurrency; i++ {
+		go s.worker()
+	}
+	logrus.Infof("Preheating scheduler initialized with max concurrency: %d, queue size: %d", s.maxConcurrency, s.maxQueueSize)
+	return s
+}
+
 func (s *PreheatingScheduler) ScheduleTask(recipeName string) {
+	s.scheduleTask(recipeName, true)
+}
+
+func (s *PreheatingScheduler) scheduleTask(recipeName string, fromUserRequest bool) {
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 
@@ -47,6 +141,9 @@ func (s *PreheatingScheduler) ScheduleTask(recipeName string) {
 	now := time.Now()
 
 	if !exists {
+		if !fromUserRequest {
+			return
+		}
 		ctx = &PreheatingContext{
 			taskKey:          recipeName,
 			firstRequestTime: now,
@@ -54,57 +151,129 @@ func (s *PreheatingScheduler) ScheduleTask(recipeName string) {
 			preheatingCount:  0,
 		}
 		s.contexts[recipeName] = ctx
-	} else {
+	} else if fromUserRequest {
 		ctx.lastRequestTime = now
+		ctx.preheatingCount = 0
 	}
 
 	// 如果存在旧的定时器，先停止
 	if ctx.timer != nil {
 		ctx.timer.Stop()
+		ctx.timer = nil
 	}
 
 	// 检查是否超过时间窗口或预热次数上限
-	if now.Sub(ctx.firstRequestTime) > MAX_PREHEATING_GRACE_TIME ||
-		ctx.preheatingCount >= MAX_PREHEATING_COUNT {
+	if now.Sub(ctx.lastRequestTime) > s.graceTime ||
+		ctx.preheatingCount >= s.maxCount {
 		delete(s.contexts, recipeName)
 		return
 	}
 
 	// 设置下一次预热
-	ctx.preheatingCount++
-	nextPreheatingTime := ctx.firstRequestTime.Add(time.Duration(ctx.preheatingCount) * DEFAULT_PREHEATING_INTERVAL)
-	nextPreheatingTime = nextPreheatingTime.Add(time.Duration(rand.Intn(60)) * time.Second) // 添加一个随机的等待时间,避免短时间大量请求集中
-
-	nextRun := nextPreheatingTime.Sub(now)
+	nextRun := s.interval + s.randomJitter()
+	timerVersion := s.timerVersion.Add(1)
+	ctx.timerVersion = timerVersion
 	logrus.Debugf("next run after %s", nextRun.String())
 	//创建新的定时器
 	timer := time.AfterFunc(nextRun, func() {
-		// 执行预热任务
-		go func() {
-			logrus.Infof("running preheating task...(this is [#%d] preheating for key [%s])", ctx.preheatingCount, ctx.taskKey)
-
-			s.mutex.Lock()
-			_, taskExist := s.contexts[recipeName]
-			s.mutex.Unlock()
-			if !taskExist {
-				return
-			}
-
-			if s.shouldRun != nil && !s.shouldRun(recipeName) {
-				if s.onSkip != nil {
-					s.onSkip(recipeName)
-				}
-				return
-			}
-
-			err := s.taskFunc(recipeName)
-			if err != nil {
-				logrus.Errorf("preheating task for recipe [%s] exec failed. err: %v", recipeName, err)
-			}
-			s.ScheduleTask(recipeName)
-		}()
+		s.enqueueTask(recipeName, timerVersion)
 	})
 	ctx.timer = timer
+}
+
+func (s *PreheatingScheduler) randomJitter() time.Duration {
+	if s.jitter <= 0 {
+		return 0
+	}
+	return time.Duration(rand.Int63n(int64(s.jitter)))
+}
+
+func (s *PreheatingScheduler) enqueueTask(recipeName string, timerVersion uint64) {
+	s.mutex.Lock()
+	ctx, taskExist := s.contexts[recipeName]
+	if !taskExist || ctx.timerVersion != timerVersion {
+		s.mutex.Unlock()
+		return
+	}
+	ctx.timer = nil
+	if ctx.running || ctx.queued {
+		s.mutex.Unlock()
+		logrus.Debugf("skip enqueueing duplicate preheating task for recipe [%s]", recipeName)
+		return
+	}
+	ctx.queued = true
+	s.mutex.Unlock()
+
+	s.taskQueue <- recipeName
+}
+
+func (s *PreheatingScheduler) worker() {
+	for recipeName := range s.taskQueue {
+		if !s.markTaskRunning(recipeName) {
+			continue
+		}
+		s.runTask(recipeName)
+	}
+}
+
+func (s *PreheatingScheduler) markTaskRunning(recipeName string) bool {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	ctx, taskExist := s.contexts[recipeName]
+	if !taskExist {
+		return false
+	}
+	if ctx.running {
+		ctx.queued = false
+		return false
+	}
+	ctx.queued = false
+	ctx.running = true
+	ctx.preheatingCount++
+	logrus.Infof("running preheating task...(this is [#%d] preheating for key [%s])", ctx.preheatingCount, ctx.taskKey)
+	return true
+}
+
+func (s *PreheatingScheduler) runTask(recipeName string) {
+	shouldReschedule := true
+	defer func() {
+		if r := recover(); r != nil {
+			logrus.Errorf("preheating task for recipe [%s] panicked: %v", recipeName, r)
+		}
+		s.finishTask(recipeName, shouldReschedule)
+	}()
+
+	if s.shouldRun != nil && !s.shouldRun(recipeName) {
+		if s.onSkip != nil {
+			s.onSkip(recipeName)
+		}
+		shouldReschedule = false
+		return
+	}
+
+	err := s.taskFunc(recipeName)
+	if err != nil {
+		logrus.Errorf("preheating task for recipe [%s] exec failed. err: %v", recipeName, err)
+	}
+}
+
+func (s *PreheatingScheduler) finishTask(recipeName string, shouldReschedule bool) {
+	s.mutex.Lock()
+	ctx, taskExist := s.contexts[recipeName]
+	if !taskExist {
+		s.mutex.Unlock()
+		return
+	}
+	ctx.running = false
+	if !shouldReschedule {
+		delete(s.contexts, recipeName)
+		s.mutex.Unlock()
+		return
+	}
+	s.mutex.Unlock()
+
+	s.scheduleTask(recipeName, false)
 }
 
 type PreheatingTaskInfo struct {
@@ -113,8 +282,8 @@ type PreheatingTaskInfo struct {
 }
 
 func (s *PreheatingScheduler) GetContextInfo(key string) PreheatingTaskInfo {
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
+	s.mutex.RLock()
+	defer s.mutex.RUnlock()
 	ctx, ok := s.contexts[key]
 	if !ok {
 		return PreheatingTaskInfo{

--- a/internal/util/preheating_test.go
+++ b/internal/util/preheating_test.go
@@ -56,6 +56,7 @@ func TestPreheatingScheduler_DeduplicatesSameRecipeWhileRunning(t *testing.T) {
 	started := make(chan struct{})
 	release := make(chan struct{})
 	done := make(chan struct{})
+	var doneOnce sync.Once
 	var runCount int32
 
 	scheduler := NewPreheatingScheduler(func(payload string) error {
@@ -63,12 +64,14 @@ func TestPreheatingScheduler_DeduplicatesSameRecipeWhileRunning(t *testing.T) {
 			close(started)
 		}
 		<-release
-		close(done)
+		doneOnce.Do(func() {
+			close(done)
+		})
 		return nil
 	}, nil, nil,
 		WithPreheatingMaxConcurrency(1),
 		WithPreheatingQueueSize(10),
-		WithPreheatingInterval(time.Millisecond),
+		WithPreheatingInterval(50*time.Millisecond),
 		WithPreheatingJitter(0),
 		WithPreheatingMaxCount(1),
 		WithPreheatingGraceTime(time.Hour),
@@ -130,5 +133,56 @@ func TestPreheatingScheduler_UserRequestsDoNotConsumePreheatingCount(t *testing.
 	case <-done:
 	case <-time.After(time.Second):
 		t.Fatal("frequent user requests consumed the preheating count before any preheating task ran")
+	}
+}
+
+func TestPreheatingScheduler_UserRequestInvalidatesQueuedTask(t *testing.T) {
+	blockerStarted := make(chan struct{})
+	releaseBlocker := make(chan struct{})
+	var targetRuns int32
+
+	scheduler := NewPreheatingScheduler(func(payload string) error {
+		if payload == "blocker" {
+			close(blockerStarted)
+			<-releaseBlocker
+			return nil
+		}
+		atomic.AddInt32(&targetRuns, 1)
+		return nil
+	}, nil, nil,
+		WithPreheatingMaxConcurrency(1),
+		WithPreheatingQueueSize(10),
+		WithPreheatingInterval(20*time.Millisecond),
+		WithPreheatingJitter(0),
+		WithPreheatingMaxCount(1),
+		WithPreheatingGraceTime(time.Hour),
+	)
+
+	scheduler.ScheduleTask("blocker")
+	select {
+	case <-blockerStarted:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for blocker preheating task to start")
+	}
+
+	scheduler.ScheduleTask("target")
+	time.Sleep(40 * time.Millisecond)
+
+	scheduler.ScheduleTask("target")
+	close(releaseBlocker)
+
+	time.Sleep(10 * time.Millisecond)
+	if got := atomic.LoadInt32(&targetRuns); got != 0 {
+		t.Fatalf("expected stale queued target task to be invalidated, got %d runs", got)
+	}
+
+	deadline := time.After(time.Second)
+	for atomic.LoadInt32(&targetRuns) == 0 {
+		select {
+		case <-deadline:
+			t.Fatal("timed out waiting for refreshed target task to run")
+		default:
+			time.Sleep(time.Millisecond)
+		}
 	}
 }

--- a/internal/util/preheating_test.go
+++ b/internal/util/preheating_test.go
@@ -1,6 +1,7 @@
 package util
 
 import (
+	"context"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -14,7 +15,7 @@ func TestPreheatingScheduler_LimitsConcurrencyAndQueues(t *testing.T) {
 	var completed int32
 	done := make(chan struct{})
 
-	scheduler := NewPreheatingScheduler(func(payload string) error {
+	scheduler := NewPreheatingScheduler(func(_ context.Context, payload string) error {
 		current := atomic.AddInt32(&running, 1)
 		for {
 			previous := atomic.LoadInt32(&maxRunning)
@@ -59,7 +60,7 @@ func TestPreheatingScheduler_DeduplicatesSameRecipeWhileRunning(t *testing.T) {
 	var doneOnce sync.Once
 	var runCount int32
 
-	scheduler := NewPreheatingScheduler(func(payload string) error {
+	scheduler := NewPreheatingScheduler(func(_ context.Context, payload string) error {
 		if atomic.AddInt32(&runCount, 1) == 1 {
 			close(started)
 		}
@@ -111,7 +112,7 @@ func TestPreheatingScheduler_UserRequestsDoNotConsumePreheatingCount(t *testing.
 	done := make(chan struct{})
 	var runCount int32
 
-	scheduler := NewPreheatingScheduler(func(payload string) error {
+	scheduler := NewPreheatingScheduler(func(_ context.Context, payload string) error {
 		if atomic.AddInt32(&runCount, 1) == 1 {
 			close(done)
 		}
@@ -141,7 +142,7 @@ func TestPreheatingScheduler_UserRequestInvalidatesQueuedTask(t *testing.T) {
 	releaseBlocker := make(chan struct{})
 	var targetRuns int32
 
-	scheduler := NewPreheatingScheduler(func(payload string) error {
+	scheduler := NewPreheatingScheduler(func(_ context.Context, payload string) error {
 		if payload == "blocker" {
 			close(blockerStarted)
 			<-releaseBlocker
@@ -184,5 +185,49 @@ func TestPreheatingScheduler_UserRequestInvalidatesQueuedTask(t *testing.T) {
 		default:
 			time.Sleep(time.Millisecond)
 		}
+	}
+}
+
+func TestPreheatingScheduler_TaskTimeoutReleasesWorker(t *testing.T) {
+	slowStarted := make(chan struct{})
+	slowCancelled := make(chan struct{})
+	fastCompleted := make(chan struct{})
+
+	scheduler := NewPreheatingScheduler(func(ctx context.Context, payload string) error {
+		if payload == "slow" {
+			close(slowStarted)
+			<-ctx.Done()
+			close(slowCancelled)
+			return ctx.Err()
+		}
+		close(fastCompleted)
+		return nil
+	}, nil, nil,
+		WithPreheatingMaxConcurrency(1),
+		WithPreheatingQueueSize(10),
+		WithPreheatingInterval(time.Millisecond),
+		WithPreheatingJitter(0),
+		WithPreheatingMaxCount(1),
+		WithPreheatingGraceTime(time.Hour),
+		WithPreheatingTaskTimeout(20*time.Millisecond),
+	)
+
+	scheduler.ScheduleTask("slow")
+	select {
+	case <-slowStarted:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for slow task to start")
+	}
+
+	scheduler.ScheduleTask("fast")
+	select {
+	case <-slowCancelled:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for slow task context cancellation")
+	}
+	select {
+	case <-fastCompleted:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for worker to execute queued task after cancellation")
 	}
 }

--- a/internal/util/preheating_test.go
+++ b/internal/util/preheating_test.go
@@ -14,7 +14,7 @@ func TestPreheatingScheduler_DefaultQueueSizeMatchesConcurrency(t *testing.T) {
 	scheduler := NewPreheatingScheduler(func(context.Context, string) error {
 		return nil
 	}, nil, nil, WithPreheatingMaxConcurrency(3))
-	t.Cleanup(scheduler.Close)
+	registerPreheatingSchedulerCleanup(t, scheduler)
 
 	if got := cap(scheduler.taskQueue); got != 3 {
 		t.Fatalf("expected default queue size to match concurrency 3, got %d", got)
@@ -50,7 +50,7 @@ func TestPreheatingScheduler_LimitsConcurrencyAndQueues(t *testing.T) {
 		WithPreheatingMaxCount(1),
 		WithPreheatingGraceTime(time.Hour),
 	)
-	t.Cleanup(scheduler.Close)
+	registerPreheatingSchedulerCleanup(t, scheduler)
 
 	for i := 0; i < taskCount; i++ {
 		scheduler.ScheduleTask(string(rune('a' + i)))
@@ -96,7 +96,7 @@ func TestPreheatingScheduler_FullQueueDropsNewestTask(t *testing.T) {
 		WithPreheatingMaxCount(1),
 		WithPreheatingGraceTime(time.Hour),
 	)
-	t.Cleanup(scheduler.Close)
+	registerPreheatingSchedulerCleanup(t, scheduler)
 
 	scheduler.ScheduleTask("blocker")
 	select {
@@ -157,7 +157,7 @@ func TestPreheatingScheduler_AcceptedTasksRemainFIFO(t *testing.T) {
 		WithPreheatingMaxCount(1),
 		WithPreheatingGraceTime(time.Hour),
 	)
-	t.Cleanup(scheduler.Close)
+	registerPreheatingSchedulerCleanup(t, scheduler)
 
 	scheduler.ScheduleTask("blocker")
 	select {
@@ -232,7 +232,7 @@ func TestPreheatingScheduler_DeduplicatesSameRecipeWhileRunning(t *testing.T) {
 		WithPreheatingMaxCount(1),
 		WithPreheatingGraceTime(time.Hour),
 	)
-	t.Cleanup(scheduler.Close)
+	registerPreheatingSchedulerCleanup(t, scheduler)
 
 	scheduler.ScheduleTask("same")
 	select {
@@ -281,7 +281,7 @@ func TestPreheatingScheduler_UserRequestsDoNotConsumePreheatingCount(t *testing.
 		WithPreheatingMaxCount(1),
 		WithPreheatingGraceTime(time.Hour),
 	)
-	t.Cleanup(scheduler.Close)
+	registerPreheatingSchedulerCleanup(t, scheduler)
 
 	for i := 0; i < 5; i++ {
 		scheduler.ScheduleTask("frequent")
@@ -315,7 +315,7 @@ func TestPreheatingScheduler_UserRequestInvalidatesQueuedTask(t *testing.T) {
 		WithPreheatingMaxCount(1),
 		WithPreheatingGraceTime(time.Hour),
 	)
-	t.Cleanup(scheduler.Close)
+	registerPreheatingSchedulerCleanup(t, scheduler)
 
 	scheduler.ScheduleTask("blocker")
 	select {
@@ -369,7 +369,7 @@ func TestPreheatingScheduler_TaskTimeoutReleasesWorker(t *testing.T) {
 		WithPreheatingGraceTime(time.Hour),
 		WithPreheatingTaskTimeout(20*time.Millisecond),
 	)
-	t.Cleanup(scheduler.Close)
+	registerPreheatingSchedulerCleanup(t, scheduler)
 
 	scheduler.ScheduleTask("slow")
 	select {
@@ -405,6 +405,7 @@ func TestPreheatingScheduler_CloseStopsTimersAndRejectsNewTasks(t *testing.T) {
 	scheduler.ScheduleTask("scheduled")
 	scheduler.Close()
 	scheduler.Close()
+	scheduler.Wait()
 	scheduler.ScheduleTask("after-close")
 
 	if scheduler.GetContextInfo("scheduled").IsActive {
@@ -445,7 +446,7 @@ func TestPreheatingScheduler_CloseCancelsRunningTaskAndWaitsForWorker(t *testing
 
 	workersStopped := make(chan struct{})
 	go func() {
-		scheduler.workers.Wait()
+		scheduler.Wait()
 		close(workersStopped)
 	}()
 
@@ -480,6 +481,15 @@ func TestPreheatingScheduler_CloseFromTaskDoesNotDeadlock(t *testing.T) {
 	case <-time.After(time.Second):
 		t.Fatal("timed out waiting for Close called from task callback")
 	}
+	scheduler.Wait()
+}
+
+func registerPreheatingSchedulerCleanup(t *testing.T, scheduler *PreheatingScheduler) {
+	t.Helper()
+	t.Cleanup(func() {
+		scheduler.Close()
+		scheduler.Wait()
+	})
 }
 
 func waitForPreheatingCondition(t *testing.T, condition func() bool, failureMessage string) {

--- a/internal/util/preheating_test.go
+++ b/internal/util/preheating_test.go
@@ -14,6 +14,7 @@ func TestPreheatingScheduler_DefaultQueueSizeMatchesConcurrency(t *testing.T) {
 	scheduler := NewPreheatingScheduler(func(context.Context, string) error {
 		return nil
 	}, nil, nil, WithPreheatingMaxConcurrency(3))
+	t.Cleanup(scheduler.Close)
 
 	if got := cap(scheduler.taskQueue); got != 3 {
 		t.Fatalf("expected default queue size to match concurrency 3, got %d", got)
@@ -49,6 +50,7 @@ func TestPreheatingScheduler_LimitsConcurrencyAndQueues(t *testing.T) {
 		WithPreheatingMaxCount(1),
 		WithPreheatingGraceTime(time.Hour),
 	)
+	t.Cleanup(scheduler.Close)
 
 	for i := 0; i < taskCount; i++ {
 		scheduler.ScheduleTask(string(rune('a' + i)))
@@ -94,6 +96,7 @@ func TestPreheatingScheduler_FullQueueDropsNewestTask(t *testing.T) {
 		WithPreheatingMaxCount(1),
 		WithPreheatingGraceTime(time.Hour),
 	)
+	t.Cleanup(scheduler.Close)
 
 	scheduler.ScheduleTask("blocker")
 	select {
@@ -154,6 +157,7 @@ func TestPreheatingScheduler_AcceptedTasksRemainFIFO(t *testing.T) {
 		WithPreheatingMaxCount(1),
 		WithPreheatingGraceTime(time.Hour),
 	)
+	t.Cleanup(scheduler.Close)
 
 	scheduler.ScheduleTask("blocker")
 	select {
@@ -228,6 +232,7 @@ func TestPreheatingScheduler_DeduplicatesSameRecipeWhileRunning(t *testing.T) {
 		WithPreheatingMaxCount(1),
 		WithPreheatingGraceTime(time.Hour),
 	)
+	t.Cleanup(scheduler.Close)
 
 	scheduler.ScheduleTask("same")
 	select {
@@ -276,6 +281,7 @@ func TestPreheatingScheduler_UserRequestsDoNotConsumePreheatingCount(t *testing.
 		WithPreheatingMaxCount(1),
 		WithPreheatingGraceTime(time.Hour),
 	)
+	t.Cleanup(scheduler.Close)
 
 	for i := 0; i < 5; i++ {
 		scheduler.ScheduleTask("frequent")
@@ -309,6 +315,7 @@ func TestPreheatingScheduler_UserRequestInvalidatesQueuedTask(t *testing.T) {
 		WithPreheatingMaxCount(1),
 		WithPreheatingGraceTime(time.Hour),
 	)
+	t.Cleanup(scheduler.Close)
 
 	scheduler.ScheduleTask("blocker")
 	select {
@@ -362,6 +369,7 @@ func TestPreheatingScheduler_TaskTimeoutReleasesWorker(t *testing.T) {
 		WithPreheatingGraceTime(time.Hour),
 		WithPreheatingTaskTimeout(20*time.Millisecond),
 	)
+	t.Cleanup(scheduler.Close)
 
 	scheduler.ScheduleTask("slow")
 	select {
@@ -380,6 +388,74 @@ func TestPreheatingScheduler_TaskTimeoutReleasesWorker(t *testing.T) {
 	case <-fastCompleted:
 	case <-time.After(time.Second):
 		t.Fatal("timed out waiting for worker to execute queued task after cancellation")
+	}
+}
+
+func TestPreheatingScheduler_CloseStopsTimersAndRejectsNewTasks(t *testing.T) {
+	var runCount int32
+	scheduler := NewPreheatingScheduler(func(context.Context, string) error {
+		atomic.AddInt32(&runCount, 1)
+		return nil
+	}, nil, nil,
+		WithPreheatingMaxConcurrency(1),
+		WithPreheatingInterval(50*time.Millisecond),
+		WithPreheatingJitter(0),
+	)
+
+	scheduler.ScheduleTask("scheduled")
+	scheduler.Close()
+	scheduler.Close()
+	scheduler.ScheduleTask("after-close")
+
+	if scheduler.GetContextInfo("scheduled").IsActive {
+		t.Fatal("expected Close to clear scheduled task context")
+	}
+	if scheduler.GetContextInfo("after-close").IsActive {
+		t.Fatal("expected scheduler to reject tasks after Close")
+	}
+	time.Sleep(75 * time.Millisecond)
+	if got := atomic.LoadInt32(&runCount); got != 0 {
+		t.Fatalf("expected stopped timers not to execute tasks, got %d runs", got)
+	}
+}
+
+func TestPreheatingScheduler_CloseCancelsRunningTaskAndWaitsForWorker(t *testing.T) {
+	started := make(chan struct{})
+	cancelled := make(chan struct{})
+	closed := make(chan struct{})
+
+	scheduler := NewPreheatingScheduler(func(ctx context.Context, _ string) error {
+		close(started)
+		<-ctx.Done()
+		close(cancelled)
+		return ctx.Err()
+	}, nil, nil,
+		WithPreheatingMaxConcurrency(1),
+		WithPreheatingInterval(time.Millisecond),
+		WithPreheatingJitter(0),
+	)
+
+	scheduler.ScheduleTask("running")
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for task to start")
+	}
+
+	go func() {
+		scheduler.Close()
+		close(closed)
+	}()
+
+	select {
+	case <-cancelled:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for Close to cancel running task")
+	}
+	select {
+	case <-closed:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for Close to stop worker")
 	}
 }
 

--- a/internal/util/preheating_test.go
+++ b/internal/util/preheating_test.go
@@ -8,6 +8,18 @@ import (
 	"time"
 )
 
+func TestPreheatingScheduler_DefaultQueueSizeMatchesConcurrency(t *testing.T) {
+	t.Setenv("FC_PREHEATING_QUEUE_SIZE", "")
+
+	scheduler := NewPreheatingScheduler(func(context.Context, string) error {
+		return nil
+	}, nil, nil, WithPreheatingMaxConcurrency(3))
+
+	if got := cap(scheduler.taskQueue); got != 3 {
+		t.Fatalf("expected default queue size to match concurrency 3, got %d", got)
+	}
+}
+
 func TestPreheatingScheduler_LimitsConcurrencyAndQueues(t *testing.T) {
 	const taskCount = 6
 	var running int32
@@ -50,6 +62,70 @@ func TestPreheatingScheduler_LimitsConcurrencyAndQueues(t *testing.T) {
 
 	if got := atomic.LoadInt32(&maxRunning); got > 2 {
 		t.Fatalf("expected at most 2 concurrent tasks, got %d", got)
+	}
+}
+
+func TestPreheatingScheduler_FullQueueDropsNewestTask(t *testing.T) {
+	blockerStarted := make(chan struct{})
+	releaseBlocker := make(chan struct{})
+	queuedCompleted := make(chan struct{})
+	var releaseOnce sync.Once
+	var droppedRuns int32
+	defer releaseOnce.Do(func() {
+		close(releaseBlocker)
+	})
+
+	scheduler := NewPreheatingScheduler(func(_ context.Context, payload string) error {
+		switch payload {
+		case "blocker":
+			close(blockerStarted)
+			<-releaseBlocker
+		case "queued":
+			close(queuedCompleted)
+		case "dropped":
+			atomic.AddInt32(&droppedRuns, 1)
+		}
+		return nil
+	}, nil, nil,
+		WithPreheatingMaxConcurrency(1),
+		WithPreheatingQueueSize(1),
+		WithPreheatingInterval(time.Millisecond),
+		WithPreheatingJitter(0),
+		WithPreheatingMaxCount(1),
+		WithPreheatingGraceTime(time.Hour),
+	)
+
+	scheduler.ScheduleTask("blocker")
+	select {
+	case <-blockerStarted:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for blocker preheating task to start")
+	}
+
+	scheduler.ScheduleTask("queued")
+	waitForPreheatingCondition(t, func() bool {
+		return len(scheduler.taskQueue) == 1
+	}, "timed out waiting for task to fill preheating queue")
+
+	scheduler.ScheduleTask("dropped")
+	waitForPreheatingCondition(t, func() bool {
+		return !scheduler.GetContextInfo("dropped").IsActive
+	}, "timed out waiting for full queue to reject newest task")
+
+	if got := len(scheduler.taskQueue); got != 1 {
+		t.Fatalf("expected accepted queued task to remain in queue, got queue length %d", got)
+	}
+
+	releaseOnce.Do(func() {
+		close(releaseBlocker)
+	})
+	select {
+	case <-queuedCompleted:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for previously queued task to execute")
+	}
+	if got := atomic.LoadInt32(&droppedRuns); got != 0 {
+		t.Fatalf("expected rejected task not to execute, got %d runs", got)
 	}
 }
 
@@ -230,4 +306,17 @@ func TestPreheatingScheduler_TaskTimeoutReleasesWorker(t *testing.T) {
 	case <-time.After(time.Second):
 		t.Fatal("timed out waiting for worker to execute queued task after cancellation")
 	}
+}
+
+func waitForPreheatingCondition(t *testing.T, condition func() bool, failureMessage string) {
+	t.Helper()
+
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		if condition() {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatal(failureMessage)
 }

--- a/internal/util/preheating_test.go
+++ b/internal/util/preheating_test.go
@@ -422,7 +422,6 @@ func TestPreheatingScheduler_CloseStopsTimersAndRejectsNewTasks(t *testing.T) {
 func TestPreheatingScheduler_CloseCancelsRunningTaskAndWaitsForWorker(t *testing.T) {
 	started := make(chan struct{})
 	cancelled := make(chan struct{})
-	closed := make(chan struct{})
 
 	scheduler := NewPreheatingScheduler(func(ctx context.Context, _ string) error {
 		close(started)
@@ -442,9 +441,12 @@ func TestPreheatingScheduler_CloseCancelsRunningTaskAndWaitsForWorker(t *testing
 		t.Fatal("timed out waiting for task to start")
 	}
 
+	scheduler.Close()
+
+	workersStopped := make(chan struct{})
 	go func() {
-		scheduler.Close()
-		close(closed)
+		scheduler.workers.Wait()
+		close(workersStopped)
 	}()
 
 	select {
@@ -453,9 +455,30 @@ func TestPreheatingScheduler_CloseCancelsRunningTaskAndWaitsForWorker(t *testing
 		t.Fatal("timed out waiting for Close to cancel running task")
 	}
 	select {
-	case <-closed:
+	case <-workersStopped:
 	case <-time.After(time.Second):
 		t.Fatal("timed out waiting for Close to stop worker")
+	}
+}
+
+func TestPreheatingScheduler_CloseFromTaskDoesNotDeadlock(t *testing.T) {
+	closeReturned := make(chan struct{})
+	var scheduler *PreheatingScheduler
+	scheduler = NewPreheatingScheduler(func(context.Context, string) error {
+		scheduler.Close()
+		close(closeReturned)
+		return nil
+	}, nil, nil,
+		WithPreheatingMaxConcurrency(1),
+		WithPreheatingInterval(time.Millisecond),
+		WithPreheatingJitter(0),
+	)
+
+	scheduler.ScheduleTask("self-close")
+	select {
+	case <-closeReturned:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for Close called from task callback")
 	}
 }
 

--- a/internal/util/preheating_test.go
+++ b/internal/util/preheating_test.go
@@ -129,6 +129,81 @@ func TestPreheatingScheduler_FullQueueDropsNewestTask(t *testing.T) {
 	}
 }
 
+func TestPreheatingScheduler_AcceptedTasksRemainFIFO(t *testing.T) {
+	blockerStarted := make(chan struct{})
+	releaseBlocker := make(chan struct{})
+	order := make(chan string, 2)
+	var releaseOnce sync.Once
+	defer releaseOnce.Do(func() {
+		close(releaseBlocker)
+	})
+
+	scheduler := NewPreheatingScheduler(func(_ context.Context, payload string) error {
+		if payload == "blocker" {
+			close(blockerStarted)
+			<-releaseBlocker
+			return nil
+		}
+		order <- payload
+		return nil
+	}, nil, nil,
+		WithPreheatingMaxConcurrency(1),
+		WithPreheatingQueueSize(2),
+		WithPreheatingInterval(time.Millisecond),
+		WithPreheatingJitter(0),
+		WithPreheatingMaxCount(1),
+		WithPreheatingGraceTime(time.Hour),
+	)
+
+	scheduler.ScheduleTask("blocker")
+	select {
+	case <-blockerStarted:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for blocker preheating task to start")
+	}
+
+	scheduler.ScheduleTask("first")
+	waitForPreheatingCondition(t, func() bool {
+		return len(scheduler.taskQueue) == 1
+	}, "timed out waiting for first queued task")
+	scheduler.ScheduleTask("second")
+	waitForPreheatingCondition(t, func() bool {
+		return len(scheduler.taskQueue) == 2
+	}, "timed out waiting for second queued task")
+
+	releaseOnce.Do(func() {
+		close(releaseBlocker)
+	})
+	for _, expected := range []string{"first", "second"} {
+		select {
+		case actual := <-order:
+			if actual != expected {
+				t.Fatalf("expected FIFO task %q, got %q", expected, actual)
+			}
+		case <-time.After(time.Second):
+			t.Fatalf("timed out waiting for FIFO task %q", expected)
+		}
+	}
+}
+
+func TestPreheatingScheduler_DiscardQueuedTaskPreservesNewerVersion(t *testing.T) {
+	scheduler := &PreheatingScheduler{
+		contexts: map[string]*PreheatingContext{
+			"recipe": {
+				taskKey:      "recipe",
+				timerVersion: 2,
+				queued:       true,
+			},
+		},
+	}
+
+	scheduler.discardQueuedTask("recipe", 1)
+
+	if !scheduler.GetContextInfo("recipe").IsActive {
+		t.Fatal("expected cleanup for stale timer version to preserve newer context")
+	}
+}
+
 func TestPreheatingScheduler_DeduplicatesSameRecipeWhileRunning(t *testing.T) {
 	started := make(chan struct{})
 	release := make(chan struct{})

--- a/internal/util/preheating_test.go
+++ b/internal/util/preheating_test.go
@@ -1,0 +1,134 @@
+package util
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestPreheatingScheduler_LimitsConcurrencyAndQueues(t *testing.T) {
+	const taskCount = 6
+	var running int32
+	var maxRunning int32
+	var completed int32
+	done := make(chan struct{})
+
+	scheduler := NewPreheatingScheduler(func(payload string) error {
+		current := atomic.AddInt32(&running, 1)
+		for {
+			previous := atomic.LoadInt32(&maxRunning)
+			if current <= previous || atomic.CompareAndSwapInt32(&maxRunning, previous, current) {
+				break
+			}
+		}
+		time.Sleep(20 * time.Millisecond)
+		atomic.AddInt32(&running, -1)
+		if atomic.AddInt32(&completed, 1) == taskCount {
+			close(done)
+		}
+		return nil
+	}, nil, nil,
+		WithPreheatingMaxConcurrency(2),
+		WithPreheatingQueueSize(taskCount),
+		WithPreheatingInterval(time.Millisecond),
+		WithPreheatingJitter(0),
+		WithPreheatingMaxCount(1),
+		WithPreheatingGraceTime(time.Hour),
+	)
+
+	for i := 0; i < taskCount; i++ {
+		scheduler.ScheduleTask(string(rune('a' + i)))
+	}
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatalf("timed out waiting for queued preheating tasks, completed=%d", atomic.LoadInt32(&completed))
+	}
+
+	if got := atomic.LoadInt32(&maxRunning); got > 2 {
+		t.Fatalf("expected at most 2 concurrent tasks, got %d", got)
+	}
+}
+
+func TestPreheatingScheduler_DeduplicatesSameRecipeWhileRunning(t *testing.T) {
+	started := make(chan struct{})
+	release := make(chan struct{})
+	done := make(chan struct{})
+	var runCount int32
+
+	scheduler := NewPreheatingScheduler(func(payload string) error {
+		if atomic.AddInt32(&runCount, 1) == 1 {
+			close(started)
+		}
+		<-release
+		close(done)
+		return nil
+	}, nil, nil,
+		WithPreheatingMaxConcurrency(1),
+		WithPreheatingQueueSize(10),
+		WithPreheatingInterval(time.Millisecond),
+		WithPreheatingJitter(0),
+		WithPreheatingMaxCount(1),
+		WithPreheatingGraceTime(time.Hour),
+	)
+
+	scheduler.ScheduleTask("same")
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for first preheating task to start")
+	}
+
+	var wg sync.WaitGroup
+	for i := 0; i < 5; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			scheduler.ScheduleTask("same")
+		}()
+	}
+	wg.Wait()
+	time.Sleep(10 * time.Millisecond)
+	close(release)
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for preheating task to finish")
+	}
+
+	if got := atomic.LoadInt32(&runCount); got != 1 {
+		t.Fatalf("expected duplicate schedules for the same recipe to be coalesced while running, got %d runs", got)
+	}
+}
+
+func TestPreheatingScheduler_UserRequestsDoNotConsumePreheatingCount(t *testing.T) {
+	done := make(chan struct{})
+	var runCount int32
+
+	scheduler := NewPreheatingScheduler(func(payload string) error {
+		if atomic.AddInt32(&runCount, 1) == 1 {
+			close(done)
+		}
+		return nil
+	}, nil, nil,
+		WithPreheatingMaxConcurrency(1),
+		WithPreheatingQueueSize(10),
+		WithPreheatingInterval(20*time.Millisecond),
+		WithPreheatingJitter(0),
+		WithPreheatingMaxCount(1),
+		WithPreheatingGraceTime(time.Hour),
+	)
+
+	for i := 0; i < 5; i++ {
+		scheduler.ScheduleTask("frequent")
+	}
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("frequent user requests consumed the preheating count before any preheating task ran")
+	}
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Bound preheating concurrency and pending capacity; reject newest best-effort work without blocking timer goroutines when saturated.
- Add an idempotent, non-blocking scheduler `Close()` plus explicit `Wait()` lifecycle; stop timers, clear contexts, cancel active tasks, and shut down before observability.
- Coalesce duplicate work, discard stale timer versions, and propagate configurable task timeouts into recipe processing.
- Keep advanced preheating settings out of `.env.example`; document them briefly in all advanced-customization locales.
- Cover saturation, FIFO, stale-version cleanup, timeout recovery, timer shutdown, active cancellation, repeated close, and self-close behavior.

### Testing
- `go test ./internal/util`
- `go test -race ./internal/util`
- `go test ./internal/util -run Preheating -count=20`
- `go test ./...`
- `task fix`
- `task backend-build`
- `task frontend-build`
- `task docs-build`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ee7075dc-7df6-4cc4-ae42-ba0eb53f3b89"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ee7075dc-7df6-4cc4-ae42-ba0eb53f3b89"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

## Summary by Sourcery

Introduce a configurable, concurrency-limited preheating scheduler with queued task execution and improved lifecycle handling for recipe preheating.

New Features:
- Add configuration options for preheating scheduler concurrency, queue size, interval, jitter, max count, and grace time with sensible defaults and environment overrides.

Enhancements:
- Replace direct goroutine spawning with a bounded worker-queue model for preheating tasks to control concurrency and avoid unbounded background work.
- Coalesce duplicate preheating tasks for the same recipe while queued or running, and version timer callbacks so stale scheduled work is discarded.
- Adjust preheating accounting so only completed preheating executions increment the preheating count, and improve context access with read locks.

Tests:
- Add focused unit tests covering scheduler concurrency limits, task queuing, duplicate deduplication, user-request handling of preheating counts, and invalidation/rescheduling of queued tasks.