### PR TITLE
Fix LLM filter cache key inputs

### DIFF
--- a/internal/craft/common_llm_logic.go
+++ b/internal/craft/common_llm_logic.go
@@ -71,8 +71,11 @@ func BuildLLMArticlePayload(title string, content string) string {
 // CheckConditionWithGenericPrompt 使用通用模板构造 prompt 并调用 LLM
 // userPrompt: 用户提供的判断标准，例如 "Is this regarding politics?"
 func CheckConditionWithGenericPrompt(title string, content string, userPrompt string) (bool, error) {
-	// 构造强制要求 true/false 的完整 prompt
-	fullPrompt := fmt.Sprintf(`
+	return CheckConditionWithLLM(title, content, buildGenericConditionPrompt(userPrompt))
+}
+
+func buildGenericConditionPrompt(userPrompt string) string {
+	return fmt.Sprintf(`
 Evaluate the following content based on this criterion:
 "%s"
 
@@ -80,6 +83,4 @@ If the content matches the criterion, return 'true'.
 Otherwise return 'false'.
 Do not include any other text.
 `, userPrompt)
-
-	return CheckConditionWithLLM(title, content, fullPrompt)
 }

--- a/internal/craft/llm_processors.go
+++ b/internal/craft/llm_processors.go
@@ -267,11 +267,14 @@ func newLLMFilterProcessor(condition string) *ArticlePredicateProcessor {
 	if condition == "" {
 		condition = "Is this content spam or low quality?"
 	}
+	fullPrompt := buildGenericConditionPrompt(condition)
 	matcher := GetCommonCachedArticlePredicate(
-		newArticleTitleContentCacheKeyGenerator(condition),
+		newArticleLLMPayloadCacheKeyGenerator(fullPrompt, func(article *model.CraftArticle) string {
+			return BuildLLMArticlePayload(article.Title, getPrimaryArticleContent(article))
+		}),
 		func(ctx context.Context, article *model.CraftArticle) (bool, error) {
 			content := getPrimaryArticleContent(article)
-			return CheckConditionWithGenericPrompt(article.Title, content, condition)
+			return CheckConditionWithLLM(article.Title, content, fullPrompt)
 		},
 		"llm filter",
 	)
@@ -333,6 +336,20 @@ func newArticleTitleContentCacheKeyGenerator(prompt string) ArticleCacheKeyGener
 			strings.TrimSpace(getPrimaryArticleContent(article)),
 		}, "|"))
 		return payloadHash, nil
+	}
+}
+
+func newArticleLLMPayloadCacheKeyGenerator(prompt string, payloadBuilder func(article *model.CraftArticle) string) ArticleCacheKeyGenerator {
+	promptHash := util.GetTextContentHash(prompt)
+	return func(article *model.CraftArticle) (string, error) {
+		payload := ""
+		if payloadBuilder != nil {
+			payload = payloadBuilder(article)
+		}
+		return util.GetTextContentHash(strings.Join([]string{
+			promptHash,
+			util.GetTextContentHash(payload),
+		}, "|")), nil
 	}
 }
 

--- a/internal/craft/runtime_test.go
+++ b/internal/craft/runtime_test.go
@@ -370,6 +370,45 @@ func TestLLMFilterProcessor_RemovesMatchedArticleAndUsesTitleContentPayload(t *t
 	assert.Contains(t, seen[0], "Article Content:")
 }
 
+func TestLLMFilterProcessor_CacheKeyUsesFullPromptAndLLMPayload(t *testing.T) {
+	redis := setupTestRedis(t)
+
+	original := llmContextCaller
+	llmContextCaller = func(prompt, context string, option util.ContentProcessOption) (string, error) {
+		t.Fatalf("expected llm-filter to hit cache, got LLM call with prompt %q and context %q", prompt, context)
+		return "false", nil
+	}
+	t.Cleanup(func() { llmContextCaller = original })
+
+	condition := "filter cached article " + t.Name()
+	title := "Cached Drop " + t.Name()
+	content := "<p>cached body with enough content length for llm filter cache key</p>"
+	fullPrompt := fmt.Sprintf(`
+Evaluate the following content based on this criterion:
+"%s"
+
+If the content matches the criterion, return 'true'.
+Otherwise return 'false'.
+Do not include any other text.
+`, condition)
+	llmPayload := BuildLLMArticlePayload(title, content)
+	hashVal := util.GetTextContentHash(strings.Join([]string{
+		util.GetTextContentHash(fullPrompt),
+		util.GetTextContentHash(llmPayload),
+	}, "|"))
+	redis.SetString(t, getCraftCacheKey("llm filter", hashVal), "true", time.Minute)
+
+	processor := newLLMFilterProcessor(condition)
+	result, err := processor.Process(context.Background(), &model.CraftFeed{
+		Articles: []*model.CraftArticle{
+			{Title: title, Content: content},
+		},
+	})
+
+	require.NoError(t, err)
+	require.Empty(t, result.Articles)
+}
+
 func TestIgnoreAdvertorialProcessor_KeepsArticleOnLLMError(t *testing.T) {
 	setupTestRedis(t)
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Include the rendered llm-filter prompt and exact LLM payload in cache key generation.
- Add a regression test that pre-seeds the expected cache key and verifies the processor does not call the LLM.

### Testing
- `go test ./internal/craft -run TestLLMFilterProcessor_CacheKeyUsesFullPromptAndLLMPayload -count=1`
- `go test ./internal/craft -count=1`
- `task fix`
- `go test ./...`
- `task backend-build`
- `task frontend-build`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b1a48f8b-86e1-4c5c-bba5-b110b8e640d7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b1a48f8b-86e1-4c5c-bba5-b110b8e640d7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

## Summary by Sourcery

Ensure LLM filter caching uses the complete rendered prompt and LLM payload to avoid unnecessary model calls.

Bug Fixes:
- Fix LLM filter cache key generation so that it incorporates both the full generic prompt and the exact LLM article payload, preventing cache misses when content or prompts change.

Enhancements:
- Refactor generic condition prompt construction into a reusable helper and introduce a cache key generator that hashes the rendered prompt together with the LLM payload.

Tests:
- Add a regression test that pre-seeds the LLM filter cache and verifies the processor returns cached results without invoking the LLM.