### PR TITLE
refactor(web): 统一相对引用为 @ 别名路径

### DIFF
--- a/web/admin/src/views/dashboard/feed_viewer/FeedItemCard.vue
+++ b/web/admin/src/views/dashboard/feed_viewer/FeedItemCard.vue
@@ -87,8 +87,8 @@
   import dayjs from 'dayjs';
   import { useI18n } from 'vue-i18n';
   import type { FeedViewerPreviewItem } from '@/api/feed_viewer';
-  import FeedItemContent from './FeedItemContent.vue';
-  import FeedItemDetailModal from './FeedItemDetailModal.vue';
+  import FeedItemContent from '@/views/dashboard/feed_viewer/FeedItemContent.vue';
+  import FeedItemDetailModal from '@/views/dashboard/feed_viewer/FeedItemDetailModal.vue';
 
   export type ViewMode = 'normal' | 'rich' | 'html';
 

--- a/web/admin/src/views/dashboard/feed_viewer/FeedItemDetailModal.vue
+++ b/web/admin/src/views/dashboard/feed_viewer/FeedItemDetailModal.vue
@@ -43,8 +43,8 @@
   import dayjs from 'dayjs';
   import { useI18n } from 'vue-i18n';
   import type { FeedViewerPreviewItem } from '@/api/feed_viewer';
-  import FeedItemContent from './FeedItemContent.vue';
-  import type { ViewMode } from './FeedItemCard.vue';
+  import FeedItemContent from '@/views/dashboard/feed_viewer/FeedItemContent.vue';
+  import type { ViewMode } from '@/views/dashboard/feed_viewer/FeedItemCard.vue';
 
   interface Props {
     item: FeedViewerPreviewItem;

--- a/web/admin/src/views/dashboard/feed_viewer/feed_view_container.vue
+++ b/web/admin/src/views/dashboard/feed_viewer/feed_view_container.vue
@@ -54,8 +54,8 @@
   import { computed, ref } from 'vue';
   import { useI18n } from 'vue-i18n';
   import type { FeedViewerPreview } from '@/api/feed_viewer';
-  import FeedItemCard from './FeedItemCard.vue';
-  import type { ViewMode } from './FeedItemCard.vue';
+  import FeedItemCard from '@/views/dashboard/feed_viewer/FeedItemCard.vue';
+  import type { ViewMode } from '@/views/dashboard/feed_viewer/FeedItemCard.vue';
 
   const MAX_VISIBLE_ITEMS = 20;
 

--- a/web/admin/src/views/dashboard/topic_feed/components/TopicAggregatorEditor.vue
+++ b/web/admin/src/views/dashboard/topic_feed/components/TopicAggregatorEditor.vue
@@ -128,7 +128,7 @@
     type StepType,
     createDefaultStep,
     defaultThreshold,
-  } from '../topicInputUtils';
+  } from '@/views/dashboard/topic_feed/topicInputUtils';
 
   const props = defineProps<{
     modelValue: StepFormItem[];

--- a/web/admin/src/views/dashboard/topic_feed/components/TopicInputSourcesEditor.vue
+++ b/web/admin/src/views/dashboard/topic_feed/components/TopicInputSourcesEditor.vue
@@ -143,7 +143,7 @@
     type InputSourceItem,
     type SourceType,
     sourceToUri,
-  } from '../topicInputUtils';
+  } from '@/views/dashboard/topic_feed/topicInputUtils';
 
   const props = withDefaults(
     defineProps<{

--- a/web/admin/src/views/dashboard/topic_feed/editor.vue
+++ b/web/admin/src/views/dashboard/topic_feed/editor.vue
@@ -198,8 +198,8 @@
   } from '@/api/topic';
   import XHeader from '@/components/header/x-header.vue';
   import { getRecipeIdRules } from '@/utils/slug';
-  import TopicAggregatorEditor from './components/TopicAggregatorEditor.vue';
-  import TopicInputSourcesEditor from './components/TopicInputSourcesEditor.vue';
+  import TopicAggregatorEditor from '@/views/dashboard/topic_feed/components/TopicAggregatorEditor.vue';
+  import TopicInputSourcesEditor from '@/views/dashboard/topic_feed/components/TopicInputSourcesEditor.vue';
   import {
     defaultFormData,
     formatAggregatorSummary,
@@ -207,7 +207,7 @@
     normalizeTopicPayload,
     topicFeedToFormData,
     type TopicFormData,
-  } from './topicInputUtils';
+  } from '@/views/dashboard/topic_feed/topicInputUtils';
 
   const { t } = useI18n();
   const route = useRoute();

--- a/web/admin/src/views/dashboard/topic_feed/topic_feed.vue
+++ b/web/admin/src/views/dashboard/topic_feed/topic_feed.vue
@@ -108,7 +108,7 @@
   import XHeader from '@/components/header/x-header.vue';
   import buildPublicFeedUrl from '@/utils/publicFeedUrl';
   import { TopicFeed, deleteTopicFeed, listTopicFeeds } from '@/api/topic';
-  import { formatAggregatorSummary } from './topicInputUtils';
+  import { formatAggregatorSummary } from '@/views/dashboard/topic_feed/topicInputUtils';
 
   const { t } = useI18n();
   const router = useRouter();


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 背景

前端 `web/admin/src` 中部分模块仍使用 `./` / `../` 形式的相对路径引用，与项目统一使用 `@/`（映射到 `src/`）别名的约定不一致。

## 改动

将 `src/` 下所有相对路径 import 转换为以 `@/` 开头的别名引用，涉及文件：

- `views/dashboard/topic_feed/topic_feed.vue`
- `views/dashboard/topic_feed/editor.vue`
- `views/dashboard/topic_feed/components/TopicInputSourcesEditor.vue`
- `views/dashboard/topic_feed/components/TopicAggregatorEditor.vue`
- `views/dashboard/feed_viewer/feed_view_container.vue`
- `views/dashboard/feed_viewer/FeedItemDetailModal.vue`
- `views/dashboard/feed_viewer/FeedItemCard.vue`

转换后再次全量搜索 `src/`，已无任何 `./` / `../` 相对引用。

## 验证

- `pnpm run type:check` 通过
- `pnpm run lint` 通过（仅遗留与本次无关的 `v-html` 警告）
- `pnpm run build` 成功，模块解析正常

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9f022fc7-c700-47ea-b747-94068031be52"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9f022fc7-c700-47ea-b747-94068031be52"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

## Summary by Sourcery

Unify dashboard topic feed and feed viewer modules to use the '@/src' alias imports instead of relative paths for shared utilities and components.

Enhancements:
- Refactor topic feed views and editors to replace relative imports with '@/views/dashboard/...' alias paths for shared utilities and components.
- Refactor feed viewer container, card, and modal components to use alias-based imports for their internal components and shared types.