### PR TITLE
test(craft): 增加 atom/flow 文章处理链路单元测试

### DIFF
--- a/internal/craft/guid_test.go
+++ b/internal/craft/guid_test.go
@@ -1,0 +1,72 @@
+package craft
+
+import (
+	"testing"
+
+	"FeedCraft/internal/util"
+
+	"github.com/gorilla/feeds"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFeedItemGuidGenerator_DeterministicForSameContent(t *testing.T) {
+	itemA := &feeds.Item{Title: "Hello", Content: "World", Description: "desc"}
+	itemB := &feeds.Item{Title: "Hello", Content: "World", Description: "desc"}
+
+	guidA, err := feedItemGuidGenerator(itemA)
+	require.NoError(t, err)
+	guidB, err := feedItemGuidGenerator(itemB)
+	require.NoError(t, err)
+
+	assert.Equal(t, guidA, guidB)
+	assert.Equal(t, util.GetTextContentHash("HelloWorlddesc"), guidA)
+}
+
+func TestFeedItemGuidGenerator_DiffersWhenContentDiffers(t *testing.T) {
+	guidA, err := feedItemGuidGenerator(&feeds.Item{Title: "Hello", Content: "World"})
+	require.NoError(t, err)
+	guidB, err := feedItemGuidGenerator(&feeds.Item{Title: "Hello", Content: "Mars"})
+	require.NoError(t, err)
+
+	assert.NotEqual(t, guidA, guidB)
+}
+
+func TestFeedItemGuidGenerator_EmptyFieldsYieldUniqueRandomGuids(t *testing.T) {
+	guidA, err := feedItemGuidGenerator(&feeds.Item{})
+	require.NoError(t, err)
+	guidB, err := feedItemGuidGenerator(&feeds.Item{})
+	require.NoError(t, err)
+
+	assert.NotEmpty(t, guidA)
+	assert.NotEmpty(t, guidB)
+	// With no title/content/description, a random uuid is returned each call.
+	assert.NotEqual(t, guidA, guidB)
+}
+
+func TestGetGuidProcessor_OverwritesItemId(t *testing.T) {
+	processor := GetGuidProcessor(func(item *feeds.Item) (string, error) {
+		return "computed-id", nil
+	})
+
+	item := &feeds.Item{Id: "stale", Title: "title"}
+	require.NoError(t, processor(item, ExtraPayload{}))
+	assert.Equal(t, "computed-id", item.Id)
+}
+
+func TestGetGuidCraftOptions_RewritesIdsAcrossFeed(t *testing.T) {
+	options := GetGuidCraftOptions()
+	require.Len(t, options, 1)
+
+	feed := &feeds.Feed{
+		Items: []*feeds.Item{
+			{Id: "old-1", Title: "First", Content: "alpha"},
+			{Id: "old-2", Title: "Second", Content: "beta"},
+		},
+	}
+	require.NoError(t, options[0](feed, ExtraPayload{}))
+
+	assert.Equal(t, util.GetTextContentHash("Firstalpha"), feed.Items[0].Id)
+	assert.Equal(t, util.GetTextContentHash("Secondbeta"), feed.Items[1].Id)
+	assert.NotEqual(t, feed.Items[0].Id, feed.Items[1].Id)
+}

--- a/internal/craft/keyword_test.go
+++ b/internal/craft/keyword_test.go
@@ -1,0 +1,135 @@
+package craft
+
+import (
+	"testing"
+
+	"github.com/gorilla/feeds"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func keywordTestFeed() *feeds.Feed {
+	return &feeds.Feed{
+		Items: []*feeds.Item{
+			{Title: "Golang release notes", Content: "performance improvements", Description: "go runtime"},
+			{Title: "Cooking recipes", Content: "delicious pasta", Description: "italian food"},
+			{Title: "Weather report", Content: "sunny with golang clouds", Description: "forecast"},
+		},
+	}
+}
+
+func itemTitles(items []*feeds.Item) []string {
+	titles := make([]string, 0, len(items))
+	for _, item := range items {
+		titles = append(titles, item.Title)
+	}
+	return titles
+}
+
+func TestOptionKeyword_IncludeAndExcludeScopes(t *testing.T) {
+	tests := []struct {
+		name     string
+		mode     KeywordFilterMode
+		scope    KeywordMatchScope
+		keywords []string
+		want     []string
+	}{
+		{
+			name:     "include by title only",
+			mode:     KeywordIncludeMode,
+			scope:    KeywordMatchTitle,
+			keywords: []string{"Golang"},
+			want:     []string{"Golang release notes"},
+		},
+		{
+			name:     "include by content only matches body",
+			mode:     KeywordIncludeMode,
+			scope:    KeywordMatchContent,
+			keywords: []string{"golang"},
+			want:     []string{"Weather report"},
+		},
+		{
+			name:     "include by all matches title or content",
+			mode:     KeywordIncludeMode,
+			scope:    KeywordMatchAll,
+			keywords: []string{"golang", "Golang"},
+			want:     []string{"Golang release notes", "Weather report"},
+		},
+		{
+			name:     "exclude by title removes matched",
+			mode:     KeywordExcludeMode,
+			scope:    KeywordMatchTitle,
+			keywords: []string{"Golang"},
+			want:     []string{"Cooking recipes", "Weather report"},
+		},
+		{
+			name:     "content scope also matches description",
+			mode:     KeywordIncludeMode,
+			scope:    KeywordMatchContent,
+			keywords: []string{"italian"},
+			want:     []string{"Cooking recipes"},
+		},
+		{
+			name:     "no match yields empty for include",
+			mode:     KeywordIncludeMode,
+			scope:    KeywordMatchAll,
+			keywords: []string{"nonexistent"},
+			want:     []string{},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			feed := keywordTestFeed()
+			option := optionKeyword(tc.mode, tc.scope, tc.keywords)
+			require.NoError(t, option(feed, ExtraPayload{}))
+			assert.Equal(t, tc.want, itemTitles(feed.Items))
+		})
+	}
+}
+
+func TestOptionKeyword_EmptyKeywordListIsNoop(t *testing.T) {
+	feed := keywordTestFeed()
+	option := optionKeyword(KeywordIncludeMode, KeywordMatchAll, nil)
+	require.NoError(t, option(feed, ExtraPayload{}))
+	assert.Len(t, feed.Items, 3)
+}
+
+func TestOptionKeyword_UnknownModeDropsEverything(t *testing.T) {
+	feed := keywordTestFeed()
+	option := optionKeyword(KeywordFilterMode("bogus"), KeywordMatchAll, []string{"Golang"})
+	require.NoError(t, option(feed, ExtraPayload{}))
+	assert.Empty(t, feed.Items)
+}
+
+func TestKeywordCraftLoadParams_ParsesModeAndKeywords(t *testing.T) {
+	options := keywordCraftLoadParams(map[string]string{
+		"mode":     "exclude",
+		"scope":    "title",
+		"keywords": "Golang,Cooking",
+	})
+	require.Len(t, options, 1)
+
+	feed := keywordTestFeed()
+	require.NoError(t, options[0](feed, ExtraPayload{}))
+	assert.Equal(t, []string{"Weather report"}, itemTitles(feed.Items))
+}
+
+// TestKeywordCraftLoadParams_ContentScopeFallsBackToTitle pins the current
+// behavior of the legacy loader: scope="content" is mapped to title matching
+// (see keyword.go). The native runtime path handles content scope correctly;
+// this regression test documents the legacy quirk so a future fix is intentional.
+func TestKeywordCraftLoadParams_ContentScopeFallsBackToTitle(t *testing.T) {
+	options := keywordCraftLoadParams(map[string]string{
+		"mode":     "include",
+		"scope":    "content",
+		"keywords": "golang",
+	})
+	require.Len(t, options, 1)
+
+	feed := keywordTestFeed()
+	require.NoError(t, options[0](feed, ExtraPayload{}))
+	// Lowercase "golang" only appears in content bodies, but because the loader
+	// maps content scope to title matching, nothing matches in the title.
+	assert.Empty(t, feed.Items)
+}

--- a/internal/craft/llm_condition_test.go
+++ b/internal/craft/llm_condition_test.go
@@ -1,0 +1,109 @@
+package craft
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"FeedCraft/internal/util"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCheckConditionWithLLM_ShortContentSkipsLLM(t *testing.T) {
+	called := false
+	original := llmContextCaller
+	llmContextCaller = func(prompt, context string, option util.ContentProcessOption) (string, error) {
+		called = true
+		return "true", nil
+	}
+	t.Cleanup(func() { llmContextCaller = original })
+
+	result, err := CheckConditionWithLLM("title", "short", "is this spam?")
+	require.NoError(t, err)
+	assert.False(t, result)
+	assert.False(t, called, "LLM should not be called for content shorter than the minimum length")
+}
+
+func TestCheckConditionWithLLM_ParsesTrueFalseResponses(t *testing.T) {
+	tests := []struct {
+		name     string
+		response string
+		want     bool
+	}{
+		{name: "lowercase true", response: "true", want: true},
+		{name: "uppercase with spaces", response: "  TRUE \n", want: true},
+		{name: "lowercase false", response: "false", want: false},
+		{name: "mixed case false", response: "False", want: false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			original := llmContextCaller
+			llmContextCaller = func(prompt, context string, option util.ContentProcessOption) (string, error) {
+				return tc.response, nil
+			}
+			t.Cleanup(func() { llmContextCaller = original })
+
+			result, err := CheckConditionWithLLM("title", strings.Repeat("content ", 10), "is this spam?")
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, result)
+		})
+	}
+}
+
+func TestCheckConditionWithLLM_UnexpectedResponseReturnsError(t *testing.T) {
+	original := llmContextCaller
+	llmContextCaller = func(prompt, context string, option util.ContentProcessOption) (string, error) {
+		return "maybe", nil
+	}
+	t.Cleanup(func() { llmContextCaller = original })
+
+	result, err := CheckConditionWithLLM("title", strings.Repeat("content ", 10), "is this spam?")
+	require.Error(t, err)
+	assert.False(t, result)
+	assert.Contains(t, err.Error(), "unexpected llm response")
+}
+
+func TestCheckConditionWithLLM_PropagatesLLMError(t *testing.T) {
+	original := llmContextCaller
+	llmContextCaller = func(prompt, context string, option util.ContentProcessOption) (string, error) {
+		return "", fmt.Errorf("upstream timeout")
+	}
+	t.Cleanup(func() { llmContextCaller = original })
+
+	result, err := CheckConditionWithLLM("title", strings.Repeat("content ", 10), "is this spam?")
+	require.Error(t, err)
+	assert.False(t, result)
+	assert.Contains(t, err.Error(), "upstream timeout")
+}
+
+func TestCheckConditionWithGenericPrompt_WrapsUserCriterion(t *testing.T) {
+	var capturedPrompt string
+	original := llmContextCaller
+	llmContextCaller = func(prompt, context string, option util.ContentProcessOption) (string, error) {
+		capturedPrompt = prompt
+		return "true", nil
+	}
+	t.Cleanup(func() { llmContextCaller = original })
+
+	result, err := CheckConditionWithGenericPrompt("title", strings.Repeat("content ", 10), "Is this about sports?")
+	require.NoError(t, err)
+	assert.True(t, result)
+	assert.Contains(t, capturedPrompt, "Is this about sports?")
+	assert.Contains(t, capturedPrompt, "return 'true'")
+	assert.Contains(t, capturedPrompt, "return 'false'")
+}
+
+func TestBuildLLMArticlePayload_TitleOnlyAndContentOnly(t *testing.T) {
+	titleOnly := BuildLLMArticlePayload("Just A Title", "")
+	assert.Contains(t, titleOnly, "Article Title:")
+	assert.Contains(t, titleOnly, "Just A Title")
+	assert.NotContains(t, titleOnly, "Article Content:")
+
+	contentOnly := BuildLLMArticlePayload("", "Body only content")
+	assert.Contains(t, contentOnly, "Article Content:")
+	assert.Contains(t, contentOnly, "Body only content")
+	assert.NotContains(t, contentOnly, "Article Title:")
+}

--- a/internal/craft/llm_legacy_filter_test.go
+++ b/internal/craft/llm_legacy_filter_test.go
@@ -1,0 +1,125 @@
+package craft
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"FeedCraft/internal/util"
+
+	"github.com/gorilla/feeds"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const longBody = "this article body is long enough to exceed the minimum content length required by the llm condition checker"
+
+func TestOptionIgnoreAdvertorial_RemovesArticlesMarkedAsAds(t *testing.T) {
+	original := llmContextCaller
+	llmContextCaller = func(prompt, context string, option util.ContentProcessOption) (string, error) {
+		if strings.Contains(context, "Sponsored Deal") {
+			return "true", nil
+		}
+		return "false", nil
+	}
+	t.Cleanup(func() { llmContextCaller = original })
+
+	feed := &feeds.Feed{
+		Items: []*feeds.Item{
+			{Title: "Real News", Content: longBody},
+			{Title: "Sponsored Deal", Content: longBody},
+			{Title: "Another Story", Content: longBody},
+		},
+	}
+
+	option := OptionIgnoreAdvertorial("decide if advertorial")
+	require.NoError(t, option(feed, ExtraPayload{}))
+	assert.Equal(t, []string{"Real News", "Another Story"}, itemTitles(feed.Items))
+}
+
+func TestOptionIgnoreAdvertorial_UsesDescriptionWhenContentEmpty(t *testing.T) {
+	var seenContexts []string
+	original := llmContextCaller
+	llmContextCaller = func(prompt, context string, option util.ContentProcessOption) (string, error) {
+		seenContexts = append(seenContexts, context)
+		return "false", nil
+	}
+	t.Cleanup(func() { llmContextCaller = original })
+
+	feed := &feeds.Feed{
+		Items: []*feeds.Item{
+			{Title: "Fallback", Description: longBody},
+		},
+	}
+
+	option := OptionIgnoreAdvertorial("decide if advertorial")
+	require.NoError(t, option(feed, ExtraPayload{}))
+	require.Len(t, feed.Items, 1)
+	require.Len(t, seenContexts, 1)
+	assert.Contains(t, seenContexts[0], longBody)
+}
+
+func TestOptionIgnoreAdvertorial_KeepsArticleOnLLMError(t *testing.T) {
+	original := llmContextCaller
+	llmContextCaller = func(prompt, context string, option util.ContentProcessOption) (string, error) {
+		return "", fmt.Errorf("llm down")
+	}
+	t.Cleanup(func() { llmContextCaller = original })
+
+	feed := &feeds.Feed{
+		Items: []*feeds.Item{
+			{Title: "Survivor", Content: longBody},
+		},
+	}
+
+	option := OptionIgnoreAdvertorial("decide if advertorial")
+	require.NoError(t, option(feed, ExtraPayload{}))
+	assert.Equal(t, []string{"Survivor"}, itemTitles(feed.Items))
+}
+
+func TestOptionIgnoreAdvertorial_EmptyFeedIsNoop(t *testing.T) {
+	feed := &feeds.Feed{}
+	option := OptionIgnoreAdvertorial("decide if advertorial")
+	require.NoError(t, option(feed, ExtraPayload{}))
+	assert.Empty(t, feed.Items)
+}
+
+func TestOptionLLMFilterGeneric_RemovesMatchingArticles(t *testing.T) {
+	original := llmContextCaller
+	llmContextCaller = func(prompt, context string, option util.ContentProcessOption) (string, error) {
+		if strings.Contains(context, "Sports") {
+			return "true", nil
+		}
+		return "false", nil
+	}
+	t.Cleanup(func() { llmContextCaller = original })
+
+	feed := &feeds.Feed{
+		Items: []*feeds.Item{
+			{Title: "Sports Update", Content: longBody},
+			{Title: "Tech News", Content: longBody},
+		},
+	}
+
+	option := OptionLLMFilterGeneric("Is this about sports?")
+	require.NoError(t, option(feed, ExtraPayload{}))
+	assert.Equal(t, []string{"Tech News"}, itemTitles(feed.Items))
+}
+
+func TestOptionLLMFilterGeneric_KeepsArticleWhenLLMErrors(t *testing.T) {
+	original := llmContextCaller
+	llmContextCaller = func(prompt, context string, option util.ContentProcessOption) (string, error) {
+		return "", fmt.Errorf("llm error")
+	}
+	t.Cleanup(func() { llmContextCaller = original })
+
+	feed := &feeds.Feed{
+		Items: []*feeds.Item{
+			{Title: "Kept On Error", Content: longBody},
+		},
+	}
+
+	option := OptionLLMFilterGeneric("Is this spam?")
+	require.NoError(t, option(feed, ExtraPayload{}))
+	assert.Equal(t, []string{"Kept On Error"}, itemTitles(feed.Items))
+}

--- a/internal/craft/resolve_atoms_test.go
+++ b/internal/craft/resolve_atoms_test.go
@@ -1,0 +1,91 @@
+package craft
+
+import (
+	"testing"
+
+	"FeedCraft/internal/dao"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolveCraftAtoms_UnknownCraftNameReturnsError(t *testing.T) {
+	db := newCraftRuntimeTestDB(t)
+
+	_, err := ResolveCraftAtoms(db, "does-not-exist")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not a valid craft name")
+}
+
+func TestResolveCraftAtoms_CommaSeparatedTopLevel(t *testing.T) {
+	db := newCraftRuntimeTestDB(t)
+
+	atoms, err := ResolveCraftAtoms(db, "proxy, limit ,guid-fix")
+	require.NoError(t, err)
+	require.Len(t, atoms, 3)
+	assert.Equal(t, "proxy", atoms[0].TemplateName)
+	assert.Equal(t, "limit", atoms[1].TemplateName)
+	assert.Equal(t, "guid-fix", atoms[2].TemplateName)
+}
+
+func TestResolveCraftAtoms_CommaSeparatedSkipsEmptyParts(t *testing.T) {
+	db := newCraftRuntimeTestDB(t)
+
+	atoms, err := ResolveCraftAtoms(db, "proxy,,limit,")
+	require.NoError(t, err)
+	require.Len(t, atoms, 2)
+	assert.Equal(t, "proxy", atoms[0].TemplateName)
+	assert.Equal(t, "limit", atoms[1].TemplateName)
+}
+
+func TestResolveCraftAtoms_InvalidTemplateNameOnCustomAtom(t *testing.T) {
+	db := newCraftRuntimeTestDB(t)
+	require.NoError(t, dao.CreateCraftAtom(db, &dao.CraftAtom{
+		Name:         "broken-atom",
+		TemplateName: "no-such-template",
+	}))
+
+	_, err := ResolveCraftAtoms(db, "broken-atom")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid tmpl name")
+}
+
+func TestResolveCraftAtoms_NestedFlowExceedsMaxDepth(t *testing.T) {
+	db := newCraftRuntimeTestDB(t)
+	// A self-referencing flow guarantees recursion until the max depth guard trips.
+	require.NoError(t, dao.CreateCraftFlow(db, &dao.CraftFlow{
+		Name: "loop-flow",
+		CraftFlowConfig: []dao.CraftFlowItem{
+			{CraftName: "loop-flow"},
+		},
+	}))
+
+	_, err := ResolveCraftAtoms(db, "loop-flow")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "max call depth hit")
+}
+
+func TestResolveCraftAtoms_NestedFlowWithinDepthResolves(t *testing.T) {
+	db := newCraftRuntimeTestDB(t)
+	require.NoError(t, dao.CreateCraftFlow(db, &dao.CraftFlow{
+		Name: "inner-flow",
+		CraftFlowConfig: []dao.CraftFlowItem{
+			{CraftName: "limit"},
+			{CraftName: "guid-fix"},
+		},
+	}))
+	require.NoError(t, dao.CreateCraftFlow(db, &dao.CraftFlow{
+		Name: "outer-flow",
+		CraftFlowConfig: []dao.CraftFlowItem{
+			{CraftName: "proxy"},
+			{CraftName: "inner-flow"},
+		},
+	}))
+
+	atoms, err := ResolveCraftAtoms(db, "outer-flow")
+	require.NoError(t, err)
+	require.Len(t, atoms, 3)
+	assert.Equal(t, "proxy", atoms[0].TemplateName)
+	assert.Equal(t, "limit", atoms[1].TemplateName)
+	assert.Equal(t, "guid-fix", atoms[2].TemplateName)
+}

--- a/internal/craft/url_resolve_test.go
+++ b/internal/craft/url_resolve_test.go
@@ -1,0 +1,86 @@
+package craft
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetAbsFeedLink(t *testing.T) {
+	tests := []struct {
+		name         string
+		feedURL      string
+		feedLinkAttr string
+		want         string
+	}{
+		{
+			name:         "absolute feed link is preserved",
+			feedURL:      "https://example.com/rss.xml",
+			feedLinkAttr: "https://blog.example.com/",
+			want:         "https://blog.example.com/",
+		},
+		{
+			name:         "relative feed link resolved against feed url",
+			feedURL:      "https://example.com/path/rss.xml",
+			feedLinkAttr: "/home",
+			want:         "https://example.com/home",
+		},
+		{
+			name:         "empty feed link falls back to feed url origin",
+			feedURL:      "https://example.com/path/rss.xml",
+			feedLinkAttr: "",
+			want:         "https://example.com",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, getAbsFeedLink(tc.feedURL, tc.feedLinkAttr))
+		})
+	}
+}
+
+func TestGetAbsLinkForFeedItem(t *testing.T) {
+	tests := []struct {
+		name         string
+		feedURL      string
+		feedLinkAttr string
+		feedItemURL  string
+		want         string
+	}{
+		{
+			name:         "item already absolute is kept",
+			feedURL:      "https://example.com/rss.xml",
+			feedLinkAttr: "https://example.com/",
+			feedItemURL:  "https://cdn.example.com/article-1",
+			want:         "https://cdn.example.com/article-1",
+		},
+		{
+			name:         "relative item resolved against absolute feed link",
+			feedURL:      "https://aggregator.example.net/rss.xml",
+			feedLinkAttr: "https://blog.example.com/",
+			feedItemURL:  "/posts/hello",
+			want:         "https://blog.example.com/posts/hello",
+		},
+		{
+			name:         "relative item resolved against feed url when feed link is relative",
+			feedURL:      "https://example.com/section/rss.xml",
+			feedLinkAttr: "/relative-link",
+			feedItemURL:  "article-2",
+			want:         "https://example.com/section/article-2",
+		},
+		{
+			name:         "relative item resolved against feed url when feed link empty",
+			feedURL:      "https://example.com/section/rss.xml",
+			feedLinkAttr: "",
+			feedItemURL:  "article-3",
+			want:         "https://example.com/section/article-3",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, getAbsLinkForFeedItem(tc.feedURL, tc.feedLinkAttr, tc.feedItemURL))
+		})
+	}
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 背景

为文章处理链路（AtomCraft / FlowCraft）补充更多 Go 单元测试，覆盖此前缺失测试的纯逻辑函数与 legacy 处理路径，提升 `internal/craft` 包的回归保护能力。

## 新增测试文件

| 文件 | 覆盖内容 |
| --- | --- |
| `internal/craft/keyword_test.go` | `optionKeyword` 各 scope（title/content/all）与 mode（include/exclude）、空关键词列表 noop、未知 mode；`keywordCraftLoadParams` 解析，并以回归测试固定 `scope=content` 当前回退到 title 匹配的 legacy 行为 |
| `internal/craft/guid_test.go` | `feedItemGuidGenerator` 哈希确定性 / 内容不同则哈希不同 / 空字段返回随机 uuid；`GetGuidProcessor` 覆写 Id；`GetGuidCraftOptions` 整 feed 重写 |
| `internal/craft/url_resolve_test.go` | `getAbsFeedLink` 与 `getAbsLinkForFeedItem` 的绝对/相对/空链接各分支 URL 绝对化 |
| `internal/craft/llm_condition_test.go` | `CheckConditionWithLLM` 短内容跳过 LLM、`true/false` 解析、异常响应报错、LLM 错误传播；`CheckConditionWithGenericPrompt` prompt 包装；`BuildLLMArticlePayload` 仅标题/仅正文分支 |
| `internal/craft/llm_legacy_filter_test.go` | legacy `OptionIgnoreAdvertorial` 与 `OptionLLMFilterGeneric` 的过滤、content 为空时回退 description、LLM 出错保留文章、空 feed noop |
| `internal/craft/resolve_atoms_test.go` | `ResolveCraftAtoms` 未知 craft 名报错、逗号分隔顶层解析、跳过空段、非法模板名、自引用 flow 触发最大深度上限、正常嵌套 flow 解析 |

## 实现要点

- 复用现有测试基础设施：内存 SQLite（`newCraftRuntimeTestDB`）、包级可替换变量 mock（`llmContextCaller`）等，未引入新依赖。
- 通过 `t.Cleanup` 恢复被替换的包级变量，避免测试间相互污染。
- 仅新增测试文件，未改动生产代码。

## 验证

- `go test ./internal/craft/`：通过（约 40 个新增用例全部 PASS）
- `go test ./...`：全部通过
- `task fix`（gofmt + golangci-lint）：Go lint 0 issues
- `task backend-build`：构建成功

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ef3f4c93-baed-44c9-a6f7-bd1011528f23"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ef3f4c93-baed-44c9-a6f7-bd1011528f23"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

## Summary by Sourcery

Add unit test coverage for the craft article processing pipeline, including keywords, GUIDs, URL resolution, LLM-based conditions, legacy LLM filters, and atom/flow resolution, to improve regression protection without changing production code.

Tests:
- Add keyword filtering tests covering include/exclude modes, match scopes, empty keyword no-op, unknown mode behavior, and legacy content-scope parsing.
- Add GUID generation and processing tests ensuring deterministic hashes, random GUIDs for empty items, per-item ID rewriting, and feed-wide GUID regeneration.
- Add URL resolution tests for feed and item links to validate absolute/relative handling and fallbacks to the feed URL.
- Add LLM condition tests validating short-content bypass, true/false parsing, error propagation, generic prompt wrapping, and article payload construction for title-only/content-only cases.
- Add legacy LLM filter tests for advertorial and generic filters, including description fallback, LLM error behavior, and empty-feed no-op.
- Add ResolveCraftAtoms tests for unknown craft names, comma-separated top-level parsing, invalid template names, recursive flows hitting max depth, and nested flows resolving within depth limits.