### PR TITLE
test(adapter): 为 LLM 调用链补充 OpenAI 兼容功能与异常场景测试

### DIFF
--- a/internal/adapter/common_llm_scenarios_test.go
+++ b/internal/adapter/common_llm_scenarios_test.go
@@ -1,0 +1,383 @@
+package adapter
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// chatCompletionRequest 描述 OpenAI 兼容 /chat/completions 请求体中我们关心的字段。
+type chatCompletionRequest struct {
+	Model       string  `json:"model"`
+	Temperature float64 `json:"temperature"`
+	Messages    []struct {
+		Role    string `json:"role"`
+		Content string `json:"content"`
+	} `json:"messages"`
+}
+
+// fastRetry 是测试用的极速重试配置，避免真实退避拖慢测试。
+var fastRetry = llmRetryConfig{
+	attemptsPerModel: 3,
+	delay:            time.Nanosecond,
+	maxDelay:         time.Nanosecond,
+}
+
+// resetLLMClients 清空全局客户端缓存，避免测试间互相污染。
+func resetLLMClients(t *testing.T) {
+	t.Helper()
+	llmClients = sync.Map{}
+	t.Cleanup(func() {
+		llmClients = sync.Map{}
+	})
+}
+
+// setOpenAILLMEnv 设置标准的 OpenAI 兼容环境变量，并清空 legacy 变量。
+func setOpenAILLMEnv(t *testing.T, baseURL string) {
+	t.Helper()
+	t.Setenv("FC_LLM_API_TYPE", "openai")
+	t.Setenv("FC_LLM_API_BASE", baseURL)
+	t.Setenv("FC_LLM_API_KEY", "test-key")
+	t.Setenv("FC_LLM_API_MODEL", "")
+	t.Setenv("FC_OPENAI_ENDPOINT", "")
+	t.Setenv("FC_OPENAI_AUTH_KEY", "")
+	t.Setenv("FC_OPENAI_DEFAULT_MODEL", "")
+}
+
+// writeChatCompletion 写出一个最简单的成功 chat/completions 响应。
+func writeChatCompletion(w http.ResponseWriter, content string) {
+	w.Header().Set("Content-Type", "application/json")
+	resp := map[string]any{
+		"choices": []map[string]any{
+			{"message": map[string]any{"role": "assistant", "content": content}},
+		},
+		"usage": map[string]any{"total_tokens": 1},
+	}
+	_ = json.NewEncoder(w).Encode(resp)
+}
+
+// --- OpenAI 兼容 API 基础功能 ---
+
+func TestSimpleLLMCallSuccessSendsExpectedRequest(t *testing.T) {
+	resetLLMClients(t)
+
+	var captured chatCompletionRequest
+	var authHeader string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/chat/completions", r.URL.Path)
+		authHeader = r.Header.Get("Authorization")
+		body, _ := io.ReadAll(r.Body)
+		require.NoError(t, json.Unmarshal(body, &captured))
+		writeChatCompletion(w, "hello world")
+	}))
+	t.Cleanup(server.Close)
+
+	setOpenAILLMEnv(t, server.URL)
+
+	result, err := SimpleLLMCall("gpt-test", "please answer")
+
+	require.NoError(t, err)
+	require.Equal(t, "hello world", result)
+	require.Equal(t, "Bearer test-key", authHeader, "OpenAI 兼容 API 必须发送 Bearer 鉴权头")
+	require.Equal(t, "gpt-test", captured.Model)
+	require.Len(t, captured.Messages, 1)
+	require.Equal(t, "user", captured.Messages[0].Role)
+	require.Equal(t, "please answer", captured.Messages[0].Content)
+}
+
+func TestSimpleLLMCallUsesDefaultModelFromEnv(t *testing.T) {
+	resetLLMClients(t)
+
+	var captured chatCompletionRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		require.NoError(t, json.Unmarshal(body, &captured))
+		writeChatCompletion(w, "ok")
+	}))
+	t.Cleanup(server.Close)
+
+	setOpenAILLMEnv(t, server.URL)
+	t.Setenv("FC_LLM_API_MODEL", "env-default-model")
+
+	result, err := SimpleLLMCall(UseDefaultModel, "hi")
+
+	require.NoError(t, err)
+	require.Equal(t, "ok", result)
+	require.Equal(t, "env-default-model", captured.Model, "model 入参为空时应使用 FC_LLM_API_MODEL")
+}
+
+func TestSimpleLLMCallFallsBackToLegacyEnv(t *testing.T) {
+	resetLLMClients(t)
+
+	var captured chatCompletionRequest
+	var authHeader string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		authHeader = r.Header.Get("Authorization")
+		body, _ := io.ReadAll(r.Body)
+		require.NoError(t, json.Unmarshal(body, &captured))
+		writeChatCompletion(w, "legacy ok")
+	}))
+	t.Cleanup(server.Close)
+
+	// 只设置 legacy 变量，新变量留空，验证向后兼容。
+	t.Setenv("FC_LLM_API_TYPE", "")
+	t.Setenv("FC_LLM_API_BASE", "")
+	t.Setenv("FC_LLM_API_KEY", "")
+	t.Setenv("FC_LLM_API_MODEL", "")
+	t.Setenv("FC_OPENAI_ENDPOINT", server.URL)
+	t.Setenv("FC_OPENAI_AUTH_KEY", "legacy-key")
+	t.Setenv("FC_OPENAI_DEFAULT_MODEL", "legacy-model")
+
+	result, err := SimpleLLMCall(UseDefaultModel, "hi")
+
+	require.NoError(t, err)
+	require.Equal(t, "legacy ok", result)
+	require.Equal(t, "Bearer legacy-key", authHeader)
+	require.Equal(t, "legacy-model", captured.Model)
+}
+
+func TestSimpleLLMCallNoModelConfigured(t *testing.T) {
+	resetLLMClients(t)
+	setOpenAILLMEnv(t, "http://127.0.0.1:0")
+
+	_, err := simpleLLMCall(UseDefaultModel, "hi", fastRetry)
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "all models failed")
+}
+
+func TestSimpleLLMCallOllamaRequiresBase(t *testing.T) {
+	resetLLMClients(t)
+	t.Setenv("FC_LLM_API_TYPE", "ollama")
+	t.Setenv("FC_LLM_API_BASE", "")
+	t.Setenv("FC_LLM_API_KEY", "")
+	t.Setenv("FC_LLM_API_MODEL", "")
+	t.Setenv("FC_OPENAI_ENDPOINT", "")
+
+	_, err := simpleLLMCall("llama3", "hi", fastRetry)
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "FC_LLM_API_BASE")
+}
+
+// --- 异常 / 边界场景 ---
+
+func TestSimpleLLMCallEmptyChoicesReturnsError(t *testing.T) {
+	resetLLMClients(t)
+
+	var calls int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"choices":[],"usage":{"total_tokens":0}}`))
+	}))
+	t.Cleanup(server.Close)
+
+	setOpenAILLMEnv(t, server.URL)
+
+	_, err := simpleLLMCall("model-a", "hi", fastRetry)
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "all models failed")
+	// 空 choices 被视为可重试错误，应重试 attemptsPerModel 次。
+	require.Equal(t, int32(fastRetry.attemptsPerModel), atomic.LoadInt32(&calls))
+}
+
+func TestSimpleLLMCallNetworkInterruption(t *testing.T) {
+	resetLLMClients(t)
+
+	// 启动后立即关闭服务器，模拟网络中断 / 连接被拒。
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	closedURL := server.URL
+	server.Close()
+
+	setOpenAILLMEnv(t, closedURL)
+
+	_, err := simpleLLMCall("model-a", "hi", fastRetry)
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "all models failed")
+}
+
+func TestSimpleLLMCallMidResponseConnectionDrop(t *testing.T) {
+	resetLLMClients(t)
+
+	// 通过劫持底层连接并直接关闭，模拟对话过程中连接异常中断。
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hj, ok := w.(http.Hijacker)
+		if !ok {
+			http.Error(w, "no hijack", http.StatusInternalServerError)
+			return
+		}
+		conn, _, err := hj.Hijack()
+		if err != nil {
+			return
+		}
+		_ = conn.Close()
+	}))
+	t.Cleanup(server.Close)
+
+	setOpenAILLMEnv(t, server.URL)
+
+	_, err := simpleLLMCall("model-a", "hi", fastRetry)
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "all models failed")
+}
+
+func TestSimpleLLMCallRateLimitedThenFails(t *testing.T) {
+	resetLLMClients(t)
+
+	var calls int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = w.Write([]byte(`{"error":{"message":"rate limit exceeded","type":"rate_limit_error"}}`))
+	}))
+	t.Cleanup(server.Close)
+
+	setOpenAILLMEnv(t, server.URL)
+
+	_, err := simpleLLMCall("model-a", "hi", fastRetry)
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "all models failed")
+	require.Equal(t, int32(fastRetry.attemptsPerModel), atomic.LoadInt32(&calls), "429 应当被重试")
+}
+
+func TestSimpleLLMCallAuthError(t *testing.T) {
+	resetLLMClients(t)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"error":{"message":"invalid api key","type":"invalid_request_error"}}`))
+	}))
+	t.Cleanup(server.Close)
+
+	setOpenAILLMEnv(t, server.URL)
+
+	_, err := simpleLLMCall("model-a", "hi", fastRetry)
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "all models failed")
+}
+
+func TestSimpleLLMCallContextLengthExceeded(t *testing.T) {
+	resetLLMClients(t)
+
+	var lastBody string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		lastBody = `{"error":{"message":"This model's maximum context length is 4096 tokens","type":"invalid_request_error","code":"context_length_exceeded"}}`
+		_, _ = w.Write([]byte(lastBody))
+	}))
+	t.Cleanup(server.Close)
+
+	setOpenAILLMEnv(t, server.URL)
+
+	_, err := simpleLLMCall("model-a", "hi", fastRetry)
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "all models failed")
+	// 上游错误信息应被透传，便于运维定位 token 超限问题。
+	require.Contains(t, err.Error(), "maximum context length")
+}
+
+func TestSimpleLLMCallTimeout(t *testing.T) {
+	resetLLMClients(t)
+
+	// 临时缩短调用超时，让 server 故意阻塞触发超时。
+	oldTimeout := llmCallTimeout
+	llmCallTimeout = 100 * time.Millisecond
+	t.Cleanup(func() { llmCallTimeout = oldTimeout })
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case <-r.Context().Done():
+		case <-time.After(time.Second):
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	setOpenAILLMEnv(t, server.URL)
+
+	start := time.Now()
+	_, err := simpleLLMCall("model-a", "hi", llmRetryConfig{
+		attemptsPerModel: 1,
+		delay:            time.Nanosecond,
+		maxDelay:         time.Nanosecond,
+	})
+	elapsed := time.Since(start)
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "all models failed")
+	require.Less(t, elapsed, 2*time.Second, "超时应在 llmCallTimeout 后及时返回，而非等待整个上游耗时")
+}
+
+func TestSimpleLLMCallRecoversAfterTransientFailures(t *testing.T) {
+	resetLLMClients(t)
+
+	var calls int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt32(&calls, 1)
+		if n < 3 {
+			http.Error(w, "temporary upstream failure", http.StatusBadGateway)
+			return
+		}
+		writeChatCompletion(w, "recovered")
+	}))
+	t.Cleanup(server.Close)
+
+	setOpenAILLMEnv(t, server.URL)
+
+	result, err := simpleLLMCall("model-a", "hi", fastRetry)
+
+	require.NoError(t, err)
+	require.Equal(t, "recovered", result)
+	require.Equal(t, int32(3), atomic.LoadInt32(&calls), "前两次失败后第三次应成功返回")
+}
+
+func TestSimpleLLMCallFailsOverToHealthyModel(t *testing.T) {
+	resetLLMClients(t)
+
+	var mu sync.Mutex
+	requested := make([]string, 0)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var payload chatCompletionRequest
+		body, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(body, &payload)
+
+		mu.Lock()
+		requested = append(requested, payload.Model)
+		mu.Unlock()
+
+		// model-bad 始终失败，model-good 始终成功。
+		if payload.Model == "model-bad" {
+			http.Error(w, "bad model down", http.StatusServiceUnavailable)
+			return
+		}
+		writeChatCompletion(w, "served by good model")
+	}))
+	t.Cleanup(server.Close)
+
+	setOpenAILLMEnv(t, server.URL)
+
+	result, err := simpleLLMCall("model-bad,model-good", "hi", fastRetry)
+
+	require.NoError(t, err)
+	require.Equal(t, "served by good model", result)
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.Contains(t, requested, "model-good", "应当在坏模型失败后切换到健康模型")
+}

--- a/internal/adapter/llm_test.go
+++ b/internal/adapter/llm_test.go
@@ -1,0 +1,152 @@
+package adapter
+
+import (
+	"FeedCraft/internal/util"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// requireRedis 配置并探测 Redis，不可用时跳过依赖缓存的测试。
+func requireRedis(t *testing.T) {
+	t.Helper()
+	t.Setenv("FC_REDIS_URI", "redis://127.0.0.1:6379")
+	if err := util.TryCacheSetString("feedcraft_test_ping", "1", time.Minute); err != nil {
+		t.Skipf("Redis 不可用，跳过缓存链路测试: %v", err)
+	}
+}
+
+// uniquePrompt 生成进程内唯一前缀，避免命中上一轮测试遗留的 Redis 缓存。
+func uniquePrompt(base string) string {
+	return fmt.Sprintf("%s-%d", base, time.Now().UnixNano())
+}
+
+func TestCallLLMUsingContextCachesResult(t *testing.T) {
+	requireRedis(t)
+	resetLLMClients(t)
+
+	var calls int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		writeChatCompletion(w, "cached answer")
+	}))
+	t.Cleanup(server.Close)
+
+	setOpenAILLMEnv(t, server.URL)
+	t.Setenv("FC_LLM_API_MODEL", "model-a")
+
+	prompt := uniquePrompt("summarize this")
+
+	first, err := CallLLMUsingContext(prompt, "some article content", util.ContentProcessOption{})
+	require.NoError(t, err)
+	require.Equal(t, "cached answer", first)
+
+	second, err := CallLLMUsingContext(prompt, "some article content", util.ContentProcessOption{})
+	require.NoError(t, err)
+	require.Equal(t, "cached answer", second)
+
+	require.Equal(t, int32(1), atomic.LoadInt32(&calls), "相同 prompt+context 应命中缓存，仅请求上游一次")
+}
+
+func TestCallLLMUsingContextStripsBackticksFromContext(t *testing.T) {
+	requireRedis(t)
+	resetLLMClients(t)
+
+	var captured chatCompletionRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		require.NoError(t, json.Unmarshal(body, &captured))
+		writeChatCompletion(w, "ok")
+	}))
+	t.Cleanup(server.Close)
+
+	setOpenAILLMEnv(t, server.URL)
+	t.Setenv("FC_LLM_API_MODEL", "model-a")
+
+	prompt := uniquePrompt("translate")
+	_, err := CallLLMUsingContext(prompt, "danger `inline code` here", util.ContentProcessOption{})
+	require.NoError(t, err)
+
+	require.Len(t, captured.Messages, 1)
+	content := captured.Messages[0].Content
+	require.Contains(t, content, "danger inline code here", "context 内的反引号应被剥离")
+	require.NotContains(t, content, "`inline code`", "context 内不应残留反引号包裹的内容")
+}
+
+func TestCallLLMUsingContextTemperatureSeparatesCache(t *testing.T) {
+	requireRedis(t)
+	resetLLMClients(t)
+
+	var mu = make(chan struct{}, 1)
+	mu <- struct{}{}
+	temperatures := make([]float64, 0)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var payload chatCompletionRequest
+		body, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(body, &payload)
+		<-mu
+		temperatures = append(temperatures, payload.Temperature)
+		mu <- struct{}{}
+		writeChatCompletion(w, "ok")
+	}))
+	t.Cleanup(server.Close)
+
+	setOpenAILLMEnv(t, server.URL)
+	t.Setenv("FC_LLM_API_MODEL", "model-a")
+
+	prompt := uniquePrompt("rate")
+	context := "content for temperature test"
+
+	zero := 0.0
+	high := 0.9
+
+	_, err := CallLLMUsingContext(prompt, context, util.ContentProcessOption{Temperature: &zero})
+	require.NoError(t, err)
+	_, err = CallLLMUsingContext(prompt, context, util.ContentProcessOption{Temperature: &high})
+	require.NoError(t, err)
+
+	<-mu
+	captured := append([]float64(nil), temperatures...)
+	mu <- struct{}{}
+
+	require.Len(t, captured, 2, "不同 temperature 应使用不同缓存键，分别请求上游")
+	require.Contains(t, captured, 0.0)
+	require.Contains(t, captured, 0.9)
+}
+
+func TestCallLLMUsingContextErrorNotCached(t *testing.T) {
+	requireRedis(t)
+	resetLLMClients(t)
+
+	// CallLLMUsingContext 内部走 SimpleLLMCall 使用默认重试配置，
+	// 临时压缩退避时间，避免测试因真实退避而过慢。
+	oldRetry := defaultLLMRetryConfig
+	defaultLLMRetryConfig = fastRetry
+	t.Cleanup(func() { defaultLLMRetryConfig = oldRetry })
+
+	var calls int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		http.Error(w, "upstream down", http.StatusServiceUnavailable)
+	}))
+	t.Cleanup(server.Close)
+
+	setOpenAILLMEnv(t, server.URL)
+	t.Setenv("FC_LLM_API_MODEL", "model-a")
+
+	prompt := uniquePrompt("fail case")
+	_, err := CallLLMUsingContext(prompt, "content", util.ContentProcessOption{})
+	require.Error(t, err)
+
+	before := atomic.LoadInt32(&calls)
+	_, err = CallLLMUsingContext(prompt, "content", util.ContentProcessOption{})
+	require.Error(t, err)
+	require.Greater(t, atomic.LoadInt32(&calls), before, "失败结果不应被缓存，二次调用应再次请求上游")
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 背景

LLM 调用链路（`internal/adapter/common_llm.go` 与 `internal/adapter/llm.go`）此前仅有 3 个测试，主要覆盖多模型轮换重试与 temperature 透传。对 OpenAI 兼容 API 的必要功能以及常见故障场景（网络中断、超时、限流、token 超限等）缺乏验证。

## 改动

新增两个测试文件（纯测试代码，未改动生产逻辑）：

### `internal/adapter/common_llm_scenarios_test.go` — `simpleLLMCall` 调用链
OpenAI 兼容必要功能：
- 成功请求：校验 `/chat/completions` 路径、`Bearer` 鉴权头、`model`、消息 role/content。
- `model` 入参为空时回退到 `FC_LLM_API_MODEL`。
- legacy 环境变量回退（`FC_OPENAI_ENDPOINT` / `FC_OPENAI_AUTH_KEY` / `FC_OPENAI_DEFAULT_MODEL`）。
- 未配置任何 model 时报错。
- `ollama` 类型缺少 base URL 时报错。

常见问题场景：
- 网络中断（连接被拒）与对话中途连接被劫持关闭。
- 调用超时（临时缩短 `llmCallTimeout`，验证及时返回而非干等上游）。
- 429 限流、401 鉴权失败、400 context token 超限（错误信息透传）。
- 空 `choices` 响应被视为可重试错误。
- 瞬时失败后重试恢复成功。
- 坏模型失败后故障转移到健康模型。

### `internal/adapter/llm_test.go` — `CallLLMUsingContext` 缓存链路（需 Redis，缺省自动 skip）
- 相同 prompt+context 命中缓存，仅请求上游一次。
- context 内反引号被剥离。
- 不同 temperature 使用不同缓存键，分别请求上游。
- 失败结果不被缓存，二次调用重新请求上游。

## 测试

- ✅ `go test ./internal/adapter/`（Redis 已启动，缓存链路用例全部执行）
- ✅ `go test ./...`
- ✅ `task fix`（Go lint 0 issues）
- ✅ `task backend-build`
- ✅ `gofmt -l internal/adapter/` 无输出、`go vet ./internal/adapter/` 通过

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-662dea6f-9e58-48f3-aa1c-48113ec5d46e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-662dea6f-9e58-48f3-aa1c-48113ec5d46e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

## Summary by Sourcery

Add comprehensive tests for LLM adapter OpenAI-compatible call chain and Redis-backed caching behavior.

Enhancements:
- Add scenario-based tests for SimpleLLMCall covering OpenAI-compatible request construction, environment fallbacks, error handling, retries, and multi-model failover.
- Add tests for CallLLMUsingContext to verify Redis caching, context preprocessing, temperature-specific cache keys, and non-caching of failed calls.

Tests:
- Introduce common_llm_scenarios_test to cover success and failure paths for OpenAI-style chat completion calls, including network issues, timeouts, rate limiting, auth errors, and token limits.
- Introduce llm_test to validate the LLM context-based caching pipeline when Redis is available, skipping these tests automatically if Redis is unreachable.