### PR TITLE
feat(web-monitor): 网页变动订阅新增可选的 AI 判定

### DIFF
--- a/internal/config/source_config.go
+++ b/internal/config/source_config.go
@@ -64,6 +64,29 @@ type WebMonitorParserConfig struct {
 	TitleTemplate       string            `json:"title_template,omitempty"`
 	DescriptionTemplate string            `json:"description_template,omitempty"`
 	ContentTemplate     string            `json:"content_template,omitempty"`
+
+	// AIJudge is an optional LLM-based judgement step. When enabled, the LLM
+	// evaluates the extracted field values against a user instruction and
+	// produces a short verdict label. The verdict is injected as an extra
+	// template variable (named by OutputField) and can be added to KeyFields so
+	// that the RSS GUID — and therefore change notifications — is driven by the
+	// AI verdict instead of raw text diffs.
+	AIJudge *WebMonitorAIJudgeConfig `json:"ai_judge,omitempty"`
+}
+
+// WebMonitorAIJudgeConfig configures the optional AI judgement step for the web monitor.
+type WebMonitorAIJudgeConfig struct {
+	// Enabled toggles the AI judgement step.
+	Enabled bool `json:"enabled,omitempty"`
+	// Prompt is the user instruction describing what to judge and which verdict
+	// labels to output. Required when Enabled is true.
+	Prompt string `json:"prompt,omitempty"`
+	// OutputField is the variable name that stores the verdict. Defaults to
+	// "ai_verdict" when empty. It must not collide with an existing extractor
+	// name or the reserved "url" variable.
+	OutputField string `json:"output_field,omitempty"`
+	// Model optionally overrides the default LLM model for the judgement call.
+	Model string `json:"model,omitempty"`
 }
 
 // InboxSourceConfig holds the configuration for an inbox source.

--- a/internal/source/parser/web_monitor_parser.go
+++ b/internal/source/parser/web_monitor_parser.go
@@ -1,6 +1,7 @@
 package parser
 
 import (
+	"FeedCraft/internal/adapter"
 	"FeedCraft/internal/config"
 	"FeedCraft/internal/model"
 	"FeedCraft/internal/util"
@@ -13,6 +14,17 @@ import (
 
 	"github.com/PuerkitoBio/goquery"
 )
+
+// DefaultWebMonitorAIJudgeField is the variable name used to store the AI verdict
+// when the user does not specify a custom output field.
+const DefaultWebMonitorAIJudgeField = "ai_verdict"
+
+// webMonitorJudgeCaller performs the underlying LLM call for AI judgement.
+// It is a package-level variable so tests can stub it out without hitting a
+// real LLM or Redis cache. The default implementation reuses
+// adapter.CallLLMUsingContext, which caches results by prompt+context hash and
+// therefore keeps verdicts (and thus the RSS GUID) stable for identical inputs.
+var webMonitorJudgeCaller = adapter.CallLLMUsingContext
 
 type WebMonitorParser struct {
 	Config  *config.WebMonitorParserConfig
@@ -32,12 +44,10 @@ func (p *WebMonitorParser) Parse(data []byte) (*model.CraftFeed, error) {
 		return nil, fmt.Errorf("parser config is nil")
 	}
 
-	doc, values, templates, err := p.prepare(data)
+	doc, values, templates, err := p.prepare(data, p.PageURL)
 	if err != nil {
 		return nil, err
 	}
-
-	values["url"] = p.PageURL
 
 	rendered, err := renderWebMonitorPreview(doc, values, p.Config.KeyFields, templates)
 	if err != nil {
@@ -64,12 +74,11 @@ type webMonitorRendered struct {
 }
 
 func PreviewWebMonitor(data []byte, cfg *config.WebMonitorParserConfig, pageURL string) (*WebMonitorPreviewResult, error) {
-	parser := &WebMonitorParser{Config: cfg}
-	doc, values, templates, err := parser.prepare(data)
+	parser := &WebMonitorParser{Config: cfg, PageURL: pageURL}
+	doc, values, templates, err := parser.prepare(data, pageURL)
 	if err != nil {
 		return nil, err
 	}
-	values["url"] = pageURL
 
 	rendered, err := renderWebMonitorPreview(doc, values, cfg.KeyFields, templates)
 	if err != nil {
@@ -78,7 +87,7 @@ func PreviewWebMonitor(data []byte, cfg *config.WebMonitorParserConfig, pageURL 
 	return rendered.preview, nil
 }
 
-func (p *WebMonitorParser) prepare(data []byte) (*goquery.Document, map[string]string, *compiledWebMonitorTemplates, error) {
+func (p *WebMonitorParser) prepare(data []byte, pageURL string) (*goquery.Document, map[string]string, *compiledWebMonitorTemplates, error) {
 	if len(p.Config.Extractors) == 0 {
 		return nil, nil, nil, fmt.Errorf("extractors are required")
 	}
@@ -93,6 +102,15 @@ func (p *WebMonitorParser) prepare(data []byte) (*goquery.Document, map[string]s
 	}
 
 	values := extractWebMonitorValues(doc, p.Config.Extractors)
+	values["url"] = pageURL
+
+	// Optional AI judgement: derive an extra verdict variable from the
+	// extracted values. It runs before key-field validation so the verdict can
+	// itself be used as a key field driving the RSS GUID.
+	if err := p.applyAIJudge(values); err != nil {
+		return nil, nil, nil, err
+	}
+
 	for _, field := range p.Config.KeyFields {
 		if _, ok := values[field]; !ok {
 			return nil, nil, nil, fmt.Errorf("key field '%s' is not defined in extractors", field)
@@ -105,6 +123,81 @@ func (p *WebMonitorParser) prepare(data []byte) (*goquery.Document, map[string]s
 	}
 
 	return doc, values, templates, nil
+}
+
+// applyAIJudge runs the optional LLM judgement step and injects the verdict into
+// values under the configured output field name.
+func (p *WebMonitorParser) applyAIJudge(values map[string]string) error {
+	cfg := p.Config.AIJudge
+	if cfg == nil || !cfg.Enabled {
+		return nil
+	}
+
+	prompt := strings.TrimSpace(cfg.Prompt)
+	if prompt == "" {
+		return fmt.Errorf("ai_judge prompt is required when ai judge is enabled")
+	}
+
+	outputField := strings.TrimSpace(cfg.OutputField)
+	if outputField == "" {
+		outputField = DefaultWebMonitorAIJudgeField
+	}
+	if outputField == "url" {
+		return fmt.Errorf("ai_judge output_field cannot be the reserved variable 'url'")
+	}
+	if _, exists := p.Config.Extractors[outputField]; exists {
+		return fmt.Errorf("ai_judge output_field '%s' conflicts with an existing extractor name", outputField)
+	}
+
+	verdict, err := webMonitorJudgeCaller(
+		buildWebMonitorJudgePrompt(prompt),
+		buildWebMonitorJudgeContext(values),
+		util.ContentProcessOption{Temperature: util.LowestLLMTemperaturePtr()},
+	)
+	if err != nil {
+		return fmt.Errorf("ai judge failed: %w", err)
+	}
+
+	values[outputField] = normalizeWebMonitorVerdict(verdict)
+	return nil
+}
+
+func buildWebMonitorJudgePrompt(userPrompt string) string {
+	return fmt.Sprintf(`You are a web page change monitoring assistant.
+
+Based on the extracted field values from a web page (provided in the context), follow the user's judgement instruction and output a SHORT verdict label.
+
+User judgement instruction:
+%s
+
+Output requirements:
+- Output ONLY the verdict label. No explanation, punctuation, quotes, or markdown.
+- Keep it short and stable, for example a single word or label such as "available", "unavailable", "yes", or "no".
+- Given identical inputs, you MUST always produce the identical verdict.`, userPrompt)
+}
+
+// buildWebMonitorJudgeContext renders the extracted values into a deterministic,
+// key-sorted text block so the LLM (and its cache) sees stable input.
+func buildWebMonitorJudgeContext(values map[string]string) string {
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	parts := make([]string, 0, len(keys))
+	for _, key := range keys {
+		parts = append(parts, fmt.Sprintf("%s: %s", key, values[key]))
+	}
+	return strings.Join(parts, "\n")
+}
+
+func normalizeWebMonitorVerdict(raw string) string {
+	verdict := strings.TrimSpace(raw)
+	if idx := strings.IndexAny(verdict, "\r\n"); idx >= 0 {
+		verdict = strings.TrimSpace(verdict[:idx])
+	}
+	return verdict
 }
 
 func extractWebMonitorValues(doc *goquery.Document, extractors map[string]string) map[string]string {

--- a/internal/source/parser/web_monitor_parser_test.go
+++ b/internal/source/parser/web_monitor_parser_test.go
@@ -2,11 +2,22 @@ package parser
 
 import (
 	"FeedCraft/internal/config"
+	"FeedCraft/internal/util"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// stubWebMonitorJudge replaces the package-level LLM caller for the duration of
+// a test and restores it on cleanup.
+func stubWebMonitorJudge(t *testing.T, fn func(prompt, context string, option util.ContentProcessOption) (string, error)) {
+	t.Helper()
+	original := webMonitorJudgeCaller
+	webMonitorJudgeCaller = fn
+	t.Cleanup(func() { webMonitorJudgeCaller = original })
+}
 
 func TestWebMonitorParser_Parse_KeyFieldsDriveGUID(t *testing.T) {
 	html := `
@@ -161,6 +172,153 @@ func TestWebMonitorParser_Parse_MissingKeyFieldFails(t *testing.T) {
 	assert.Error(t, err)
 	assert.Nil(t, feed)
 	assert.Contains(t, err.Error(), "key field 'stock' is not defined in extractors")
+}
+
+func TestWebMonitorParser_Parse_AIJudgeInjectsVerdictVariable(t *testing.T) {
+	var seenContext string
+	stubWebMonitorJudge(t, func(prompt, context string, option util.ContentProcessOption) (string, error) {
+		seenContext = context
+		require.NotNil(t, option.Temperature)
+		assert.Equal(t, 0.0, *option.Temperature)
+		assert.Contains(t, prompt, "判断商品是否可购买")
+		return "  available\nignored second line ", nil
+	})
+
+	cfg := &config.WebMonitorParserConfig{
+		Extractors:      map[string]string{"stock": ".stock"},
+		KeyFields:       []string{"stock"},
+		ContentTemplate: "状态：{{.ai_verdict}}",
+		AIJudge: &config.WebMonitorAIJudgeConfig{
+			Enabled: true,
+			Prompt:  "根据库存文案判断商品是否可购买，只回答 available 或 unavailable",
+		},
+	}
+
+	parser := &WebMonitorParser{Config: cfg, PageURL: "https://example.com/p"}
+	feed, err := parser.Parse([]byte(`<html><body><div class="stock">In Stock</div></body></html>`))
+	require.NoError(t, err)
+	require.Len(t, feed.Articles, 1)
+	// Verdict is trimmed and only the first line is kept.
+	assert.Equal(t, "状态：available", feed.Articles[0].Content)
+	// Extracted values are passed to the judge as deterministic context.
+	assert.Contains(t, seenContext, "stock: In Stock")
+	assert.Contains(t, seenContext, "url: https://example.com/p")
+}
+
+func TestWebMonitorParser_Parse_AIVerdictDrivesGUID(t *testing.T) {
+	verdict := "unavailable"
+	stubWebMonitorJudge(t, func(prompt, context string, option util.ContentProcessOption) (string, error) {
+		return verdict, nil
+	})
+
+	cfg := &config.WebMonitorParserConfig{
+		Extractors: map[string]string{"stock": ".stock"},
+		KeyFields:  []string{"ai_verdict"},
+		AIJudge: &config.WebMonitorAIJudgeConfig{
+			Enabled: true,
+			Prompt:  "判断是否有货",
+		},
+	}
+	parser := &WebMonitorParser{Config: cfg, PageURL: "https://example.com/p"}
+
+	feedOut, err := parser.Parse([]byte(`<html><body><div class="stock">Sold Out</div></body></html>`))
+	require.NoError(t, err)
+
+	// Raw stock text changes but verdict stays the same -> GUID must not change.
+	feedOutAgain, err := parser.Parse([]byte(`<html><body><div class="stock">Currently unavailable</div></body></html>`))
+	require.NoError(t, err)
+	assert.Equal(t, feedOut.Articles[0].Id, feedOutAgain.Articles[0].Id)
+
+	// Verdict flips -> GUID must change.
+	verdict = "available"
+	feedIn, err := parser.Parse([]byte(`<html><body><div class="stock">In Stock</div></body></html>`))
+	require.NoError(t, err)
+	assert.NotEqual(t, feedOut.Articles[0].Id, feedIn.Articles[0].Id)
+}
+
+func TestWebMonitorParser_Parse_AIJudgeCustomOutputField(t *testing.T) {
+	stubWebMonitorJudge(t, func(prompt, context string, option util.ContentProcessOption) (string, error) {
+		return "rising", nil
+	})
+
+	cfg := &config.WebMonitorParserConfig{
+		Extractors:      map[string]string{"price": ".price"},
+		KeyFields:       []string{"trend"},
+		ContentTemplate: "趋势：{{.trend}}",
+		AIJudge: &config.WebMonitorAIJudgeConfig{
+			Enabled:     true,
+			Prompt:      "判断价格趋势",
+			OutputField: "trend",
+		},
+	}
+	parser := &WebMonitorParser{Config: cfg, PageURL: "https://example.com/p"}
+	feed, err := parser.Parse([]byte(`<html><body><div class="price">$10</div></body></html>`))
+	require.NoError(t, err)
+	assert.Equal(t, "趋势：rising", feed.Articles[0].Content)
+}
+
+func TestWebMonitorParser_Parse_AIJudgeRequiresPrompt(t *testing.T) {
+	stubWebMonitorJudge(t, func(prompt, context string, option util.ContentProcessOption) (string, error) {
+		return "x", nil
+	})
+	parser := &WebMonitorParser{Config: &config.WebMonitorParserConfig{
+		Extractors: map[string]string{"price": ".price"},
+		KeyFields:  []string{"price"},
+		AIJudge:    &config.WebMonitorAIJudgeConfig{Enabled: true},
+	}}
+	feed, err := parser.Parse([]byte(`<html><body><div class="price">$1</div></body></html>`))
+	assert.Error(t, err)
+	assert.Nil(t, feed)
+	assert.Contains(t, err.Error(), "ai_judge prompt is required")
+}
+
+func TestWebMonitorParser_Parse_AIJudgeOutputFieldConflict(t *testing.T) {
+	stubWebMonitorJudge(t, func(prompt, context string, option util.ContentProcessOption) (string, error) {
+		return "x", nil
+	})
+	parser := &WebMonitorParser{Config: &config.WebMonitorParserConfig{
+		Extractors: map[string]string{"price": ".price"},
+		KeyFields:  []string{"price"},
+		AIJudge: &config.WebMonitorAIJudgeConfig{
+			Enabled:     true,
+			Prompt:      "judge",
+			OutputField: "price",
+		},
+	}}
+	feed, err := parser.Parse([]byte(`<html><body><div class="price">$1</div></body></html>`))
+	assert.Error(t, err)
+	assert.Nil(t, feed)
+	assert.Contains(t, err.Error(), "conflicts with an existing extractor")
+}
+
+func TestWebMonitorParser_Parse_AIJudgePropagatesError(t *testing.T) {
+	stubWebMonitorJudge(t, func(prompt, context string, option util.ContentProcessOption) (string, error) {
+		return "", fmt.Errorf("llm down")
+	})
+	parser := &WebMonitorParser{Config: &config.WebMonitorParserConfig{
+		Extractors: map[string]string{"price": ".price"},
+		KeyFields:  []string{"price"},
+		AIJudge:    &config.WebMonitorAIJudgeConfig{Enabled: true, Prompt: "judge"},
+	}}
+	feed, err := parser.Parse([]byte(`<html><body><div class="price">$1</div></body></html>`))
+	assert.Error(t, err)
+	assert.Nil(t, feed)
+	assert.Contains(t, err.Error(), "ai judge failed")
+}
+
+func TestWebMonitorParser_Parse_AIJudgeDisabledByDefault(t *testing.T) {
+	stubWebMonitorJudge(t, func(prompt, context string, option util.ContentProcessOption) (string, error) {
+		t.Fatal("judge should not be called when disabled")
+		return "", nil
+	})
+	parser := &WebMonitorParser{Config: &config.WebMonitorParserConfig{
+		Extractors: map[string]string{"price": ".price"},
+		KeyFields:  []string{"price"},
+		AIJudge:    &config.WebMonitorAIJudgeConfig{Enabled: false, Prompt: "judge"},
+	}}
+	feed, err := parser.Parse([]byte(`<html><body><div class="price">$1</div></body></html>`))
+	require.NoError(t, err)
+	require.Len(t, feed.Articles, 1)
 }
 
 func TestWebMonitorParser_Parse_InvalidTemplateFails(t *testing.T) {

--- a/proposal/web_monitor_plan.md
+++ b/proposal/web_monitor_plan.md
@@ -425,6 +425,52 @@ GUID 的生成应满足：
 
 ---
 
+## 9.5 可选的 AI 判定（扩展能力）
+
+在核心“值驱动”模型之上，新增一个**可选的 AI 判定**步骤，用于把“原始文本变化”升级为“语义状态变化”。
+
+### 9.5.1 设计动机
+
+纯文本 key field 有时过于敏感：
+
+- 库存文案可能在 `Sold Out` / `Currently unavailable` / `缺货` 之间反复横跳，但语义上都还是“不可购买”。
+- 用户真正关心的是“能不能买”，而不是文案本身。
+
+因此引入一个 AI 判定步骤：让 LLM 根据提取到的字段值产出一个**简短、稳定的判定标签**（如 `available` / `unavailable`），再把这个标签当作派生变量参与模板与 GUID。
+
+### 9.5.2 配置模型
+
+在 `WebMonitorParserConfig` 中新增可选字段：
+
+```go
+type WebMonitorAIJudgeConfig struct {
+	Enabled     bool   `json:"enabled,omitempty"`
+	Prompt      string `json:"prompt,omitempty"`        // 判定指令，启用时必填
+	OutputField string `json:"output_field,omitempty"`  // 默认 "ai_verdict"
+	Model       string `json:"model,omitempty"`         // 可选模型覆盖
+}
+```
+
+### 9.5.3 运行流程
+
+1. 按 extractors 提取所有字段值。
+2. 若 `ai_judge.enabled`：
+   - 把字段值按 key 排序后拼成确定性上下文，调用 LLM（温度 0）。
+   - 结果做 `TrimSpace` 并仅保留首行，写入 `values[output_field]`。
+3. AI 判定**先于** key field 校验执行，因此判定结果本身可以被选为 key field。
+4. 用户通常把 `ai_verdict` 勾选为 key field：GUID 由语义判定驱动，仅当判定结果变化时 RSS Reader 才识别为新 item。
+
+### 9.5.4 稳定性要点
+
+- **必须复用 LLM 缓存**：判定调用复用 `adapter.CallLLMUsingContext`，按 prompt+context 哈希缓存。请求驱动模型下 RSS Reader 会反复轮询，缓存保证相同页面状态得到相同判定，避免 GUID 抖动造成通知风暴。
+- **温度固定为 0**：约束模型输出确定。
+- **prompt 约束输出**：要求只输出简短标签、相同输入必须给出相同结果。
+- **判定失败直接报错**：与现有“配置错误尽早失败”风格一致，不静默 fallback。
+
+### 9.5.5 前端入口
+
+在 Web Monitor 向导第 2 步新增可折叠的「AI 判定（可选）」卡片：开关启用、填写判定指令、可自定义输出变量名与模型、一键勾选“将判定结果用作关键字段”。预览结果中以标签形式展示 AI 判定值。
+
 ## 10. 最终建议
 
 建议这次实现优先完成：

--- a/web/admin/src/locale/en-US/webMonitor.ts
+++ b/web/admin/src/locale/en-US/webMonitor.ts
@@ -44,6 +44,23 @@ export default {
   'webMonitor.step2.nextStep': 'Next Step',
   'webMonitor.step2.remove': 'Remove',
   'webMonitor.step2.defaultVarName': 'field',
+  'webMonitor.step2.aiJudge': 'AI Judgement (optional)',
+  'webMonitor.step2.aiJudge.enable': 'Enable AI judgement',
+  'webMonitor.step2.aiJudge.tooltip':
+    'Let an LLM produce a verdict label (e.g. available/unavailable) from the extracted values. Mark the verdict as a key field to notify only when the AI verdict changes.',
+  'webMonitor.step2.aiJudge.prompt': 'Judgement Instruction',
+  'webMonitor.step2.aiJudge.prompt.placeholder':
+    'e.g. Decide whether the product is purchasable from the stock text. Answer only available or unavailable.',
+  'webMonitor.step2.aiJudge.outputField': 'Output Variable',
+  'webMonitor.step2.aiJudge.outputField.help':
+    'The verdict is stored in this variable, usable in templates (e.g. {{.ai_verdict}}) and selectable as a key field.',
+  'webMonitor.step2.aiJudge.model': 'Model (optional)',
+  'webMonitor.step2.aiJudge.model.placeholder':
+    'Leave empty to use the default model',
+  'webMonitor.step2.aiJudge.useAsKey': 'Use AI verdict as a key field',
+  'webMonitor.step2.aiJudge.verdict': 'AI Verdict',
+  'webMonitor.msg.aiPromptRequired':
+    'Judgement instruction is required when AI judgement is enabled',
   'webMonitor.step3.feedTitle': 'Feed Title',
   'webMonitor.step3.feedTitle.placeholder': 'e.g. PS5 Price Monitor',
   'webMonitor.step3.feedDesc': 'Feed Description',

--- a/web/admin/src/locale/zh-CN/webMonitor.ts
+++ b/web/admin/src/locale/zh-CN/webMonitor.ts
@@ -42,6 +42,21 @@ export default {
   'webMonitor.step2.nextStep': '下一步',
   'webMonitor.step2.remove': '删除',
   'webMonitor.step2.defaultVarName': '字段',
+  'webMonitor.step2.aiJudge': 'AI 判定（可选）',
+  'webMonitor.step2.aiJudge.enable': '启用 AI 判定',
+  'webMonitor.step2.aiJudge.tooltip':
+    '让 AI 根据提取到的字段值产出一个判定标签（如 available/unavailable）。把该标签勾选为关键字段后，仅当 AI 判定结果变化时才会推送更新。',
+  'webMonitor.step2.aiJudge.prompt': '判定指令',
+  'webMonitor.step2.aiJudge.prompt.placeholder':
+    '例如：根据库存文案判断商品是否可购买，只回答 available 或 unavailable',
+  'webMonitor.step2.aiJudge.outputField': '输出变量名',
+  'webMonitor.step2.aiJudge.outputField.help':
+    '判定结果会写入该变量，可在模板中引用（如 {{.ai_verdict}}），也可勾选为关键字段。',
+  'webMonitor.step2.aiJudge.model': '模型（可选）',
+  'webMonitor.step2.aiJudge.model.placeholder': '留空使用默认模型',
+  'webMonitor.step2.aiJudge.useAsKey': '将 AI 判定结果用作关键字段',
+  'webMonitor.step2.aiJudge.verdict': 'AI 判定结果',
+  'webMonitor.msg.aiPromptRequired': '启用 AI 判定后，判定指令不能为空',
   'webMonitor.step3.feedTitle': 'Feed 标题',
   'webMonitor.step3.feedTitle.placeholder': '例如：PS5 价格监控',
   'webMonitor.step3.feedDesc': 'Feed 描述',

--- a/web/admin/src/views/dashboard/web_monitor/web_monitor.vue
+++ b/web/admin/src/views/dashboard/web_monitor/web_monitor.vue
@@ -169,6 +169,64 @@
                   </a-button>
                 </a-card>
 
+                <a-card size="small" class="mb-4 border-purple-100">
+                  <template #title>
+                    <div class="flex items-center gap-2">
+                      <span>{{ t('webMonitor.step2.aiJudge') }}</span>
+                      <a-tooltip
+                        :content="t('webMonitor.step2.aiJudge.tooltip')"
+                      >
+                        <icon-info-circle class="text-gray-400" />
+                      </a-tooltip>
+                    </div>
+                  </template>
+                  <template #extra>
+                    <a-switch v-model="aiJudge.enabled" size="small" />
+                  </template>
+                  <a-form v-show="aiJudge.enabled" layout="vertical">
+                    <a-form-item :label="t('webMonitor.step2.aiJudge.prompt')">
+                      <a-textarea
+                        v-model="aiJudge.prompt"
+                        :placeholder="
+                          t('webMonitor.step2.aiJudge.prompt.placeholder')
+                        "
+                        :auto-size="{ minRows: 2, maxRows: 4 }"
+                        allow-clear
+                      />
+                    </a-form-item>
+                    <a-row :gutter="12">
+                      <a-col :span="12">
+                        <a-form-item
+                          :label="t('webMonitor.step2.aiJudge.outputField')"
+                          :help="t('webMonitor.step2.aiJudge.outputField.help')"
+                        >
+                          <a-input
+                            v-model="aiJudge.outputField"
+                            placeholder="ai_verdict"
+                            allow-clear
+                          />
+                        </a-form-item>
+                      </a-col>
+                      <a-col :span="12">
+                        <a-form-item
+                          :label="t('webMonitor.step2.aiJudge.model')"
+                        >
+                          <a-input
+                            v-model="aiJudge.model"
+                            :placeholder="
+                              t('webMonitor.step2.aiJudge.model.placeholder')
+                            "
+                            allow-clear
+                          />
+                        </a-form-item>
+                      </a-col>
+                    </a-row>
+                    <a-checkbox v-model="aiJudge.useAsKey">
+                      {{ t('webMonitor.step2.aiJudge.useAsKey') }}
+                    </a-checkbox>
+                  </a-form>
+                </a-card>
+
                 <a-card :title="t('webMonitor.step2.preview')" size="small">
                   <a-form layout="vertical">
                     <a-form-item :label="t('webMonitor.step2.previewTitle')">
@@ -198,6 +256,12 @@
                     "
                   >
                     <a-divider />
+                    <div v-if="aiVerdict" class="mb-2">
+                      <div class="text-xs text-gray-500 mb-1">
+                        {{ t('webMonitor.step2.aiJudge.verdict') }}
+                      </div>
+                      <a-tag color="purple">{{ aiVerdict }}</a-tag>
+                    </div>
                     <div class="mb-2">
                       <div class="text-xs text-gray-500 mb-1">
                         {{ t('webMonitor.step2.previewResultTitle') }}
@@ -393,6 +457,7 @@
   import { Message } from '@arco-design/web-vue';
   import {
     IconArrowRight,
+    IconInfoCircle,
     IconRefresh,
     IconSave,
   } from '@arco-design/web-vue/es/icon';
@@ -447,6 +512,18 @@
     content: '价格：{{.price}}\n状态：{{.stock}}\n链接：{{.url}}',
   });
 
+  const aiJudge = reactive({
+    enabled: false,
+    prompt: '',
+    outputField: 'ai_verdict',
+    model: '',
+    useAsKey: true,
+  });
+
+  const aiJudgeFieldName = computed(
+    () => aiJudge.outputField.trim() || 'ai_verdict'
+  );
+
   const preview = reactive<WebMonitorPreview>({
     values: {},
     key_fields: [],
@@ -477,12 +554,22 @@
       'url',
       ...fields.value.map((field) => field.name).filter(Boolean),
     ];
+    if (aiJudge.enabled) {
+      vars.push(aiJudgeFieldName.value);
+    }
     return vars.map((item) => `{{.${item}}}`).join(', ');
   });
-  const selectedKeyFields = computed(() =>
-    fields.value
+  const selectedKeyFields = computed(() => {
+    const keys = fields.value
       .filter((field) => field.isKey && field.name.trim())
-      .map((field) => field.name.trim())
+      .map((field) => field.name.trim());
+    if (aiJudge.enabled && aiJudge.useAsKey) {
+      keys.push(aiJudgeFieldName.value);
+    }
+    return keys;
+  });
+  const aiVerdict = computed(
+    () => preview.values?.[aiJudgeFieldName.value] || ''
   );
   const canProceedFromStep2 = computed(
     () =>
@@ -634,6 +721,11 @@
       return false;
     }
 
+    if (aiJudge.enabled && !aiJudge.prompt.trim()) {
+      Message.warning(t('webMonitor.msg.aiPromptRequired'));
+      return false;
+    }
+
     if (selectedKeyFields.value.length === 0) {
       Message.warning(t('webMonitor.msg.keyRequired'));
       return false;
@@ -641,26 +733,39 @@
     return true;
   };
 
+  const buildParserConfig = () => {
+    const extractors = Object.fromEntries(
+      fields.value.map((field) => [field.name.trim(), field.selector.trim()])
+    );
+    const parser: Record<string, any> = {
+      extractors,
+      key_fields: selectedKeyFields.value,
+      title_template: templates.title,
+      description_template: templates.description,
+      content_template: templates.content,
+    };
+    if (aiJudge.enabled) {
+      parser.ai_judge = {
+        enabled: true,
+        prompt: aiJudge.prompt.trim(),
+        output_field: aiJudgeFieldName.value,
+        ...(aiJudge.model.trim() ? { model: aiJudge.model.trim() } : {}),
+      };
+    }
+    return parser;
+  };
+
   const runPreview = async () => {
     if (!validateFields()) return;
     parsing.value = true;
     try {
-      const extractors = Object.fromEntries(
-        fields.value.map((field) => [field.name.trim(), field.selector.trim()])
-      );
       const { data: res } = (await axios.post(
         '/api/admin/tools/web-monitor/preview',
         {
           html: htmlContent.value,
           url: url.value,
           use_browserless: enhancedMode.value,
-          web_monitor_parser: {
-            extractors,
-            key_fields: selectedKeyFields.value,
-            title_template: templates.title,
-            description_template: templates.description,
-            content_template: templates.content,
-          },
+          web_monitor_parser: buildParserConfig(),
         }
       )) as any;
 
@@ -685,9 +790,6 @@
     if (!validateFields()) return;
 
     saving.value = true;
-    const extractors = Object.fromEntries(
-      fields.value.map((field) => [field.name.trim(), field.selector.trim()])
-    );
 
     const sourceConfig = {
       type: 'web_monitor',
@@ -695,13 +797,7 @@
         url: url.value,
         use_browserless: enhancedMode.value,
       },
-      web_monitor_parser: {
-        extractors,
-        key_fields: selectedKeyFields.value,
-        title_template: templates.title,
-        description_template: templates.description,
-        content_template: templates.content,
-      },
+      web_monitor_parser: buildParserConfig(),
       feed_meta: {
         title: feedMeta.title,
         link: feedMeta.link,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 背景

在已有的「网页内容变化监控（Web Monitor）」能力（见 `proposal/web_monitor_plan.md`）之上，新增**可选的 AI 判定**步骤，将"原始文本变化"升级为"语义状态变化"。

纯文本 key field 有时过于敏感：库存文案可能在 `Sold Out` / `Currently unavailable` / `缺货` 之间反复横跳，但语义上都是"不可购买"。用户真正关心的是"能不能买"。AI 判定让 LLM 根据提取到的字段值产出一个简短、稳定的判定标签（如 `available` / `unavailable`），再把它当作派生变量参与模板渲染与 GUID 生成。

## 改动

- **config**：`WebMonitorParserConfig` 新增可选 `ai_judge`（`enabled` / `prompt` / `output_field` / `model`）。
- **parser**：
  - AI 判定**先于** key field 校验执行，因此判定结果本身可被选为 key field。
  - 输入上下文按 key 排序，确定性拼接；温度固定为 `0`。
  - 复用 `adapter.CallLLMUsingContext`（按 prompt+context 哈希缓存），保证请求驱动模型下相同页面状态得到相同判定，避免 GUID 抖动造成通知风暴。
  - 校验：启用时 prompt 必填；`output_field` 不可为保留变量 `url`，也不可与已有 extractor 重名；判定失败直接报错（不静默 fallback）。
- **frontend**：Web Monitor 向导第 2 步新增可折叠的「AI 判定（可选）」卡片（开关 / 判定指令 / 输出变量名 / 模型 / 一键勾选用作关键字段），预览结果以标签展示判定值；中英文 i18n 同步。
- **tests**：覆盖判定变量注入、AI 判定驱动 GUID、自定义输出字段、prompt 缺失、字段冲突、判定报错、未启用时不调用等。
- **docs**：在 `proposal/web_monitor_plan.md` 补充「9.5 可选的 AI 判定」章节。

## 工作机制

用户通常把 `ai_verdict` 勾选为 key field：GUID 由语义判定驱动，仅当判定结果变化时 RSS Reader 才识别为新 item，从而精准推送"语义状态变化"而非文案抖动。

## 测试

- ✅ `go test ./...`
- ✅ `task fix`（golangci-lint 0 issues；前端仅有预存在的 v-html 告警）
- ✅ `task backend-build`
- ✅ `task frontend-build`
- ✅ `pnpm run type:check`
- ✅ 手动联调：mock LLM 端点下通过向导启用 AI 判定并运行预览，验证判定标签注入、模板渲染与 GUID 行为（见下方演示）。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5d5cd186-ae0e-4d6c-b44c-7df359f29b02"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5d5cd186-ae0e-4d6c-b44c-7df359f29b02"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

## Summary by Sourcery

Add an optional LLM-based judgement step to Web Monitor so feeds can be driven by semantic verdicts rather than raw text changes.

New Features:
- Introduce configurable AI judgement (prompt, output variable, model) in Web Monitor parser to derive a stable verdict label from extracted fields.
- Expose an "AI 判定 / AI Judgement" card in the Web Monitor wizard to configure the judgement instruction, output variable, model, and whether the verdict should be a key field, and show the verdict in preview.

Enhancements:
- Ensure AI verdict is injected before key-field validation so it can be used as a key field driving GUID stability.
- Build deterministic LLM prompt/context and normalize verdict output to keep GUIDs stable across identical page states.
- Refactor Web Monitor frontend parser config construction to include optional ai_judge settings when enabled.

Documentation:
- Extend the Web Monitor proposal with a new section describing the optional AI judgement capability, configuration, flow, and stability considerations.

Tests:
- Add tests covering AI verdict injection, GUID behavior when verdict changes vs raw text changes, custom output field handling, missing prompt and output-field conflicts, error propagation, and disabled mode behavior.