### PR TITLE
ci: fix golangci-lint timeout

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,6 +25,7 @@ jobs:
         uses: golangci/golangci-lint-action@v6
         with:
           version: latest
+          args: --timeout=10m
 
       - uses: pnpm/action-setup@v6
         with:


### PR DESCRIPTION
The golangci-lint action was frequently failing with a 'Timeout exceeded' error. This commit increases the timeout limit to 10m using the `args: --timeout=10m` parameter in the `.github/workflows/lint.yml` file to resolve the issue.

---
*PR created automatically by Jules for task [1513906226506688854](https://jules.google.com/task/1513906226506688854) started by @Colin-XKL*

## Summary by Sourcery

CI:
- Configure golangci-lint GitHub Action to run with a 10-minute timeout in the lint workflow.