### PR TITLE
Add re-title atom craft

### DIFF
--- a/internal/constant/prompt_library.go
+++ b/internal/constant/prompt_library.go
@@ -6,6 +6,7 @@ type ProcessorType string
 const (
 	ProcessorTypeIntroduction ProcessorType = "add-introduction"
 	ProcessorTypeSummary      ProcessorType = "add-summary"
+	ProcessorTypeRetitle      ProcessorType = "re-title"
 	// Add more processor types here
 )
 
@@ -40,5 +41,17 @@ Guidelines
 
 
 Input Article Content:
+`,
+	ProcessorTypeRetitle: `
+You are a senior headline editor. Generate one concise, attractive title for the provided article.
+
+Guidelines:
+1. Use only the supplied article title and content. Do not invent facts.
+2. Prefer a short title that is specific, vivid, and easy to scan.
+3. Keep the title in {{.TargetLang}}.
+4. Return only the title text. Do not include quotes, markdown, labels, or explanations.
+5. If the article content is empty or does not contain enough information to create a reliable new title, return exactly: __FEEDCRAFT_KEEP_ORIGINAL_TITLE__
+
+Input Article:
 `,
 }

--- a/internal/craft/entry.go
+++ b/internal/craft/entry.go
@@ -100,6 +100,12 @@ func GetSysCraftTemplateDict() map[string]CraftTemplate {
 		ParamTemplateDefine: summaryCraftParamTmpl,
 		OptionFunc:          summaryCraftLoadParam,
 	}
+	sysCraftTempList["re-title"] = CraftTemplate{
+		Name:                "re-title",
+		Description:         "使用 LLM 根据文章内容重新生成简洁、有吸引力的标题",
+		ParamTemplateDefine: retitleCraftParamTmpl,
+		OptionFunc:          retitleCraftLoadParam,
+	}
 	sysCraftTempList["ignore-advertorial"] = CraftTemplate{
 		Name:                "ignore-advertorial",
 		Description:         "使用 LLM 排除广告文章",

--- a/internal/craft/llm_processors.go
+++ b/internal/craft/llm_processors.go
@@ -195,7 +195,7 @@ func newTranslateTitleProcessor(prompt string) *ArticleTextTransformProcessor {
 }
 
 func newRetitleProcessor(prompt string) *ArticleTextTransformProcessor {
-	finalPrompt := renderTargetLangPrompt(prompt, constant.DefaultPrompts[constant.ProcessorTypeRetitle])
+	finalPrompt := renderRetitlePrompt(prompt)
 	transformer := GetCommonCachedArticleTransformer(
 		newArticleTitleContentCacheKeyGenerator(finalPrompt),
 		func(ctx context.Context, article *model.CraftArticle) (string, error) {

--- a/internal/craft/llm_processors.go
+++ b/internal/craft/llm_processors.go
@@ -194,6 +194,42 @@ func newTranslateTitleProcessor(prompt string) *ArticleTextTransformProcessor {
 	}
 }
 
+func newRetitleProcessor(prompt string) *ArticleTextTransformProcessor {
+	finalPrompt := renderTargetLangPrompt(prompt, constant.DefaultPrompts[constant.ProcessorTypeRetitle])
+	transformer := GetCommonCachedArticleTransformer(
+		newArticleTitleContentCacheKeyGenerator(finalPrompt),
+		func(ctx context.Context, article *model.CraftArticle) (string, error) {
+			originalTitle := article.Title
+			originalContent := getPrimaryArticleContent(article)
+			if strings.TrimSpace(originalContent) == "" {
+				return originalTitle, nil
+			}
+			contentForPrompt := getArticleContentForPrompt(article, originalContent)
+			generated, err := CallLLMForArticleTransform(finalPrompt, originalTitle, contentForPrompt, util.ContentProcessOption{})
+			if err != nil {
+				return "", err
+			}
+			if shouldKeepOriginalTitle(generated) {
+				return originalTitle, nil
+			}
+			return strings.TrimSpace(generated), nil
+		},
+		string(constant.ProcessorTypeRetitle),
+	)
+
+	return &ArticleTextTransformProcessor{
+		CraftName: string(constant.ProcessorTypeRetitle),
+		Mutate: func(ctx context.Context, article *model.CraftArticle) error {
+			transformed, err := transformer(ctx, article)
+			if err != nil {
+				return err
+			}
+			article.Title = transformed
+			return nil
+		},
+	}
+}
+
 func newTranslateContentProcessor(prompt string) *ArticleTextTransformProcessor {
 	return newArticleContentLLMProcessor("translate article content", prompt, translateArticleContentPrompt)
 }

--- a/internal/craft/option.go
+++ b/internal/craft/option.go
@@ -132,6 +132,9 @@ func OptionTransformFeedItem(processor FeedItemProcessor) LegacyCraftOption {
 
 		// 1. 并发执行并将结果映射为错误切片
 		errs := parallel.Map(feed.Items, func(item *feeds.Item, _ int) error {
+			if item == nil {
+				return nil
+			}
 			err := processor(item, payload)
 			if err != nil {
 				logrus.Warnf("failed to process item [%s], err: %v", item.Title, err)

--- a/internal/craft/retitle.go
+++ b/internal/craft/retitle.go
@@ -1,6 +1,7 @@
 package craft
 
 import (
+	"fmt"
 	"strings"
 
 	"FeedCraft/internal/constant"
@@ -10,6 +11,18 @@ import (
 )
 
 const retitleNoChangeSentinel = "__FEEDCRAFT_KEEP_ORIGINAL_TITLE__"
+
+func renderRetitlePrompt(prompt string) string {
+	finalPrompt := renderTargetLangPrompt(prompt, constant.DefaultPrompts[constant.ProcessorTypeRetitle])
+	if strings.TrimSpace(prompt) == "" {
+		return finalPrompt
+	}
+	return fmt.Sprintf(`%s
+
+Important output contract:
+If the article content is empty or does not contain enough information to create a reliable new title, return exactly: %s
+Return only the new title or this special value. Do not include quotes, markdown, labels, or explanations.`, finalPrompt, retitleNoChangeSentinel)
+}
 
 func shouldKeepOriginalTitle(generated string) bool {
 	trimmed := strings.TrimSpace(generated)
@@ -45,9 +58,12 @@ func getFeedsItemContentForPrompt(item *feeds.Item, original string) string {
 }
 
 func GetRetitleCraftOptions(prompt string) []LegacyCraftOption {
-	finalPrompt := renderTargetLangPrompt(prompt, constant.DefaultPrompts[constant.ProcessorTypeRetitle])
+	finalPrompt := renderRetitlePrompt(prompt)
 	promptHash := util.GetTextContentHash(finalPrompt)
 	cacheKeyGenerator := func(item *feeds.Item) (string, error) {
+		if item == nil {
+			return promptHash, nil
+		}
 		payloadHash := util.GetTextContentHash(strings.Join([]string{
 			promptHash,
 			strings.TrimSpace(item.Title),
@@ -56,6 +72,9 @@ func GetRetitleCraftOptions(prompt string) []LegacyCraftOption {
 		return payloadHash, nil
 	}
 	transFunc := func(item *feeds.Item) (string, error) {
+		if item == nil {
+			return "", nil
+		}
 		originalTitle := item.Title
 		originalContent := getFeedsItemPrimaryContent(item)
 		if strings.TrimSpace(originalContent) == "" {

--- a/internal/craft/retitle.go
+++ b/internal/craft/retitle.go
@@ -1,0 +1,91 @@
+package craft
+
+import (
+	"strings"
+
+	"FeedCraft/internal/constant"
+	"FeedCraft/internal/util"
+
+	"github.com/gorilla/feeds"
+)
+
+const retitleNoChangeSentinel = "__FEEDCRAFT_KEEP_ORIGINAL_TITLE__"
+
+func shouldKeepOriginalTitle(generated string) bool {
+	trimmed := strings.TrimSpace(generated)
+	trimmed = strings.Trim(trimmed, "`\"' \n\t")
+	return trimmed == "" || strings.EqualFold(trimmed, retitleNoChangeSentinel)
+}
+
+func getFeedsItemPrimaryContent(item *feeds.Item) string {
+	if item == nil {
+		return ""
+	}
+	content := item.Content
+	if strings.TrimSpace(content) == "" {
+		content = item.Description
+	}
+	return content
+}
+
+func getFeedsItemContentForPrompt(item *feeds.Item, original string) string {
+	if item == nil {
+		return original
+	}
+	link := ""
+	if item.Link != nil {
+		link = item.Link.Href
+	}
+	domain, _ := util.ParseDomainFromUrl(link)
+	cleaned := util.HTMLToMarkdown(original, domain)
+	if strings.TrimSpace(cleaned) != "" {
+		return cleaned
+	}
+	return original
+}
+
+func GetRetitleCraftOptions(prompt string) []LegacyCraftOption {
+	finalPrompt := renderTargetLangPrompt(prompt, constant.DefaultPrompts[constant.ProcessorTypeRetitle])
+	promptHash := util.GetTextContentHash(finalPrompt)
+	cacheKeyGenerator := func(item *feeds.Item) (string, error) {
+		payloadHash := util.GetTextContentHash(strings.Join([]string{
+			promptHash,
+			strings.TrimSpace(item.Title),
+			strings.TrimSpace(getFeedsItemPrimaryContent(item)),
+		}, "|"))
+		return payloadHash, nil
+	}
+	transFunc := func(item *feeds.Item) (string, error) {
+		originalTitle := item.Title
+		originalContent := getFeedsItemPrimaryContent(item)
+		if strings.TrimSpace(originalContent) == "" {
+			return originalTitle, nil
+		}
+		contentForPrompt := getFeedsItemContentForPrompt(item, originalContent)
+		generated, err := CallLLMForArticleTransform(finalPrompt, originalTitle, contentForPrompt, util.ContentProcessOption{})
+		if err != nil {
+			return "", err
+		}
+		if shouldKeepOriginalTitle(generated) {
+			return originalTitle, nil
+		}
+		return strings.TrimSpace(generated), nil
+	}
+	transformer := GetCommonCachedTransformer(cacheKeyGenerator, transFunc, string(constant.ProcessorTypeRetitle))
+	return []LegacyCraftOption{
+		OptionTransformFeedItem(GetArticleTitleProcessor(transformer)),
+	}
+}
+
+func retitleCraftLoadParam(m map[string]string) []LegacyCraftOption {
+	prompt := m["prompt"]
+	return GetRetitleCraftOptions(prompt)
+}
+
+var retitleCraftParamTmpl = []ParamTemplate{
+	{
+		Key:         "prompt",
+		Description: "the llm prompt for regenerating article title",
+		Default:     constant.DefaultPrompts[constant.ProcessorTypeRetitle],
+	},
+}

--- a/internal/craft/runtime.go
+++ b/internal/craft/runtime.go
@@ -59,6 +59,7 @@ var nativeProcessorBuilders = map[string]nativeProcessorBuilder{
 	"fulltext-plus":               buildNativeFulltextPlusProcessor,
 	"summary":                     buildWithStringParam("prompt", func(s string) localProcessor { return newSummaryProcessor(s) }),
 	"introduction":                buildWithStringParam("prompt", func(s string) localProcessor { return newIntroductionProcessor(s) }),
+	"re-title":                    buildWithStringParam("prompt", func(s string) localProcessor { return newRetitleProcessor(s) }),
 	"translate-title":             buildWithStringParam("prompt", func(s string) localProcessor { return newTranslateTitleProcessor(s) }),
 	"translate-content":           buildWithStringParam("prompt", func(s string) localProcessor { return newTranslateContentProcessor(s) }),
 	"translate-content-immersive": buildWithStringParam("prompt", func(s string) localProcessor { return newTranslateContentImmersiveProcessor(s) }),

--- a/internal/craft/runtime_test.go
+++ b/internal/craft/runtime_test.go
@@ -323,6 +323,7 @@ func TestRetitleProcessor_UsesArticleContentAndUpdatesTitle(t *testing.T) {
 	original := llmContextCaller
 	llmContextCaller = func(prompt, context string, option util.ContentProcessOption) (string, error) {
 		assert.Contains(t, prompt, "custom retitle prompt")
+		assert.Contains(t, prompt, retitleNoChangeSentinel)
 		assert.Contains(t, context, "Original Title")
 		assert.Contains(t, context, "article body worth retitling")
 		return "Sharper Generated Title", nil
@@ -399,6 +400,7 @@ func TestRetitleTemplate_BuildsNativeProcessorWithCustomPrompt(t *testing.T) {
 	original := llmContextCaller
 	llmContextCaller = func(prompt, context string, option util.ContentProcessOption) (string, error) {
 		assert.Contains(t, prompt, "custom retitle prompt "+t.Name())
+		assert.Contains(t, prompt, retitleNoChangeSentinel)
 		return "Custom Prompt Title", nil
 	}
 	t.Cleanup(func() { llmContextCaller = original })
@@ -429,16 +431,20 @@ func TestRetitleLegacyOption_KeepsOriginalTitleForNoChangeSentinel(t *testing.T)
 
 	option := GetRetitleCraftOptions("legacy retitle prompt " + t.Name())[0]
 	feed := &feeds.Feed{
-		Items: []*feeds.Item{{
-			Title:       "Legacy Title " + t.Name(),
-			Link:        &feeds.Link{Href: "https://example.com/post"},
-			Description: "<p>legacy body " + t.Name() + "</p>",
-		}},
+		Items: []*feeds.Item{
+			nil,
+			{
+				Title:       "Legacy Title " + t.Name(),
+				Link:        &feeds.Link{Href: "https://example.com/post"},
+				Description: "<p>legacy body " + t.Name() + "</p>",
+			},
+		},
 	}
 
 	err := option(feed, ExtraPayload{originalFeedUrl: "https://example.com/feed.xml"})
 	require.NoError(t, err)
-	assert.Equal(t, "Legacy Title "+t.Name(), feed.Items[0].Title)
+	require.Nil(t, feed.Items[0])
+	assert.Equal(t, "Legacy Title "+t.Name(), feed.Items[1].Title)
 }
 
 func TestBeautifyContentProcessor_WritesHTML(t *testing.T) {

--- a/internal/craft/runtime_test.go
+++ b/internal/craft/runtime_test.go
@@ -12,6 +12,7 @@ import (
 	"FeedCraft/internal/util"
 
 	"github.com/glebarez/sqlite"
+	"github.com/gorilla/feeds"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gorm.io/gorm"
@@ -314,6 +315,130 @@ func TestTranslateTitleProcessor_UsesNativeLLMFlow(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "Translated Title", result.Articles[0].Title)
 	assert.Equal(t, "Original Title "+t.Name(), feed.Articles[0].Title)
+}
+
+func TestRetitleProcessor_UsesArticleContentAndUpdatesTitle(t *testing.T) {
+	setupTestRedis(t)
+
+	original := llmContextCaller
+	llmContextCaller = func(prompt, context string, option util.ContentProcessOption) (string, error) {
+		assert.Contains(t, prompt, "custom retitle prompt")
+		assert.Contains(t, context, "Original Title")
+		assert.Contains(t, context, "article body worth retitling")
+		return "Sharper Generated Title", nil
+	}
+	t.Cleanup(func() { llmContextCaller = original })
+
+	processor := newRetitleProcessor("custom retitle prompt " + t.Name())
+	feed := &model.CraftFeed{
+		Articles: []*model.CraftArticle{{
+			Title:   "Original Title " + t.Name(),
+			Content: "<p>article body worth retitling " + t.Name() + "</p>",
+		}},
+	}
+
+	result, err := processor.Process(context.Background(), feed)
+	require.NoError(t, err)
+	assert.Equal(t, "Sharper Generated Title", result.Articles[0].Title)
+	assert.Equal(t, "Original Title "+t.Name(), feed.Articles[0].Title)
+}
+
+func TestRetitleProcessor_KeepsOriginalTitleForNoChangeSentinel(t *testing.T) {
+	setupTestRedis(t)
+
+	original := llmContextCaller
+	llmContextCaller = func(prompt, context string, option util.ContentProcessOption) (string, error) {
+		return retitleNoChangeSentinel, nil
+	}
+	t.Cleanup(func() { llmContextCaller = original })
+
+	processor := newRetitleProcessor("retitle prompt " + t.Name())
+	feed := &model.CraftFeed{
+		Articles: []*model.CraftArticle{{
+			Title:   "Original Title " + t.Name(),
+			Content: "<p>too little signal</p>",
+		}},
+	}
+
+	result, err := processor.Process(context.Background(), feed)
+	require.NoError(t, err)
+	assert.Equal(t, "Original Title "+t.Name(), result.Articles[0].Title)
+}
+
+func TestRetitleProcessor_SkipsEmptyContent(t *testing.T) {
+	setupTestRedis(t)
+
+	original := llmContextCaller
+	llmContextCaller = func(prompt, context string, option util.ContentProcessOption) (string, error) {
+		t.Fatalf("llm should not be called for empty article content")
+		return "", nil
+	}
+	t.Cleanup(func() { llmContextCaller = original })
+
+	processor := newRetitleProcessor("retitle prompt " + t.Name())
+	feed := &model.CraftFeed{
+		Articles: []*model.CraftArticle{{
+			Title: "Original Title " + t.Name(),
+		}},
+	}
+
+	result, err := processor.Process(context.Background(), feed)
+	require.NoError(t, err)
+	assert.Equal(t, "Original Title "+t.Name(), result.Articles[0].Title)
+}
+
+func TestRetitleTemplate_BuildsNativeProcessorWithCustomPrompt(t *testing.T) {
+	setupTestRedis(t)
+	db := newCraftRuntimeTestDB(t)
+	require.NoError(t, dao.CreateCraftAtom(db, &dao.CraftAtom{
+		Name:         "custom-retitle",
+		TemplateName: "re-title",
+		Params:       map[string]string{"prompt": "custom retitle prompt " + t.Name()},
+	}))
+
+	original := llmContextCaller
+	llmContextCaller = func(prompt, context string, option util.ContentProcessOption) (string, error) {
+		assert.Contains(t, prompt, "custom retitle prompt "+t.Name())
+		return "Custom Prompt Title", nil
+	}
+	t.Cleanup(func() { llmContextCaller = original })
+
+	processor, err := BuildOptionChain(db, "custom-retitle", "https://example.com/feed.xml")
+	require.NoError(t, err)
+	require.NotNil(t, processor)
+
+	result, err := processor(context.Background(), &model.CraftFeed{
+		Articles: []*model.CraftArticle{{
+			Title:   "Original Title " + t.Name(),
+			Content: "<p>article body worth retitling " + t.Name() + "</p>",
+		}},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "Custom Prompt Title", result.Articles[0].Title)
+}
+
+func TestRetitleLegacyOption_KeepsOriginalTitleForNoChangeSentinel(t *testing.T) {
+	setupTestRedis(t)
+
+	original := llmContextCaller
+	llmContextCaller = func(prompt, context string, option util.ContentProcessOption) (string, error) {
+		assert.Contains(t, context, "legacy body")
+		return retitleNoChangeSentinel, nil
+	}
+	t.Cleanup(func() { llmContextCaller = original })
+
+	option := GetRetitleCraftOptions("legacy retitle prompt " + t.Name())[0]
+	feed := &feeds.Feed{
+		Items: []*feeds.Item{{
+			Title:       "Legacy Title " + t.Name(),
+			Link:        &feeds.Link{Href: "https://example.com/post"},
+			Description: "<p>legacy body " + t.Name() + "</p>",
+		}},
+	}
+
+	err := option(feed, ExtraPayload{originalFeedUrl: "https://example.com/feed.xml"})
+	require.NoError(t, err)
+	assert.Equal(t, "Legacy Title "+t.Name(), feed.Items[0].Title)
 }
 
 func TestBeautifyContentProcessor_WritesHTML(t *testing.T) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add built-in `re-title` AtomCraft for LLM-generated concise article titles.
- Support custom prompt override while preserving the no-change sentinel contract.
- Keep original titles when content is empty, LLM returns `__FEEDCRAFT_KEEP_ORIGINAL_TITLE__`, or LLM returns blank output.
- Cover native runtime, custom atom, empty-content, sentinel, legacy option, and nil legacy feed item behavior with tests.

## Validation on latest `dev`
- `go test ./internal/craft -run 'TestRetitle' -count=1`
- `go test ./...`
- `task fix` (Go lint: 0 issues; frontend retains 2 existing `vue/no-v-html` warnings)
- `task backend-build`
- `task --force frontend-build`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3555e816-d242-433f-b714-4875eb4714d7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3555e816-d242-433f-b714-4875eb4714d7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

## Summary by Sourcery

Introduce an LLM-powered retitle processor and integrate it into both native and legacy craft pipelines for generating concise article titles while preserving originals when appropriate.

New Features:
- Add a re-title processor that uses article content and a configurable prompt to generate concise new titles via LLM.
- Expose a built-in re-title craft template for configuring retitle behavior through system craft definitions.

Enhancements:
- Extend the prompt library with a default re-title prompt and a no-change sentinel contract to safely preserve original titles when content is insufficient.
- Add legacy feed item retitle support with caching and HTML-to-markdown normalization while safely handling nil feed items in the transform pipeline.

Tests:
- Add runtime and legacy option tests covering retitle behavior, including content-based generation, custom prompts, empty content, sentinel handling, and nil legacy feed items.