### PR TITLE
ci: 升级 GitHub Actions 到 Node 24 并修复 golangci-lint

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -29,25 +29,25 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       # Install the cosign tool except on PR
       # https://github.com/sigstore/cosign-installer
       - name: Install cosign
         if: github.event_name != 'pull_request'
-        uses: sigstore/cosign-installer@v3.9.2
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
 
       # Set up BuildKit Docker container builder to be able to build
       # multi-platform images and export cache
       # https://github.com/docker/setup-buildx-action
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       # Login against a Docker registry except on PR
       # https://github.com/docker/login-action
       - name: Log into extra registry ${{ env.REGISTRY }}
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -55,7 +55,7 @@ jobs:
 
       - name: Login to Docker Hub
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v3
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -64,7 +64,7 @@ jobs:
       # https://github.com/docker/metadata-action
       - name: Extract Docker metadata
         id: meta
-        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5.10.0
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
         with:
           images: |
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
@@ -99,7 +99,7 @@ jobs:
       # https://github.com/docker/build-push-action
       - name: Build and push Docker image
         id: build-and-push
-        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           file: build/Dockerfile
           context: .

--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -24,10 +24,10 @@ jobs:
           --health-timeout 5s
           --health-retries 5
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v7
         with:
           go-version: "1.25.13"
           cache: true

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,26 +14,26 @@ jobs:
     name: Format and Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v7
         with:
           go-version: "1.25.13"
           cache: false
 
       - name: Install golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v9
         with:
-          version: latest
-          args: --timeout=10m
+          version: v2.12.2
+          install-only: true
 
       - uses: pnpm/action-setup@v6
         with:
-          version: 9
+          version: 10
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
-          node-version: "22"
+          node-version: "24"
           cache: "pnpm"
           cache-dependency-path: web/admin/pnpm-lock.yaml
 

--- a/.github/workflows/ossar.yml
+++ b/.github/workflows/ossar.yml
@@ -32,7 +32,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       # Ensure a compatible version of dotnet is installed.
       # The [Microsoft Security Code Analysis CLI](https://aka.ms/mscadocs) is built with dotnet v3.1.201.
@@ -45,7 +45,7 @@ jobs:
       #     dotnet-version: '3.1.x'
       # Run open source static analysis tools
       - name: Run OSSAR
-        uses: github/ossar-action@v1
+        uses: github/ossar-action@v2
         id: ossar
 
         # Upload results to the Security tab

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -328,7 +328,7 @@ tasks:
       - cmd: |
           echo "Running Go linter..."
           if command -v golangci-lint >/dev/null 2>&1; then
-            golangci-lint run ./...
+            golangci-lint run ./... --timeout=10m
           else
             echo "golangci-lint not installed. Please install it to lint Go code."
             exit 1


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 问题

近期 `Lint` workflow 在 `dev` 上失败，同时 GitHub Actions 提示 Node.js 20 已弃用。

**Lint 失败根因：** `golangci/golangci-lint-action@v6` 安装的仍是 golangci-lint v1.64.8（用 Go 1.24 构建）。项目 `go.mod` 的 toolchain 是 `go1.25.13`，因此报错：

```
can't load config: the Go language version (go1.24) used to build golangci-lint is lower than the targeted Go version (1.25.13)
```

**Node 20 弃用：** runner 已默认用 Node 24 强制执行仍声明 `node20` 的 action，例如 `actions/checkout@v4`、`actions/setup-go@v5`、`golangci-lint-action@v6`、`docker/setup-buildx-action@v3`、`docker/metadata-action@v5`。

## 改动

- 将 `checkout` / `setup-go` / `setup-node` 升到 v7（Node 24 runtime），前端 Node 版本改为 `24`
- `golangci-lint-action` 升到 v9，安装 golangci-lint **v2.12.2**（`install-only`），由 `task fix` 实际执行
- Docker publish 相关 action 升到 Node 24 版本（buildx v4.2.0、metadata v6.2.0、login v4.6.0、build-push v7.3.0、cosign-installer v4.1.2）
- OSSAR 升到 v2（上游仍声明 node20，这是目前最新可用版本；runner 会强制用 Node 24）
- `task lint` 为 golangci-lint 增加 `--timeout=10m`

## 验证

本 PR 上 GitHub Actions 已全部通过：

- Format and Lint：通过（golangci-lint v2.12.2，Node v24.18.0，无 Node 20 弃用警告）
- Golang Test：通过
- Docker Build & Release：通过

## 说明

`github/ossar-action@v2` 仍声明 Node 20，暂无 Node 24 版本。其余 JavaScript action 均已切到 `using: node24`。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9b61bb6e-d3c3-46b6-848c-91d169450aa0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9b61bb6e-d3c3-46b6-848c-91d169450aa0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

## Summary by Sourcery

升级 CI/CD 工作流至 Node 24，并修复 Go lint 工具链版本兼容性问题。

Bug Fixes:
- 修复 golangci-lint 与项目 Go toolchain 版本不匹配导致的 lint 失败。

Enhancements:
- 将 GitHub Actions 及 Docker 发布流程升级至兼容 Node 24 的最新可用版本，并统一使用指定的 golangci-lint v2.12.2。
- 为 Go lint 检查设置 10 分钟超时，并升级 OSSAR action。

CI:
- 升级 lint、Go 测试和 OSSAR workflows 中的 Actions 依赖，并将前端 CI Node.js 版本升级至 24。

Deployment:
- 升级 Docker 构建、镜像元数据、登录和签名工具相关 actions。