### PR TITLE
fix(admin): 为空列表页增加创建引导

### DIFF
--- a/web/admin/src/components/list-empty-guide/index.vue
+++ b/web/admin/src/components/list-empty-guide/index.vue
@@ -1,28 +1,20 @@
 <template>
   <div class="list-empty-guide">
-    <a-empty :description="description">
-      <template #extra>
-        <div class="list-empty-guide__extra">
-          <p v-if="hint" class="list-empty-guide__hint">{{ hint }}</p>
-          <a-space>
-            <a-button type="primary" @click="$emit('create')">
-              <template #icon>
-                <icon-plus />
-              </template>
-              {{ createLabel }}
-            </a-button>
-            <a-link
-              :href="docsHref"
-              target="_blank"
-              rel="noopener noreferrer"
-              icon
-            >
-              {{ docsLabel }}
-            </a-link>
-          </a-space>
-        </div>
-      </template>
-    </a-empty>
+    <a-empty :description="description" />
+    <div class="list-empty-guide__extra">
+      <p v-if="hint" class="list-empty-guide__hint">{{ hint }}</p>
+      <a-space>
+        <a-button type="primary" @click="$emit('create')">
+          <template #icon>
+            <icon-plus />
+          </template>
+          {{ createLabel }}
+        </a-button>
+        <a-link :href="docsHref" target="_blank" rel="noopener noreferrer" icon>
+          {{ docsLabel }}
+        </a-link>
+      </a-space>
+    </div>
   </div>
 </template>
 

--- a/web/admin/src/components/list-empty-guide/index.vue
+++ b/web/admin/src/components/list-empty-guide/index.vue
@@ -1,0 +1,68 @@
+<template>
+  <div class="list-empty-guide">
+    <a-empty :description="description">
+      <template #extra>
+        <div class="list-empty-guide__extra">
+          <p v-if="hint" class="list-empty-guide__hint">{{ hint }}</p>
+          <a-space>
+            <a-button type="primary" @click="$emit('create')">
+              <template #icon>
+                <icon-plus />
+              </template>
+              {{ createLabel }}
+            </a-button>
+            <a-link
+              :href="docsHref"
+              target="_blank"
+              rel="noopener noreferrer"
+              icon
+            >
+              {{ docsLabel }}
+            </a-link>
+          </a-space>
+        </div>
+      </template>
+    </a-empty>
+  </div>
+</template>
+
+<script lang="ts" setup>
+  defineProps<{
+    description: string;
+    hint?: string;
+    createLabel: string;
+    docsLabel: string;
+    docsHref: string;
+  }>();
+
+  defineEmits<{
+    (e: 'create'): void;
+  }>();
+</script>
+
+<script lang="ts">
+  export default {
+    name: 'ListEmptyGuide',
+  };
+</script>
+
+<style scoped lang="less">
+  .list-empty-guide {
+    padding: 3rem 1rem;
+  }
+
+  .list-empty-guide__extra {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.75rem;
+  }
+
+  .list-empty-guide__hint {
+    max-width: 28rem;
+    margin: 0;
+    color: var(--color-text-3);
+    font-size: 0.875rem;
+    line-height: 1.5;
+  }
+</style>

--- a/web/admin/src/locale/en-US/craftAtom.ts
+++ b/web/admin/src/locale/en-US/craftAtom.ts
@@ -22,4 +22,9 @@ export default {
   'craftAtom.form.save': 'Save',
   'craftAtom.form.rule.templateRequired': 'Template is required',
   'craftAtom.form.rule.nameRequired': 'Name is required',
+  'craftAtom.empty.description': 'No AtomCrafts yet',
+  'craftAtom.empty.hint':
+    'AtomCrafts define how an RSS feed is processed, such as translation, full-text extraction, or summarization. Create your first one to reuse it in recipes and FlowCrafts.',
+  'craftAtom.empty.createFirst': 'Create your first AtomCraft',
+  'craftAtom.empty.docs': 'Read the customization guide',
 };

--- a/web/admin/src/locale/en-US/craftFlow.ts
+++ b/web/admin/src/locale/en-US/craftFlow.ts
@@ -21,4 +21,9 @@ export default {
   'craftFlow.editor.moveUp': 'Move Up',
   'craftFlow.editor.moveDown': 'Move Down',
   'craftFlow.editor.remove': 'Remove',
+  'craftFlow.empty.description': 'No FlowCrafts yet',
+  'craftFlow.empty.hint':
+    'A FlowCraft chains multiple AtomCrafts into a processing pipeline. Create your first one to run extraction, filtering, and summarization in sequence.',
+  'craftFlow.empty.createFirst': 'Create your first FlowCraft',
+  'craftFlow.empty.docs': 'Read the customization guide',
 };

--- a/web/admin/src/locale/en-US/topic.ts
+++ b/web/admin/src/locale/en-US/topic.ts
@@ -34,6 +34,10 @@ export default {
   'topic.deleteAction': 'Delete',
   'topic.deleteConfirm': 'Are you sure you want to delete this topic?',
   'topic.noTopics': 'No topics yet',
+  'topic.empty.hint':
+    'Create your first topic to combine multiple RSS sources into one feed. You can also read the quick start guide first.',
+  'topic.empty.createFirst': 'Create your first topic',
+  'topic.empty.docs': 'Read the quick start guide',
   'topic.inputs': 'Inputs',
   'topic.inputsHelp':
     'For External RSS, enter an http/https URL. For Recipe, Topic, or Inbox, pick from the dropdown to use internal FeedCraft resources.',

--- a/web/admin/src/locale/zh-CN/craftAtom.ts
+++ b/web/admin/src/locale/zh-CN/craftAtom.ts
@@ -22,4 +22,9 @@ export default {
   'craftAtom.form.save': '保存',
   'craftAtom.form.rule.templateRequired': 'template is required',
   'craftAtom.form.rule.nameRequired': 'Name is required',
+  'craftAtom.empty.description': '暂无原子工艺',
+  'craftAtom.empty.hint':
+    '原子工艺决定如何处理 RSS，例如翻译、提取全文或生成摘要。创建第一个 AtomCraft 后即可在配方和组合工艺中复用。',
+  'craftAtom.empty.createFirst': '创建第一个原子工艺',
+  'craftAtom.empty.docs': '查看定制指南',
 };

--- a/web/admin/src/locale/zh-CN/craftFlow.ts
+++ b/web/admin/src/locale/zh-CN/craftFlow.ts
@@ -21,4 +21,9 @@ export default {
   'craftFlow.editor.moveUp': '上移',
   'craftFlow.editor.moveDown': '下移',
   'craftFlow.editor.remove': '移除',
+  'craftFlow.empty.description': '暂无组合工艺',
+  'craftFlow.empty.hint':
+    '组合工艺把多个原子工艺串成处理流水线。创建第一个 FlowCraft，即可对订阅源按顺序执行提取、筛选和摘要。',
+  'craftFlow.empty.createFirst': '创建第一个组合工艺',
+  'craftFlow.empty.docs': '查看定制指南',
 };

--- a/web/admin/src/locale/zh-CN/topic.ts
+++ b/web/admin/src/locale/zh-CN/topic.ts
@@ -33,6 +33,10 @@ export default {
   'topic.deleteAction': '删除',
   'topic.deleteConfirm': '确定要删除这个主题吗？',
   'topic.noTopics': '暂无主题',
+  'topic.empty.hint':
+    '创建第一个主题，把多个 RSS 源聚合到同一条订阅里。也可以先阅读快速开始文档了解核心概念。',
+  'topic.empty.createFirst': '创建第一个主题',
+  'topic.empty.docs': '查看快速开始文档',
   'topic.inputs': '输入源',
   'topic.inputsHelp':
     '外部 RSS 直接填入 http/https 地址；选择 Recipe、Topic 或 Inbox 可从下拉列表中选取 FeedCraft 内部资源。',

--- a/web/admin/src/utils/docsUrl.test.ts
+++ b/web/admin/src/utils/docsUrl.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { buildDocsUrl } from '@/utils/docsUrl';
+
+describe('buildDocsUrl', () => {
+  it('maps zh-CN to the simplified Chinese docs site', () => {
+    expect(buildDocsUrl('zh-CN', 'guides/start/quick-start')).toBe(
+      'https://feed-craft-doc.vercel.app/zh/guides/start/quick-start/'
+    );
+  });
+
+  it('maps zh-TW to the traditional Chinese docs site', () => {
+    expect(buildDocsUrl('zh-TW', 'guides/start/quick-start')).toBe(
+      'https://feed-craft-doc.vercel.app/zh-tw/guides/start/quick-start/'
+    );
+  });
+
+  it('maps en-US and unknown locales to the English docs site', () => {
+    expect(buildDocsUrl('en-US', 'guides/advanced/customization')).toBe(
+      'https://feed-craft-doc.vercel.app/en/guides/advanced/customization/'
+    );
+    expect(buildDocsUrl('fr-FR', 'guides/start/quick-start')).toBe(
+      'https://feed-craft-doc.vercel.app/en/guides/start/quick-start/'
+    );
+  });
+
+  it('keeps a trailing slash and strips extra leading slashes on the path', () => {
+    expect(buildDocsUrl('zh-CN', '/guides/start/quick-start/')).toBe(
+      'https://feed-craft-doc.vercel.app/zh/guides/start/quick-start/'
+    );
+  });
+});

--- a/web/admin/src/utils/docsUrl.ts
+++ b/web/admin/src/utils/docsUrl.ts
@@ -1,0 +1,20 @@
+const DOCS_ORIGIN = 'https://feed-craft-doc.vercel.app';
+
+const LOCALE_TO_DOCS_LANG: Record<string, string> = {
+  'zh-CN': 'zh',
+  'zh-TW': 'zh-tw',
+  'en-US': 'en',
+};
+
+export function docsLangForLocale(locale?: string): string {
+  if (!locale) {
+    return 'en';
+  }
+  return LOCALE_TO_DOCS_LANG[locale] ?? 'en';
+}
+
+export function buildDocsUrl(locale: string, path: string): string {
+  const lang = docsLangForLocale(locale);
+  const normalizedPath = path.replace(/^\/+/, '').replace(/\/+$/, '');
+  return `${DOCS_ORIGIN}/${lang}/${normalizedPath}/`;
+}

--- a/web/admin/src/views/dashboard/craft_atom/craft_atom.vue
+++ b/web/admin/src/views/dashboard/craft_atom/craft_atom.vue
@@ -14,7 +14,12 @@
       </a-button>
     </a-space>
 
-    <a-table :data="craftAtoms" :columns="columns" :loading="isLoading">
+    <a-table
+      v-if="isLoading || craftAtoms.length > 0"
+      :data="craftAtoms"
+      :columns="columns"
+      :loading="isLoading"
+    >
       <template #actions="{ record }">
         <a-space>
           <a-button type="outline" @click="editBtnHandler(record)"
@@ -29,6 +34,16 @@
         </a-space>
       </template>
     </a-table>
+
+    <ListEmptyGuide
+      v-else
+      :description="t('craftAtom.empty.description')"
+      :hint="t('craftAtom.empty.hint')"
+      :create-label="t('craftAtom.empty.createFirst')"
+      :docs-label="t('craftAtom.empty.docs')"
+      :docs-href="atomDocsHref"
+      @create="handleAdd"
+    />
 
     <a-modal
       v-model:visible="showEditModal"
@@ -216,7 +231,9 @@
 
 <script setup lang="ts">
   import XHeader from '@/components/header/x-header.vue';
-  import { onBeforeMount, ref } from 'vue';
+  import ListEmptyGuide from '@/components/list-empty-guide/index.vue';
+  import { computed, onBeforeMount, ref } from 'vue';
+  import { buildDocsUrl } from '@/utils/docsUrl';
   import {
     CraftAtom,
     createCraftAtom,
@@ -243,7 +260,10 @@
     toCraftParamFormValue,
   } from '@/views/dashboard/craft_atom/paramOptions';
 
-  const { t } = useI18n();
+  const { t, locale } = useI18n();
+  const atomDocsHref = computed(() =>
+    buildDocsUrl(locale.value, 'guides/advanced/customization')
+  );
 
   const isLoading = ref(false);
   const formRef = ref();
@@ -351,7 +371,7 @@
 
   async function listAllCraftAtoms() {
     isLoading.value = true;
-    craftAtoms.value = (await listCraftAtoms()).data;
+    craftAtoms.value = (await listCraftAtoms()).data ?? [];
     isLoading.value = false;
   }
 

--- a/web/admin/src/views/dashboard/craft_atom/craft_atom.vue
+++ b/web/admin/src/views/dashboard/craft_atom/craft_atom.vue
@@ -5,45 +5,52 @@
       :description="t('craftAtom.description')"
     ></x-header>
 
-    <a-space direction="horizontal" class="mb-6">
-      <a-button type="primary" :loading="isLoading" @click="listAllCraftAtoms">
-        {{ t('craftAtom.query') }}
-      </a-button>
-      <a-button type="outline" @click="handleAdd"
-        >{{ t('craftAtom.create') }}
-      </a-button>
-    </a-space>
-
-    <a-table
-      v-if="isLoading || craftAtoms.length > 0"
-      :data="craftAtoms"
-      :columns="columns"
-      :loading="isLoading"
-    >
-      <template #actions="{ record }">
+    <a-card class="general-card" :title="t('menu.craftAtom')">
+      <template #extra>
         <a-space>
-          <a-button type="outline" @click="editBtnHandler(record)"
-            >{{ t('craftAtom.edit') }}
+          <a-button :loading="isLoading" @click="listAllCraftAtoms">
+            {{ t('craftAtom.query') }}
           </a-button>
-          <a-popconfirm
-            :content="t('craftAtom.deleteConfirm')"
-            @ok="deleteCraftAtomHandler(record.name)"
-          >
-            <a-button status="danger">{{ t('craftAtom.delete') }}</a-button>
-          </a-popconfirm>
+          <a-button type="primary" @click="handleAdd">
+            <template #icon>
+              <icon-plus />
+            </template>
+            {{ t('craftAtom.create') }}
+          </a-button>
         </a-space>
       </template>
-    </a-table>
 
-    <ListEmptyGuide
-      v-else
-      :description="t('craftAtom.empty.description')"
-      :hint="t('craftAtom.empty.hint')"
-      :create-label="t('craftAtom.empty.createFirst')"
-      :docs-label="t('craftAtom.empty.docs')"
-      :docs-href="atomDocsHref"
-      @create="handleAdd"
-    />
+      <a-table
+        v-if="isLoading || craftAtoms.length > 0"
+        :data="craftAtoms"
+        :columns="columns"
+        :loading="isLoading"
+      >
+        <template #actions="{ record }">
+          <a-space>
+            <a-button type="outline" @click="editBtnHandler(record)"
+              >{{ t('craftAtom.edit') }}
+            </a-button>
+            <a-popconfirm
+              :content="t('craftAtom.deleteConfirm')"
+              @ok="deleteCraftAtomHandler(record.name)"
+            >
+              <a-button status="danger">{{ t('craftAtom.delete') }}</a-button>
+            </a-popconfirm>
+          </a-space>
+        </template>
+      </a-table>
+
+      <ListEmptyGuide
+        v-else
+        :description="t('craftAtom.empty.description')"
+        :hint="t('craftAtom.empty.hint')"
+        :create-label="t('craftAtom.empty.createFirst')"
+        :docs-label="t('craftAtom.empty.docs')"
+        :docs-href="atomDocsHref"
+        @create="handleAdd"
+      />
+    </a-card>
 
     <a-modal
       v-model:visible="showEditModal"

--- a/web/admin/src/views/dashboard/craft_atom/craft_atom.vue
+++ b/web/admin/src/views/dashboard/craft_atom/craft_atom.vue
@@ -42,7 +42,7 @@
       </a-table>
 
       <ListEmptyGuide
-        v-else
+        v-else-if="!listFailed"
         :description="t('craftAtom.empty.description')"
         :hint="t('craftAtom.empty.hint')"
         :create-label="t('craftAtom.empty.createFirst')"
@@ -273,6 +273,7 @@
   );
 
   const isLoading = ref(false);
+  const listFailed = ref(false);
   const formRef = ref();
   const craftAtoms = ref<CraftAtom[]>([]);
   const editedCraftAtom = ref<CraftAtom>({
@@ -378,8 +379,14 @@
 
   async function listAllCraftAtoms() {
     isLoading.value = true;
-    craftAtoms.value = (await listCraftAtoms()).data ?? [];
-    isLoading.value = false;
+    try {
+      craftAtoms.value = (await listCraftAtoms()).data ?? [];
+      listFailed.value = false;
+    } catch {
+      listFailed.value = true;
+    } finally {
+      isLoading.value = false;
+    }
   }
 
   const addParam = () => {

--- a/web/admin/src/views/dashboard/craft_flow/craft_flow.vue
+++ b/web/admin/src/views/dashboard/craft_flow/craft_flow.vue
@@ -9,24 +9,17 @@
       <a-button type="primary" :loading="isLoading" @click="listAllCraftFlow">
         {{ t('craftFlow.query') }}
       </a-button>
-      <a-button
-        type="outline"
-        @click="
-          () => {
-            showEditModal = true;
-            isUpdating = false;
-            editedCraftFlow = {
-              name: '',
-              description: '',
-              craftList: [],
-            };
-          }
-        "
+      <a-button type="outline" @click="handleAdd"
         >{{ t('craftFlow.create') }}
       </a-button>
     </a-space>
 
-    <a-table :data="craftFlows" :columns="columns" :loading="isLoading">
+    <a-table
+      v-if="isLoading || craftFlows.length > 0"
+      :data="craftFlows"
+      :columns="columns"
+      :loading="isLoading"
+    >
       <template #craft-flow-item-list="{ record }">
         <a-tag>开始</a-tag>
         >
@@ -55,6 +48,16 @@
         </a-space>
       </template>
     </a-table>
+
+    <ListEmptyGuide
+      v-else
+      :description="t('craftFlow.empty.description')"
+      :hint="t('craftFlow.empty.hint')"
+      :create-label="t('craftFlow.empty.createFirst')"
+      :docs-label="t('craftFlow.empty.docs')"
+      :docs-href="flowDocsHref"
+      @create="handleAdd"
+    />
 
     <a-modal
       v-model:visible="showEditModal"
@@ -104,7 +107,9 @@
 
 <script setup lang="ts">
   import XHeader from '@/components/header/x-header.vue';
+  import ListEmptyGuide from '@/components/list-empty-guide/index.vue';
   import { onBeforeMount, ref, computed } from 'vue';
+  import { buildDocsUrl } from '@/utils/docsUrl';
   import {
     CraftFlow,
     createCraftFlow,
@@ -119,7 +124,20 @@
   import { useI18n } from 'vue-i18n';
   import { Message } from '@arco-design/web-vue';
 
-  const { t } = useI18n();
+  const { t, locale } = useI18n();
+  const flowDocsHref = computed(() =>
+    buildDocsUrl(locale.value, 'guides/advanced/customization')
+  );
+
+  const handleAdd = () => {
+    editedCraftFlow.value = {
+      name: '',
+      description: '',
+      craftList: [],
+    };
+    showEditModal.value = true;
+    isUpdating.value = false;
+  };
 
   const rules = {
     name: [
@@ -191,7 +209,7 @@
     isLoading.value = true;
     try {
       const res = await listCraftFlows();
-      craftFlows.value = res.data.map((item) => {
+      craftFlows.value = (res.data ?? []).map((item) => {
         const ret = item as any;
         const craftFlowConfigList = item.craft_flow_config ?? [];
         ret.craftList =

--- a/web/admin/src/views/dashboard/craft_flow/craft_flow.vue
+++ b/web/admin/src/views/dashboard/craft_flow/craft_flow.vue
@@ -5,59 +5,66 @@
       :description="t('craftFlow.description')"
     ></x-header>
 
-    <a-space direction="horizontal" class="mb-6">
-      <a-button type="primary" :loading="isLoading" @click="listAllCraftFlow">
-        {{ t('craftFlow.query') }}
-      </a-button>
-      <a-button type="outline" @click="handleAdd"
-        >{{ t('craftFlow.create') }}
-      </a-button>
-    </a-space>
-
-    <a-table
-      v-if="isLoading || craftFlows.length > 0"
-      :data="craftFlows"
-      :columns="columns"
-      :loading="isLoading"
-    >
-      <template #craft-flow-item-list="{ record }">
-        <a-tag>开始</a-tag>
-        >
-        <template
-          v-for="(item, index) in record.craft_flow_config"
-          :key="index"
-        >
-          <a-tooltip :content="getCraftDescription(item.craft_name)">
-            <a-tag color="arcoblue">{{ item.craft_name }}</a-tag>
-          </a-tooltip>
-          >
-        </template>
-        <a-tag>结束</a-tag>
-      </template>
-      <template #actions="{ record }">
+    <a-card class="general-card" :title="t('menu.craftFlow')">
+      <template #extra>
         <a-space>
-          <a-button type="outline" @click="editBtnHandler(record)"
-            >{{ t('craftFlow.edit') }}
+          <a-button :loading="isLoading" @click="listAllCraftFlow">
+            {{ t('craftFlow.query') }}
           </a-button>
-          <a-popconfirm
-            :content="t('craftFlow.deleteConfirm')"
-            @ok="deleteCraftFlowHandler(record.name)"
-          >
-            <a-button status="danger">{{ t('craftFlow.delete') }}</a-button>
-          </a-popconfirm>
+          <a-button type="primary" @click="handleAdd">
+            <template #icon>
+              <icon-plus />
+            </template>
+            {{ t('craftFlow.create') }}
+          </a-button>
         </a-space>
       </template>
-    </a-table>
 
-    <ListEmptyGuide
-      v-else
-      :description="t('craftFlow.empty.description')"
-      :hint="t('craftFlow.empty.hint')"
-      :create-label="t('craftFlow.empty.createFirst')"
-      :docs-label="t('craftFlow.empty.docs')"
-      :docs-href="flowDocsHref"
-      @create="handleAdd"
-    />
+      <a-table
+        v-if="isLoading || craftFlows.length > 0"
+        :data="craftFlows"
+        :columns="columns"
+        :loading="isLoading"
+      >
+        <template #craft-flow-item-list="{ record }">
+          <a-tag>开始</a-tag>
+          >
+          <template
+            v-for="(item, index) in record.craft_flow_config"
+            :key="index"
+          >
+            <a-tooltip :content="getCraftDescription(item.craft_name)">
+              <a-tag color="arcoblue">{{ item.craft_name }}</a-tag>
+            </a-tooltip>
+            >
+          </template>
+          <a-tag>结束</a-tag>
+        </template>
+        <template #actions="{ record }">
+          <a-space>
+            <a-button type="outline" @click="editBtnHandler(record)"
+              >{{ t('craftFlow.edit') }}
+            </a-button>
+            <a-popconfirm
+              :content="t('craftFlow.deleteConfirm')"
+              @ok="deleteCraftFlowHandler(record.name)"
+            >
+              <a-button status="danger">{{ t('craftFlow.delete') }}</a-button>
+            </a-popconfirm>
+          </a-space>
+        </template>
+      </a-table>
+
+      <ListEmptyGuide
+        v-else
+        :description="t('craftFlow.empty.description')"
+        :hint="t('craftFlow.empty.hint')"
+        :create-label="t('craftFlow.empty.createFirst')"
+        :docs-label="t('craftFlow.empty.docs')"
+        :docs-href="flowDocsHref"
+        @create="handleAdd"
+      />
+    </a-card>
 
     <a-modal
       v-model:visible="showEditModal"

--- a/web/admin/src/views/dashboard/craft_flow/craft_flow.vue
+++ b/web/admin/src/views/dashboard/craft_flow/craft_flow.vue
@@ -56,7 +56,7 @@
       </a-table>
 
       <ListEmptyGuide
-        v-else
+        v-else-if="!listFailed"
         :description="t('craftFlow.empty.description')"
         :hint="t('craftFlow.empty.hint')"
         :create-label="t('craftFlow.empty.createFirst')"
@@ -158,6 +158,7 @@
   };
 
   const isLoading = ref(false);
+  const listFailed = ref(false);
   const saving = ref(false);
   const formRef = ref();
   const craftFlows = ref<CraftFlow[]>([]);
@@ -225,6 +226,9 @@
           ) ?? [];
         return ret;
       });
+      listFailed.value = false;
+    } catch {
+      listFailed.value = true;
     } finally {
       isLoading.value = false;
     }

--- a/web/admin/src/views/dashboard/topic_feed/topic_feed.vue
+++ b/web/admin/src/views/dashboard/topic_feed/topic_feed.vue
@@ -22,6 +22,7 @@
       </template>
 
       <a-table
+        v-if="loading || topics.length > 0"
         :data="topics"
         :loading="loading"
         :pagination="false"
@@ -92,25 +93,35 @@
         </template>
       </a-table>
 
-      <a-empty
-        v-if="!loading && topics.length === 0"
+      <ListEmptyGuide
+        v-else
         :description="t('topic.noTopics')"
+        :hint="t('topic.empty.hint')"
+        :create-label="t('topic.empty.createFirst')"
+        :docs-label="t('topic.empty.docs')"
+        :docs-href="topicDocsHref"
+        @create="handleAdd"
       />
     </a-card>
   </div>
 </template>
 
 <script lang="ts" setup>
-  import { onMounted, ref } from 'vue';
+  import { computed, onMounted, ref } from 'vue';
   import { Message } from '@arco-design/web-vue';
   import { useI18n } from 'vue-i18n';
   import { useRouter } from 'vue-router';
   import XHeader from '@/components/header/x-header.vue';
+  import ListEmptyGuide from '@/components/list-empty-guide/index.vue';
   import buildPublicFeedUrl from '@/utils/publicFeedUrl';
+  import { buildDocsUrl } from '@/utils/docsUrl';
   import { TopicFeed, deleteTopicFeed, listTopicFeeds } from '@/api/topic';
   import { formatAggregatorSummary } from '@/views/dashboard/topic_feed/topicInputUtils';
 
-  const { t } = useI18n();
+  const { t, locale } = useI18n();
+  const topicDocsHref = computed(() =>
+    buildDocsUrl(locale.value, 'guides/start/quick-start')
+  );
   const router = useRouter();
   const topics = ref<TopicFeed[]>([]);
   const loading = ref(false);

--- a/web/admin/vitest.config.ts
+++ b/web/admin/vitest.config.ts
@@ -9,5 +9,6 @@ export default defineConfig({
   },
   test: {
     environment: 'node',
+    include: ['src/**/*.test.ts'],
   },
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 背景

Linear [COL-11](https://linear.app/colin-x-studio/issue/COL-11/空状态页面缺失创建引导)：主题订阅、原子工艺等列表页在空数据时只显示空表格，缺少创建引导。

已在当前 `dev` 上复现：`/worktable/topic_feed` 仅有「暂无主题」，`/worktable/craft_atom` 和 `/worktable/craft_flow` 走表格默认空状态，都没有「创建第一个…」入口或文档链接。

## 改动

- 空列表改为展示 `ListEmptyGuide`：说明文案、创建按钮、对应文档链接
- 覆盖页面：主题订阅、原子工艺、组合工艺
- 三个列表页统一使用白底 `general-card`，空状态不再铺在页面灰底上
- 文档链接按当前语言指向 `feed-craft-doc` 的快速开始 / 定制指南
- 操作按钮放在 Arco Empty 外部（该组件没有 extra 插槽）
- 列表请求失败时复位 loading，并用 `listFailed` 避免把失败渲染成空状态引导
- 补充 `buildDocsUrl` 单元测试，并加入最小 `vitest.config.ts` 让 `@` 别名在测试中生效

## 验证

- `pnpm test`：19 个前端单测通过
- `pnpm run type:check`、`pnpm run build` 通过
- `go test ./...` 通过
- `task backend-build` 通过
- 三个空状态均在白底卡片内，布局一致

[主题订阅白底空状态卡片](https://cursor.com/agents/bc-b47b05ff-8ef9-49e4-a417-7ef26fc2c310/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Funified_topic_feed_empty_card.webp)
[原子工艺白底空状态卡片](https://cursor.com/agents/bc-b47b05ff-8ef9-49e4-a417-7ef26fc2c310/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Funified_craft_atom_empty_card.webp)
[组合工艺白底空状态卡片](https://cursor.com/agents/bc-b47b05ff-8ef9-49e4-a417-7ef26fc2c310/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Funified_craft_flow_empty_card.webp)
[unified_empty_state_cards.mp4](https://cursor.com/agents/bc-b47b05ff-8ef9-49e4-a417-7ef26fc2c310/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Funified_empty_state_cards.mp4)

## 合并说明

已 rebase 到最新 `dev`。唯一冲突是双方都新增了 `web/admin/vitest.config.ts`：保留 `environment: 'node'` 和 `include: ['src/**/*.test.ts']`。

## Summary by Sourcery

Provide consistent, localized onboarding guidance for creating the first topic or craft resource from empty admin list pages.

New Features:
- Add reusable empty-list guidance with creation actions and localized documentation links for topics, AtomCrafts, and FlowCrafts.

Bug Fixes:
- Replace unhelpful empty table states with actionable creation guidance when supported lists contain no data.

Enhancements:
- Standardize the three list pages around white card layouts and preserve empty-state rendering when list requests succeed with empty results.
- Handle list request failures without presenting the successful empty-state guide.

Tests:
- Add unit coverage for locale-aware documentation URL generation and configure Vitest to discover the frontend tests.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b47b05ff-8ef9-49e4-a417-7ef26fc2c310?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b47b05ff-8ef9-49e4-a417-7ef26fc2c310&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

## Summary by Sourcery

Provide consistent, localized onboarding guidance for creating the first topic or craft resource from empty admin list pages.

New Features:
- Add reusable empty-list guidance with creation actions and localized documentation links for topics, AtomCrafts, and FlowCrafts.

Bug Fixes:
- Replace unhelpful empty table states with actionable creation guidance when supported lists contain no data.

Enhancements:
- Standardize the three list pages around white card layouts and preserve empty-state rendering when list requests succeed with empty results.
- Handle list request failures without presenting the successful empty-state guide.

Tests:
- Add unit coverage for locale-aware documentation URL generation and configure Vitest to discover the frontend tests.