### PR TITLE
feat: 限制 Feed 输入条目数

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -153,3 +153,6 @@ start.sh
 start-full.sh
 .claude/
 .dev-data/
+
+# Local agent design notes
+docs/superpowers/

--- a/internal/feedruntime/builder.go
+++ b/internal/feedruntime/builder.go
@@ -676,6 +676,7 @@ func (p *InboxProvider) Fetch(ctx context.Context) (*model.CraftFeed, error) {
 		})
 	}
 
+	source.ApplyInputFeedItemLimit(feed)
 	return feed, nil
 }
 

--- a/internal/source/adapter.go
+++ b/internal/source/adapter.go
@@ -31,6 +31,7 @@ func (a *LegacySourceAdapter) Fetch(ctx context.Context) (*model.CraftFeed, erro
 
 	// Ensure feed link is absolute, replicating logic from legacy TransformFeed
 	cf.Link = getAbsFeedLink(a.LegacySource.BaseURL(), cf.Link)
+	applyInputFeedItemLimit(cf)
 
 	return cf, nil
 }

--- a/internal/source/inbox.go
+++ b/internal/source/inbox.go
@@ -66,6 +66,7 @@ func (s *InboxSource) Fetch(ctx context.Context) (*model.CraftFeed, error) {
 		feed.Articles = append(feed.Articles, article)
 	}
 
+	applyInputFeedItemLimit(feed)
 	return feed, nil
 }
 

--- a/internal/source/input_feed_limit.go
+++ b/internal/source/input_feed_limit.go
@@ -1,0 +1,55 @@
+package source
+
+import (
+	"FeedCraft/internal/model"
+	"FeedCraft/internal/util"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/sirupsen/logrus"
+)
+
+const defaultInputFeedItemLimit = 30
+
+func inputFeedItemLimit() int {
+	raw := strings.TrimSpace(util.GetEnvClient().GetString("INPUT_FEED_ITEM_LIMIT"))
+	if raw == "" {
+		return defaultInputFeedItemLimit
+	}
+
+	limit, err := strconv.Atoi(raw)
+	if err != nil || limit < 0 {
+		logrus.Warnf("invalid FC_INPUT_FEED_ITEM_LIMIT %q; using default %d", raw, defaultInputFeedItemLimit)
+		return defaultInputFeedItemLimit
+	}
+	return limit
+}
+
+func applyInputFeedItemLimit(feed *model.CraftFeed) {
+	limit := inputFeedItemLimit()
+	if feed == nil || limit == 0 || len(feed.Articles) <= limit {
+		return
+	}
+
+	sort.SliceStable(feed.Articles, func(i, j int) bool {
+		return inputArticleTime(feed.Articles[i]).After(inputArticleTime(feed.Articles[j]))
+	})
+	feed.Articles = feed.Articles[:limit]
+}
+
+// ApplyInputFeedItemLimit keeps the most recent configured number of input articles.
+func ApplyInputFeedItemLimit(feed *model.CraftFeed) {
+	applyInputFeedItemLimit(feed)
+}
+
+func inputArticleTime(article *model.CraftArticle) time.Time {
+	if article == nil {
+		return time.Time{}
+	}
+	if !article.Created.IsZero() {
+		return article.Created
+	}
+	return article.Updated
+}

--- a/internal/source/input_feed_limit_test.go
+++ b/internal/source/input_feed_limit_test.go
@@ -1,0 +1,103 @@
+package source
+
+import (
+	"FeedCraft/internal/model"
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestInputFeedItemLimit(t *testing.T) {
+	t.Setenv("FC_INPUT_FEED_ITEM_LIMIT", "")
+	assert.Equal(t, 30, inputFeedItemLimit())
+
+	t.Setenv("FC_INPUT_FEED_ITEM_LIMIT", "0")
+	assert.Equal(t, 0, inputFeedItemLimit())
+
+	t.Setenv("FC_INPUT_FEED_ITEM_LIMIT", "12")
+	assert.Equal(t, 12, inputFeedItemLimit())
+
+	t.Setenv("FC_INPUT_FEED_ITEM_LIMIT", "invalid")
+	assert.Equal(t, 30, inputFeedItemLimit())
+
+	t.Setenv("FC_INPUT_FEED_ITEM_LIMIT", "-1")
+	assert.Equal(t, 30, inputFeedItemLimit())
+}
+
+func TestApplyInputFeedItemLimit_SortsAndTruncatesBeforeProcessing(t *testing.T) {
+	now := time.Now()
+	feed := &model.CraftFeed{
+		Articles: []*model.CraftArticle{
+			{Id: "oldest", Created: now.Add(-3 * time.Hour)},
+			{Id: "newest", Created: now},
+			{Id: "updated-fallback", Updated: now.Add(-1 * time.Hour)},
+			{Id: "undated"},
+		},
+	}
+	t.Setenv("FC_INPUT_FEED_ITEM_LIMIT", "2")
+
+	applyInputFeedItemLimit(feed)
+
+	assert.Equal(t, []string{"newest", "updated-fallback"}, articleIDs(feed.Articles))
+}
+
+func TestApplyInputFeedItemLimit_ZeroKeepsAllArticles(t *testing.T) {
+	feed := &model.CraftFeed{
+		Articles: []*model.CraftArticle{
+			{Id: "first"},
+			{Id: "second"},
+		},
+	}
+	t.Setenv("FC_INPUT_FEED_ITEM_LIMIT", "0")
+
+	applyInputFeedItemLimit(feed)
+
+	assert.Equal(t, []string{"first", "second"}, articleIDs(feed.Articles))
+}
+
+func TestPipelineSourceFetch_AppliesInputFeedItemLimit(t *testing.T) {
+	now := time.Now()
+	pipeline := &PipelineSource{
+		Fetcher: inputLimitTestFetcher{},
+		Parser: inputLimitTestParser{feed: &model.CraftFeed{
+			Articles: []*model.CraftArticle{
+				{Id: "older", Created: now.Add(-time.Hour)},
+				{Id: "newer", Created: now},
+			},
+		}},
+	}
+	t.Setenv("FC_INPUT_FEED_ITEM_LIMIT", "1")
+
+	feed, err := pipeline.Fetch(context.Background())
+
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"newer"}, articleIDs(feed.Articles))
+}
+
+func articleIDs(articles []*model.CraftArticle) []string {
+	ids := make([]string, 0, len(articles))
+	for _, article := range articles {
+		ids = append(ids, article.Id)
+	}
+	return ids
+}
+
+type inputLimitTestFetcher struct{}
+
+func (inputLimitTestFetcher) Fetch(context.Context) ([]byte, error) {
+	return []byte("feed"), nil
+}
+
+func (inputLimitTestFetcher) BaseURL() string {
+	return ""
+}
+
+type inputLimitTestParser struct {
+	feed *model.CraftFeed
+}
+
+func (p inputLimitTestParser) Parse([]byte) (*model.CraftFeed, error) {
+	return p.feed, nil
+}

--- a/internal/source/pipeline.go
+++ b/internal/source/pipeline.go
@@ -33,6 +33,7 @@ func (p *PipelineSource) Fetch(ctx context.Context) (*model.CraftFeed, error) {
 	}
 
 	p.normalizeCraftFeed(feed)
+	applyInputFeedItemLimit(feed)
 
 	return feed, nil
 }

--- a/internal/source/search.go
+++ b/internal/source/search.go
@@ -138,11 +138,13 @@ func (s *EnhancedSearchSource) Fetch(ctx context.Context) (*model.CraftFeed, err
 	}
 	wg.Wait()
 
-	return &model.CraftFeed{
+	feed := &model.CraftFeed{
 		Title:       fmt.Sprintf("Search: %s", s.Config.SearchFetcher.Query),
 		Description: fmt.Sprintf("Enhanced search results for %s", s.Config.SearchFetcher.Query),
 		Articles:    allItems,
-	}, nil
+	}
+	applyInputFeedItemLimit(feed)
+	return feed, nil
 }
 
 func expandQueryWithLLM(query string) ([]string, error) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- 新增 `FC_INPUT_FEED_ITEM_LIMIT`：未设置或空值默认保留最近 30 篇，显式设为 `0` 时不限制
- 在通用 Pipeline、增强搜索、Inbox（含 runtime 直接读取）和旧 Source adapter 的输入边界，按 Created/Updated 时间稳定排序后截断
- 不在 Topic 合并或输出层增加限制，保留用户现有 craft/aggregator 控制
- `docs/superpowers` 已加入 `.gitignore`，不纳入仓库

本 PR 基于 `dev`。原先误以 `main` 为合并目标的草稿见 #878。

## Testing
- `go test ./internal/source ./internal/feedruntime`
- `task fix`、`go test ./...`、`task backend-build`、`task frontend-build` 已在实现阶段验证
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0350fe7c-fbcc-4ae8-af48-0abb149a2bab?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0350fe7c-fbcc-4ae8-af48-0abb149a2bab&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

## Summary by Sourcery

Limit the number of articles accepted from feed inputs through a configurable environment setting.

New Features:
- Add configurable input feed item limits, defaulting to the 30 most recent articles while allowing unlimited input with an explicit zero value.

Enhancements:
- Apply stable recency-based truncation across pipeline, enhanced search, Inbox, and legacy source inputs before downstream processing while leaving topic aggregation and output limits unchanged.

Tests:
- Add coverage for limit parsing, recency ordering, unlimited behavior, and pipeline integration.