### PR TITLE
fix(craft): 浏览器访问 craft 端点时渲染可读预览

### DIFF
--- a/internal/craft/common.go
+++ b/internal/craft/common.go
@@ -122,14 +122,7 @@ func CommonCraftHandlerUsingCraftOptionList(c *gin.Context, optionList []LegacyC
 		}
 	}
 
-	rssStr, err := finalCraftFeed.ToFeedsFeed().ToRss()
-	if err != nil {
-		c.String(http.StatusInternalServerError, err.Error())
-		return
-	}
-
-	c.Header("Content-Type", "application/xml; charset=utf-8")
-	c.String(http.StatusOK, rssStr)
+	ServeCraftedFeed(c, finalCraftFeed.ToFeedsFeed())
 }
 
 type RawTransformer func(item *feeds.Item) (string, error)

--- a/internal/craft/feed_response.go
+++ b/internal/craft/feed_response.go
@@ -1,0 +1,368 @@
+package craft
+
+import (
+	"bytes"
+	"html/template"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/PuerkitoBio/goquery"
+	"github.com/gin-gonic/gin"
+	"github.com/gorilla/feeds"
+)
+
+const (
+	feedFormatHTML = "html"
+	feedFormatJSON = "json"
+	feedFormatAtom = "atom"
+	feedFormatRSS  = "rss"
+)
+
+// ServeCraftedFeed writes a processed feed using the representation the client asked for.
+// RSS readers keep getting RSS XML. Browsers get a readable HTML preview. `format`
+// can force rss, html, json, or atom.
+func ServeCraftedFeed(c *gin.Context, feed *feeds.Feed) {
+	if c == nil {
+		return
+	}
+	if feed == nil {
+		c.String(http.StatusInternalServerError, "empty feed")
+		return
+	}
+
+	switch negotiateFeedFormat(c.Query("format"), c.GetHeader("Accept")) {
+	case feedFormatHTML:
+		body, err := renderFeedHTML(feed, requestPageURL(c))
+		if err != nil {
+			c.String(http.StatusInternalServerError, err.Error())
+			return
+		}
+		c.Data(http.StatusOK, "text/html; charset=utf-8", []byte(body))
+	case feedFormatJSON:
+		body, err := feed.ToJSON()
+		if err != nil {
+			c.String(http.StatusInternalServerError, err.Error())
+			return
+		}
+		c.Data(http.StatusOK, "application/feed+json; charset=utf-8", []byte(body))
+	case feedFormatAtom:
+		body, err := feed.ToAtom()
+		if err != nil {
+			c.String(http.StatusInternalServerError, err.Error())
+			return
+		}
+		c.Data(http.StatusOK, "application/atom+xml; charset=utf-8", []byte(body))
+	default:
+		body, err := feed.ToRss()
+		if err != nil {
+			c.String(http.StatusInternalServerError, err.Error())
+			return
+		}
+		c.Data(http.StatusOK, "application/rss+xml; charset=utf-8", []byte(body))
+	}
+}
+
+func negotiateFeedFormat(formatQuery, acceptHeader string) string {
+	switch strings.ToLower(strings.TrimSpace(formatQuery)) {
+	case feedFormatHTML:
+		return feedFormatHTML
+	case feedFormatJSON, "jsonfeed", "json-feed":
+		return feedFormatJSON
+	case feedFormatAtom:
+		return feedFormatAtom
+	case feedFormatRSS, "xml":
+		return feedFormatRSS
+	}
+	return formatFromAccept(acceptHeader)
+}
+
+func formatFromAccept(accept string) string {
+	if strings.TrimSpace(accept) == "" {
+		return feedFormatRSS
+	}
+
+	var (
+		htmlQ, rssQ, atomQ, jsonQ         float64
+		hasHTML, hasRSS, hasAtom, hasJSON bool
+	)
+
+	for _, part := range strings.Split(accept, ",") {
+		media, q := parseAcceptPart(part)
+		switch media {
+		case "text/html", "application/xhtml+xml":
+			htmlQ, hasHTML = maxQuality(htmlQ, q, hasHTML)
+		case "application/rss+xml", "application/rdf+xml":
+			rssQ, hasRSS = maxQuality(rssQ, q, hasRSS)
+		case "application/atom+xml":
+			atomQ, hasAtom = maxQuality(atomQ, q, hasAtom)
+		case "application/feed+json", "application/json":
+			jsonQ, hasJSON = maxQuality(jsonQ, q, hasJSON)
+		}
+	}
+
+	bestFeed := feedFormatRSS
+	bestFeedQ := -1.0
+	hasFeed := false
+	if hasRSS {
+		bestFeed, bestFeedQ, hasFeed = feedFormatRSS, rssQ, true
+	}
+	if hasAtom && atomQ > bestFeedQ {
+		bestFeed, bestFeedQ, hasFeed = feedFormatAtom, atomQ, true
+	}
+	if hasJSON && jsonQ > bestFeedQ {
+		bestFeed, bestFeedQ, hasFeed = feedFormatJSON, jsonQ, true
+	}
+
+	if hasFeed && (!hasHTML || bestFeedQ >= htmlQ) {
+		return bestFeed
+	}
+	if hasHTML {
+		return feedFormatHTML
+	}
+	return feedFormatRSS
+}
+
+func parseAcceptPart(part string) (string, float64) {
+	part = strings.TrimSpace(part)
+	media := part
+	q := 1.0
+	if i := strings.Index(part, ";"); i >= 0 {
+		media = strings.TrimSpace(part[:i])
+		for _, param := range strings.Split(part[i+1:], ";") {
+			param = strings.TrimSpace(param)
+			if len(param) < 2 || !strings.EqualFold(param[:2], "q=") {
+				continue
+			}
+			if v, err := strconv.ParseFloat(strings.TrimSpace(param[2:]), 64); err == nil {
+				q = v
+			}
+		}
+	}
+	return strings.ToLower(media), q
+}
+
+func maxQuality(current, candidate float64, seen bool) (float64, bool) {
+	if !seen || candidate > current {
+		return candidate, true
+	}
+	return current, true
+}
+
+type htmlFeedView struct {
+	Title       string
+	Description string
+	PageURL     string
+	RSSURL      string
+	JSONURL     string
+	Items       []htmlFeedItem
+}
+
+type htmlFeedItem struct {
+	Title   string
+	Link    string
+	Date    string
+	Snippet string
+}
+
+var feedPreviewTemplate = template.Must(template.New("craft-feed-preview").Parse(`<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>{{.Title}} · FeedCraft</title>
+  <style>
+    :root { color-scheme: light; }
+    body { margin: 0; font-family: ui-sans-serif, system-ui, sans-serif; background: #f8fafc; color: #0f172a; }
+    main { max-width: 52rem; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
+    .banner { border: 1px solid #99f6e4; background: #f0fdfa; border-radius: 16px; padding: 1rem 1.1rem; margin-bottom: 1.5rem; }
+    .brand { color: #0d9488; font-weight: 700; letter-spacing: .02em; }
+    h1 { font-size: 1.75rem; font-weight: 650; margin: 0 0 .5rem; }
+    .desc { color: #475569; margin: 0 0 1rem; line-height: 1.6; }
+    .url { display: block; word-break: break-all; background: #fff; border-radius: 10px; padding: .7rem .85rem; color: #0f766e; text-decoration: none; margin: .75rem 0 1rem; }
+    .actions { display: flex; flex-wrap: wrap; gap: .6rem; }
+    .actions a, .actions button { appearance: none; border: 0; border-radius: 999px; padding: .45rem .9rem; font: inherit; cursor: pointer; text-decoration: none; }
+    .primary { background: #0d9488; color: #fff; }
+    .secondary { background: #e2e8f0; color: #0f172a; }
+    article { background: #fff; border: 1px solid #e2e8f0; border-radius: 16px; padding: 1rem 1.1rem; margin: .85rem 0; }
+    article h2 { font-size: 1.05rem; margin: 0 0 .35rem; }
+    article h2 a { color: inherit; text-decoration: none; }
+    article h2 a:hover { color: #0d9488; }
+    time, .snippet { color: #64748b; font-size: .92rem; }
+    .snippet { margin: .4rem 0 0; line-height: 1.55; }
+    .empty { color: #64748b; }
+  </style>
+</head>
+<body>
+  <main>
+    <section class="banner">
+      <div class="brand">FeedCraft</div>
+      <p>这是一个 RSS 订阅地址。阅读器请直接订阅当前 URL。浏览器打开时会显示可读预览，不会改变阅读器拿到的 XML。</p>
+      <a class="url" href="{{.RSSURL}}">{{.PageURL}}</a>
+      <div class="actions">
+        <button class="primary" type="button" data-copy-url="{{.PageURL}}">复制订阅地址</button>
+        <a class="secondary" href="{{.RSSURL}}">查看原始 RSS</a>
+        <a class="secondary" href="{{.JSONURL}}">JSON Feed</a>
+      </div>
+    </section>
+    <h1>{{.Title}}</h1>
+    {{if .Description}}<p class="desc">{{.Description}}</p>{{end}}
+    {{if .Items}}
+      {{range .Items}}
+        <article>
+          <h2>{{if .Link}}<a href="{{.Link}}" target="_blank" rel="noopener noreferrer">{{.Title}}</a>{{else}}{{.Title}}{{end}}</h2>
+          {{if .Date}}<time>{{.Date}}</time>{{end}}
+          {{if .Snippet}}<p class="snippet">{{.Snippet}}</p>{{end}}
+        </article>
+      {{end}}
+    {{else}}
+      <p class="empty">这个订阅源暂时没有条目。</p>
+    {{end}}
+  </main>
+  <script>
+    document.querySelectorAll("[data-copy-url]").forEach(function (button) {
+      button.addEventListener("click", function () {
+        var url = button.getAttribute("data-copy-url") || "";
+        if (!url || !navigator.clipboard) { return; }
+        navigator.clipboard.writeText(url).then(function () {
+          button.textContent = "已复制";
+        }).catch(function () {});
+      });
+    });
+  </script>
+</body>
+</html>`))
+
+func renderFeedHTML(feed *feeds.Feed, pageURL string) (string, error) {
+	if feed == nil {
+		feed = &feeds.Feed{}
+	}
+
+	view := htmlFeedView{
+		Title:       strings.TrimSpace(feed.Title),
+		Description: plainTextSnippet(feed.Description, 400),
+		PageURL:     pageURL,
+		RSSURL:      withFeedFormat(pageURL, feedFormatRSS),
+		JSONURL:     withFeedFormat(pageURL, feedFormatJSON),
+		Items:       make([]htmlFeedItem, 0, len(feed.Items)),
+	}
+	if view.Title == "" {
+		view.Title = "FeedCraft"
+	}
+
+	for _, item := range feed.Items {
+		if item == nil {
+			continue
+		}
+		content := item.Description
+		if strings.TrimSpace(content) == "" {
+			content = item.Content
+		}
+		view.Items = append(view.Items, htmlFeedItem{
+			Title:   firstNonEmpty(strings.TrimSpace(item.Title), "Untitled"),
+			Link:    safeHTTPURL(itemLink(item)),
+			Date:    formatFeedItemTime(item.Created, item.Updated),
+			Snippet: plainTextSnippet(content, 280),
+		})
+	}
+
+	var buf bytes.Buffer
+	if err := feedPreviewTemplate.Execute(&buf, view); err != nil {
+		return "", err
+	}
+	return buf.String(), nil
+}
+
+func requestPageURL(c *gin.Context) string {
+	if c == nil || c.Request == nil || c.Request.URL == nil {
+		return ""
+	}
+	if c.Request.URL.IsAbs() {
+		return c.Request.URL.String()
+	}
+	scheme := "http"
+	if c.Request.TLS != nil {
+		scheme = "https"
+	}
+	if proto := strings.TrimSpace(c.GetHeader("X-Forwarded-Proto")); proto != "" {
+		scheme = proto
+	}
+	host := strings.TrimSpace(c.Request.Host)
+	if host == "" {
+		return c.Request.URL.RequestURI()
+	}
+	return scheme + "://" + host + c.Request.URL.RequestURI()
+}
+
+func withFeedFormat(rawURL, format string) string {
+	parsed, err := url.Parse(rawURL)
+	if err != nil || parsed == nil {
+		return rawURL
+	}
+	query := parsed.Query()
+	query.Set("format", format)
+	parsed.RawQuery = query.Encode()
+	return parsed.String()
+}
+
+func itemLink(item *feeds.Item) string {
+	if item == nil || item.Link == nil {
+		return ""
+	}
+	return item.Link.Href
+}
+
+func safeHTTPURL(raw string) string {
+	parsed, err := url.Parse(strings.TrimSpace(raw))
+	if err != nil {
+		return ""
+	}
+	if parsed.Scheme != "http" && parsed.Scheme != "https" {
+		return ""
+	}
+	return parsed.String()
+}
+
+func formatFeedItemTime(primary, fallback time.Time) string {
+	when := primary
+	if when.IsZero() {
+		when = fallback
+	}
+	if when.IsZero() {
+		return ""
+	}
+	return when.Local().Format("2006-01-02 15:04")
+}
+
+func plainTextSnippet(raw string, maxRunes int) string {
+	text := strings.TrimSpace(raw)
+	if text == "" {
+		return ""
+	}
+	if doc, err := goquery.NewDocumentFromReader(strings.NewReader(text)); err == nil {
+		text = strings.Join(strings.Fields(doc.Text()), " ")
+	}
+	return truncateRunes(text, maxRunes)
+}
+
+func truncateRunes(s string, max int) string {
+	if max <= 0 {
+		return ""
+	}
+	runes := []rune(s)
+	if len(runes) <= max {
+		return s
+	}
+	return string(runes[:max]) + "…"
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return value
+		}
+	}
+	return ""
+}

--- a/internal/craft/feed_response_test.go
+++ b/internal/craft/feed_response_test.go
@@ -1,0 +1,247 @@
+package craft
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/gorilla/feeds"
+)
+
+func TestNegotiateFeedFormat(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		query  string
+		accept string
+		want   string
+	}{
+		{
+			name:   "explicit html wins over rss accept",
+			query:  "html",
+			accept: "application/rss+xml",
+			want:   "html",
+		},
+		{
+			name:   "explicit json",
+			query:  "json",
+			accept: "text/html",
+			want:   "json",
+		},
+		{
+			name:   "explicit xml aliases to rss",
+			query:  "xml",
+			accept: "text/html",
+			want:   "rss",
+		},
+		{
+			name:   "unknown format falls back to accept",
+			query:  "nope",
+			accept: "text/html",
+			want:   "html",
+		},
+		{
+			name:   "curl default accept stays rss",
+			query:  "",
+			accept: "*/*",
+			want:   "rss",
+		},
+		{
+			name:   "empty accept stays rss",
+			query:  "",
+			accept: "",
+			want:   "rss",
+		},
+		{
+			name:   "chrome-like accept renders html",
+			query:  "",
+			accept: "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8",
+			want:   "html",
+		},
+		{
+			name:   "rss reader accept stays rss",
+			query:  "",
+			accept: "application/rss+xml, application/rdf+xml;q=0.8, application/atom+xml;q=0.6, application/xml;q=0.4, text/xml;q=0.4, */*;q=0.2",
+			want:   "rss",
+		},
+		{
+			name:   "tie between html and rss prefers rss",
+			query:  "",
+			accept: "text/html, application/rss+xml",
+			want:   "rss",
+		},
+		{
+			name:   "json clients get json feed",
+			query:  "",
+			accept: "application/json, text/plain, */*",
+			want:   "json",
+		},
+		{
+			name:   "generic xml without html stays rss",
+			query:  "",
+			accept: "application/xml",
+			want:   "rss",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := negotiateFeedFormat(tt.query, tt.accept); got != tt.want {
+				t.Fatalf("negotiateFeedFormat(%q, %q) = %q, want %q", tt.query, tt.accept, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCommonCraftHandlerServesRSSForReaders(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	source := newTestRSSServer(t)
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = httptest.NewRequest(http.MethodGet, "/craft/proxy?input_url="+source.URL, nil)
+	c.Request.Header.Set("Accept", "application/rss+xml, application/xml;q=0.9, */*;q=0.8")
+
+	CommonCraftHandlerUsingCraftOptionList(c, nil)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", recorder.Code, recorder.Body.String())
+	}
+	contentType := recorder.Header().Get("Content-Type")
+	if !strings.Contains(contentType, "rss+xml") && !strings.Contains(contentType, "xml") {
+		t.Fatalf("expected RSS XML content type, got %q", contentType)
+	}
+	body := recorder.Body.String()
+	if !strings.Contains(body, "<rss") {
+		t.Fatalf("expected RSS XML body, got %s", body)
+	}
+	if !strings.Contains(body, "Browser Preview Item") {
+		t.Fatalf("expected feed item in RSS body, got %s", body)
+	}
+}
+
+func TestCommonCraftHandlerRendersHTMLForBrowsers(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	source := newTestRSSServer(t)
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = httptest.NewRequest(http.MethodGet, "/craft/proxy?input_url="+source.URL, nil)
+	c.Request.Header.Set("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8")
+
+	CommonCraftHandlerUsingCraftOptionList(c, nil)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", recorder.Code, recorder.Body.String())
+	}
+	contentType := recorder.Header().Get("Content-Type")
+	if !strings.Contains(contentType, "text/html") {
+		t.Fatalf("expected HTML content type for browsers, got %q", contentType)
+	}
+	body := recorder.Body.String()
+	if strings.Contains(body, "<rss") {
+		t.Fatalf("browser preview should not be raw RSS XML, got %s", body)
+	}
+	if !strings.Contains(body, "Browser Preview Item") {
+		t.Fatalf("expected feed title in HTML preview, got %s", body)
+	}
+	if !strings.Contains(body, "format=rss") {
+		t.Fatalf("expected a link to the raw RSS representation, got %s", body)
+	}
+}
+
+func TestCommonCraftHandlerFormatQueryOverridesAccept(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	source := newTestRSSServer(t)
+
+	t.Run("format=rss forces xml for browsers", func(t *testing.T) {
+		recorder := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(recorder)
+		c.Request = httptest.NewRequest(http.MethodGet, "/craft/proxy?input_url="+source.URL+"&format=rss", nil)
+		c.Request.Header.Set("Accept", "text/html")
+
+		CommonCraftHandlerUsingCraftOptionList(c, nil)
+
+		if !strings.Contains(recorder.Header().Get("Content-Type"), "xml") {
+			t.Fatalf("expected XML content type, got %q", recorder.Header().Get("Content-Type"))
+		}
+		if !strings.Contains(recorder.Body.String(), "<rss") {
+			t.Fatalf("expected RSS body, got %s", recorder.Body.String())
+		}
+	})
+
+	t.Run("format=json returns json feed", func(t *testing.T) {
+		recorder := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(recorder)
+		c.Request = httptest.NewRequest(http.MethodGet, "/craft/proxy?input_url="+source.URL+"&format=json", nil)
+		c.Request.Header.Set("Accept", "text/html")
+
+		CommonCraftHandlerUsingCraftOptionList(c, nil)
+
+		contentType := recorder.Header().Get("Content-Type")
+		if !strings.Contains(contentType, "json") {
+			t.Fatalf("expected JSON content type, got %q", contentType)
+		}
+		body := recorder.Body.String()
+		if !strings.Contains(body, `"items"`) && !strings.Contains(body, `"title"`) {
+			t.Fatalf("expected JSON Feed document, got %s", body)
+		}
+		if !strings.Contains(body, "Browser Preview Item") {
+			t.Fatalf("expected feed item in JSON body, got %s", body)
+		}
+	})
+}
+
+func TestRenderFeedHTMLEscapesUntrustedContent(t *testing.T) {
+	t.Parallel()
+
+	feed := &feeds.Feed{
+		Title:       `<script>alert("feed")</script>`,
+		Description: `<img src=x onerror=alert(1)>`,
+		Items: []*feeds.Item{
+			{
+				Title:       `<script>alert("item")</script>`,
+				Description: `<a href="javascript:alert(1)">click</a>`,
+				Link:        &feeds.Link{Href: "https://example.com/item"},
+			},
+		},
+	}
+
+	html, err := renderFeedHTML(feed, "https://feedcraft.example/craft/proxy?input_url=https://example.com/feed")
+	if err != nil {
+		t.Fatalf("renderFeedHTML returned error: %v", err)
+	}
+	if strings.Contains(html, `<script>alert("feed")</script>`) ||
+		strings.Contains(html, `<script>alert("item")</script>`) ||
+		strings.Contains(html, "onerror=") ||
+		strings.Contains(html, "javascript:") {
+		t.Fatalf("HTML preview leaked unsanitized markup: %s", html)
+	}
+	if !strings.Contains(html, "&lt;script&gt;") {
+		t.Fatalf("expected escaped title content, got %s", html)
+	}
+}
+
+func newTestRSSServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/rss+xml")
+		_, _ = w.Write([]byte(`<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+  <channel>
+    <title>Preview Source</title>
+    <link>https://example.com/</link>
+    <description>Test feed</description>
+    <item>
+      <title>Browser Preview Item</title>
+      <link>https://example.com/item-1</link>
+      <description>Hello from the test feed</description>
+    </item>
+  </channel>
+</rss>`))
+	}))
+	t.Cleanup(server.Close)
+	return server
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 背景

Linear [COL-8](https://linear.app/colin-x-studio/issue/COL-8/craft-端点浏览器访问返回裸-xml-而非渲染结果)：浏览器直接打开 `/craft/{option}?input_url=...` 时会看到裸 RSS XML 树。

已在当前 `dev` 复现：该路径是给 RSS 阅读器的公开订阅端点，默认返回 XML 是正确契约。问题在于 Chrome 等浏览器没有可读预览。

## 方案

不把 `/craft` 改成 JSON/HTML 默认输出（那会破坏订阅）。改为内容协商：

- RSS 阅读器（`Accept: application/rss+xml` 或 curl `*/*`）仍返回 `application/rss+xml`
- 浏览器（`Accept: text/html`）返回可读 HTML 预览，并说明这是订阅地址
- 可用 `format=rss|html|json|atom` 强制格式；JSON 走 JSON Feed

## 验证

本地对 `http://127.0.0.1:8080/craft/proxy?input_url=http://127.0.0.1:8080/example-rss-feeds/rss-2-0.xml`：

- Reader Accept → `application/rss+xml`，body 含 `<rss`
- Browser Accept → `text/html`，页面含 FeedCraft 预览与条目标题
- `format=json` → `application/feed+json`，JSON Feed 1.1

[浏览器打开 craft 端点显示 HTML 预览](https://cursor.com/agents/bc-d0acec58-0ae9-48df-bf9f-aa37566a53ba/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcraft_html_preview.webp)
[点击查看原始 RSS 后的 XML](https://cursor.com/agents/bc-d0acec58-0ae9-48df-bf9f-aa37566a53ba/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcraft_raw_rss_xml.webp)
[format=json 返回 JSON Feed](https://cursor.com/agents/bc-d0acec58-0ae9-48df-bf9f-aa37566a53ba/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcraft_json_feed.webp)
[craft_browser_preview_html_rss_json.mp4](https://cursor.com/agents/bc-d0acec58-0ae9-48df-bf9f-aa37566a53ba/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcraft_browser_preview_html_rss_json.mp4)

## 测试命令

- `go test ./internal/craft/ -run 'TestNegotiateFeedFormat|TestCommonCraftHandler|TestRenderFeedHTML'`
- `go test ./...`
- Go lint：0 issues

前端 lint 仍有仓库里已有的 `vitest` / `highlight.js` unresolved，与本次改动无关。


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d0acec58-0ae9-48df-bf9f-aa37566a53ba?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d0acec58-0ae9-48df-bf9f-aa37566a53ba&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

## Summary by Sourcery

Enable content-negotiated craft feed responses so browsers receive readable previews while subscribers continue receiving the expected feed formats.

New Features:
- Add browser-friendly HTML previews for crafted feeds while preserving RSS responses for feed readers.
- Support explicit RSS, HTML, JSON Feed, and Atom representations through the format query parameter.

Bug Fixes:
- Prevent browser visits to craft endpoints from displaying unreadable raw RSS XML by negotiating the response format from the Accept header.

Enhancements:
- Add content negotiation with quality-aware Accept header handling and safe, escaped feed preview rendering.
- Expose links from the HTML preview to the original RSS and JSON Feed representations.

Tests:
- Add coverage for response negotiation, browser HTML previews, forced formats, RSS compatibility, JSON Feed output, and untrusted-content escaping.