### PR TITLE
fix(parser): 按 token 匹配并优先选择标准 favicon

### DIFF
--- a/internal/source/parser/html_parser.go
+++ b/internal/source/parser/html_parser.go
@@ -6,6 +6,7 @@ import (
 	"FeedCraft/internal/util"
 	"bytes"
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/PuerkitoBio/goquery"
@@ -102,25 +103,127 @@ func (p *HtmlParser) Parse(data []byte) (*model.CraftFeed, error) {
 }
 
 func extractFeedIconURL(doc *goquery.Document) string {
-	iconHref := ""
-	doc.Find("link[rel]").EachWithBreak(func(_ int, s *goquery.Selection) bool {
+	bestHref := ""
+	bestScore := 0
+	found := false
+	doc.Find("link[rel]").Each(func(_ int, s *goquery.Selection) {
 		rel, _ := s.Attr("rel")
-		if !hasFeedIconRel(rel) {
-			return true
+		kind := feedIconRelKind(rel)
+		if kind == feedIconKindNone {
+			return
 		}
-		iconHref, _ = s.Attr("href")
-		iconHref = strings.TrimSpace(iconHref)
-		return iconHref == ""
+		href := strings.TrimSpace(s.AttrOr("href", ""))
+		if href == "" {
+			return
+		}
+		score := scoreFeedIcon(kind, s.AttrOr("sizes", ""), s.AttrOr("type", ""))
+		if !found || score > bestScore {
+			found = true
+			bestScore = score
+			bestHref = href
+		}
 	})
-	return iconHref
+	return bestHref
 }
 
+type feedIconKind int
+
+const (
+	feedIconKindNone feedIconKind = iota
+	feedIconKindFallback
+	feedIconKindStandard
+)
+
 func hasFeedIconRel(rel string) bool {
+	return feedIconRelKind(rel) != feedIconKindNone
+}
+
+func feedIconRelKind(rel string) feedIconKind {
+	kind := feedIconKindNone
 	for _, token := range strings.Fields(strings.ToLower(rel)) {
 		switch token {
-		case "icon", "apple-touch-icon", "apple-touch-icon-precomposed", "mask-icon":
-			return true
+		case "icon":
+			kind = feedIconKindStandard
+		case "apple-touch-icon", "apple-touch-icon-precomposed", "mask-icon":
+			if kind != feedIconKindStandard {
+				kind = feedIconKindFallback
+			}
 		}
 	}
-	return false
+	return kind
+}
+
+func scoreFeedIcon(kind feedIconKind, sizes, typ string) int {
+	score := 0
+	if kind == feedIconKindStandard {
+		score += 1000
+	}
+	score += feedIconSizeScore(sizes)
+	score += feedIconTypeScore(typ)
+	return score
+}
+
+func feedIconSizeScore(sizes string) int {
+	sizes = strings.ToLower(strings.TrimSpace(sizes))
+	if sizes == "" {
+		return 50
+	}
+	if sizes == "any" {
+		return 95
+	}
+	best := 0
+	for _, part := range strings.Fields(sizes) {
+		dim, ok := parseIconSize(part)
+		if !ok {
+			continue
+		}
+		score := 20
+		switch {
+		case dim == 32:
+			score = 100
+		case dim == 16 || dim == 48:
+			score = 80
+		case dim >= 16 && dim <= 64:
+			score = 70
+		case dim <= 128:
+			score = 40
+		}
+		if score > best {
+			best = score
+		}
+	}
+	if best == 0 {
+		return 50
+	}
+	return best
+}
+
+func parseIconSize(part string) (int, bool) {
+	widthStr, heightStr, ok := strings.Cut(strings.ToLower(part), "x")
+	if !ok {
+		return 0, false
+	}
+	width, errW := strconv.Atoi(widthStr)
+	height, errH := strconv.Atoi(heightStr)
+	if errW != nil || errH != nil || width <= 0 || height <= 0 {
+		return 0, false
+	}
+	if height < width {
+		return height, true
+	}
+	return width, true
+}
+
+func feedIconTypeScore(typ string) int {
+	typ = strings.ToLower(typ)
+	switch {
+	case strings.Contains(typ, "svg"):
+		return 25
+	case strings.Contains(typ, "png"), strings.Contains(typ, "icon"):
+		return 18
+	case typ == "":
+		return 10
+	default:
+		return 5
+	}
 }

--- a/internal/source/parser/html_parser.go
+++ b/internal/source/parser/html_parser.go
@@ -29,7 +29,11 @@ func (p *HtmlParser) Parse(data []byte) (*model.CraftFeed, error) {
 
 	// Basic feed metadata (can be overridden by FeedMetaConfig later)
 	// For now, we might try to extract title from <title> if not provided via overrides
-	feed.Title = doc.Find("title").Text()
+	feed.Title = strings.TrimSpace(doc.Find("title").Text())
+	feed.ImageURL = extractFeedIconURL(doc)
+	if feed.ImageURL != "" {
+		feed.ImageTitle = feed.Title
+	}
 
 	doc.Find(p.Config.ItemSelector).Each(func(i int, s *goquery.Selection) {
 		item := &model.CraftArticle{}
@@ -95,4 +99,28 @@ func (p *HtmlParser) Parse(data []byte) (*model.CraftFeed, error) {
 	})
 
 	return feed, nil
+}
+
+func extractFeedIconURL(doc *goquery.Document) string {
+	iconHref := ""
+	doc.Find("link[rel]").EachWithBreak(func(_ int, s *goquery.Selection) bool {
+		rel, _ := s.Attr("rel")
+		if !hasFeedIconRel(rel) {
+			return true
+		}
+		iconHref, _ = s.Attr("href")
+		iconHref = strings.TrimSpace(iconHref)
+		return iconHref == ""
+	})
+	return iconHref
+}
+
+func hasFeedIconRel(rel string) bool {
+	for _, token := range strings.Fields(strings.ToLower(rel)) {
+		switch token {
+		case "icon", "apple-touch-icon", "apple-touch-icon-precomposed", "mask-icon":
+			return true
+		}
+	}
+	return false
 }

--- a/internal/source/parser/html_parser_test.go
+++ b/internal/source/parser/html_parser_test.go
@@ -1,0 +1,81 @@
+package parser
+
+import (
+	"FeedCraft/internal/config"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHtmlParserExtractsFeedIcon(t *testing.T) {
+	htmlContent := `
+		<html>
+			<head>
+				<title>Example Site</title>
+				<link rel="stylesheet" href="/app.css">
+				<link rel="shortcut icon" href="/favicon-32.png">
+			</head>
+			<body>
+				<article class="item">
+					<a class="title" href="/posts/1">First post</a>
+				</article>
+			</body>
+		</html>`
+
+	parser := &HtmlParser{Config: &config.HtmlParserConfig{
+		ItemSelector: ".item",
+		Title:        ".title",
+		Link:         ".title",
+	}}
+
+	feed, err := parser.Parse([]byte(htmlContent))
+
+	assert.NoError(t, err)
+	if assert.NotNil(t, feed) {
+		assert.Equal(t, "Example Site", feed.Title)
+		assert.Equal(t, "/favicon-32.png", feed.ImageURL)
+		assert.Equal(t, "Example Site", feed.ImageTitle)
+	}
+}
+
+func TestHtmlParserIgnoresUnrelatedRelContainingIconSubstring(t *testing.T) {
+	htmlContent := `
+		<html>
+			<head>
+				<title>Example Site</title>
+				<link rel="iconography" href="/not-a-favicon.png">
+				<link rel="preload" href="/icon.svg">
+				<link rel="apple-touch-icon" href="/apple-touch.png">
+			</head>
+			<body>
+				<article class="item">
+					<a class="title" href="/posts/1">First post</a>
+				</article>
+			</body>
+		</html>`
+
+	parser := &HtmlParser{Config: &config.HtmlParserConfig{
+		ItemSelector: ".item",
+		Title:        ".title",
+		Link:         ".title",
+	}}
+
+	feed, err := parser.Parse([]byte(htmlContent))
+
+	require.NoError(t, err)
+	require.NotNil(t, feed)
+	assert.Equal(t, "/apple-touch.png", feed.ImageURL)
+}
+
+func TestHasFeedIconRel(t *testing.T) {
+	assert.True(t, hasFeedIconRel("icon"))
+	assert.True(t, hasFeedIconRel("SHORTCUT ICON"))
+	assert.True(t, hasFeedIconRel("apple-touch-icon"))
+	assert.True(t, hasFeedIconRel("apple-touch-icon-precomposed"))
+	assert.True(t, hasFeedIconRel("mask-icon"))
+	assert.False(t, hasFeedIconRel("iconography"))
+	assert.False(t, hasFeedIconRel("stylesheet"))
+	assert.False(t, hasFeedIconRel("preload"))
+	assert.False(t, hasFeedIconRel(""))
+}

--- a/internal/source/parser/html_parser_test.go
+++ b/internal/source/parser/html_parser_test.go
@@ -2,6 +2,7 @@ package parser
 
 import (
 	"FeedCraft/internal/config"
+	"FeedCraft/internal/model"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -78,4 +79,67 @@ func TestHasFeedIconRel(t *testing.T) {
 	assert.False(t, hasFeedIconRel("stylesheet"))
 	assert.False(t, hasFeedIconRel("preload"))
 	assert.False(t, hasFeedIconRel(""))
+}
+
+func TestHtmlParserPrefersShortcutIconOverAppleTouchIcon(t *testing.T) {
+	feed := parseHTMLFeed(t, `
+		<html>
+			<head>
+				<title>Example Site</title>
+				<link rel="apple-touch-icon" sizes="180x180" href="/apple-touch.png">
+				<link rel="mask-icon" href="/safari-pinned-tab.svg">
+				<link rel="shortcut icon" href="/favicon.ico">
+			</head>
+			<body>
+				<article class="item"><a class="title" href="/posts/1">First post</a></article>
+			</body>
+		</html>`)
+
+	assert.Equal(t, "/favicon.ico", feed.ImageURL)
+}
+
+func TestHtmlParserPrefersStandardIconSizeNear32(t *testing.T) {
+	feed := parseHTMLFeed(t, `
+		<html>
+			<head>
+				<title>Example Site</title>
+				<link rel="icon" sizes="192x192" type="image/png" href="/icon-192.png">
+				<link rel="icon" sizes="32x32" type="image/png" href="/icon-32.png">
+				<link rel="icon" sizes="16x16" type="image/png" href="/icon-16.png">
+			</head>
+			<body>
+				<article class="item"><a class="title" href="/posts/1">First post</a></article>
+			</body>
+		</html>`)
+
+	assert.Equal(t, "/icon-32.png", feed.ImageURL)
+}
+
+func TestHtmlParserPrefersSVGIconWhenSizesAny(t *testing.T) {
+	feed := parseHTMLFeed(t, `
+		<html>
+			<head>
+				<title>Example Site</title>
+				<link rel="icon" sizes="192x192" type="image/png" href="/icon-192.png">
+				<link rel="icon" type="image/svg+xml" sizes="any" href="/icon.svg">
+			</head>
+			<body>
+				<article class="item"><a class="title" href="/posts/1">First post</a></article>
+			</body>
+		</html>`)
+
+	assert.Equal(t, "/icon.svg", feed.ImageURL)
+}
+
+func parseHTMLFeed(t *testing.T, htmlContent string) *model.CraftFeed {
+	t.Helper()
+	parser := &HtmlParser{Config: &config.HtmlParserConfig{
+		ItemSelector: ".item",
+		Title:        ".title",
+		Link:         ".title",
+	}}
+	feed, err := parser.Parse([]byte(htmlContent))
+	require.NoError(t, err)
+	require.NotNil(t, feed)
+	return feed
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 背景

Favicon 提取如果用子串匹配，或简单取第一个 `link[rel*=icon]`，会误选无关关系，或优先拿到 `apple-touch-icon` / `mask-icon` 这类大图、语义不同的图标。

HTML 的 `rel` 是空格分隔的 token。应只匹配明确的图标关系，并优先标准 favicon。

## 改动

- 只接受这些 rel token：`icon`、`apple-touch-icon`、`apple-touch-icon-precomposed`、`mask-icon`
- `shortcut icon` 通过其中的 `icon` token 匹配；忽略 `iconography`、`preload` 等无关关系
- 优先 `rel="icon"` / `rel="shortcut icon"`，避免排在前面的 apple-touch / mask icon 抢走选择
- 在标准 favicon 中按 `sizes`、`type` 打分：接近 32x32 或 `image/svg+xml` + `sizes=any` 更优
- 没有标准 favicon 时才回退到 touch/mask icon
- 选中后写入 feed 的 `ImageURL` / `ImageTitle`

## 验证

- `go test ./internal/source/parser ./internal/source`
- `go test ./...`
- `golangci-lint run ./internal/source/parser/...`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-41d25896-905e-4a91-a57e-0fa376524784?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-41d25896-905e-4a91-a57e-0fa376524784&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

## Summary by Sourcery

Improve HTML favicon extraction by matching explicit rel tokens and selecting the most appropriate standard icon.

New Features:
- Extract feed favicon metadata from HTML and populate the feed image URL and title.

Bug Fixes:
- Prevent unrelated rel values from being mistaken for favicons and avoid selecting touch or mask icons when a standard favicon is available.

Enhancements:
- Prioritize standard favicon links and rank candidates by common sizes and image type.

Tests:
- Add coverage for rel-token matching, favicon prioritization, and candidate scoring.