### PR TITLE
Polish craft admin pages against dev

### DIFF
--- a/web/admin/src/api/craft_flow.test.ts
+++ b/web/admin/src/api/craft_flow.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import { normalizeCraftItems } from '@/api/craft_flow';
+
+describe('craft flow API helpers', () => {
+  it('keeps craft item arrays intact', () => {
+    const crafts = [
+      {
+        name: 'proxy',
+        description: 'Proxy feed',
+        type: '@sys/atom',
+        template_only: false,
+      },
+    ];
+
+    expect(normalizeCraftItems(crafts)).toBe(crafts);
+  });
+
+  it('falls back to an empty list for malformed craft list responses', () => {
+    expect(normalizeCraftItems(null)).toEqual([]);
+    expect(normalizeCraftItems({ data: [] })).toEqual([]);
+  });
+});

--- a/web/admin/src/api/craft_flow.test.ts
+++ b/web/admin/src/api/craft_flow.test.ts
@@ -15,8 +15,12 @@ describe('craft flow API helpers', () => {
     expect(normalizeCraftItems(crafts)).toBe(crafts);
   });
 
-  it('falls back to an empty list for malformed craft list responses', () => {
-    expect(normalizeCraftItems(null)).toEqual([]);
-    expect(normalizeCraftItems({ data: [] })).toEqual([]);
+  it('rejects malformed craft list responses', () => {
+    expect(() => normalizeCraftItems(null)).toThrow(
+      'Expected craft list response data to be an array.'
+    );
+    expect(() => normalizeCraftItems({ data: [] })).toThrow(
+      'Expected craft list response data to be an array.'
+    );
   });
 });

--- a/web/admin/src/api/craft_flow.ts
+++ b/web/admin/src/api/craft_flow.ts
@@ -21,6 +21,10 @@ export interface CraftItem {
   template_only?: boolean;
 }
 
+export function normalizeCraftItems(data: unknown): CraftItem[] {
+  return Array.isArray(data) ? data : [];
+}
+
 const adminApiBase = '/api/admin';
 
 // Define the API base URL
@@ -98,5 +102,8 @@ export function listCraftTemplates(): Promise<APIResponse<CraftTemplate[]>> {
 export function listAllCrafts(): Promise<APIResponse<CraftItem[]>> {
   return axios
     .get<APIResponse<CraftItem[]>>('/api/list-all-craft')
-    .then((res) => res.data);
+    .then((res) => ({
+      ...res.data,
+      data: normalizeCraftItems(res.data.data),
+    }));
 }

--- a/web/admin/src/api/craft_flow.ts
+++ b/web/admin/src/api/craft_flow.ts
@@ -22,7 +22,10 @@ export interface CraftItem {
 }
 
 export function normalizeCraftItems(data: unknown): CraftItem[] {
-  return Array.isArray(data) ? data : [];
+  if (!Array.isArray(data)) {
+    throw new TypeError('Expected craft list response data to be an array.');
+  }
+  return data;
 }
 
 const adminApiBase = '/api/admin';

--- a/web/admin/src/api/craft_flow.ts
+++ b/web/admin/src/api/craft_flow.ts
@@ -14,6 +14,13 @@ export interface CraftFlow {
   craft_flow_config?: CraftFlowItem[];
 }
 
+export interface CraftItem {
+  name: string;
+  description: string;
+  type: string;
+  template_only?: boolean;
+}
+
 const adminApiBase = '/api/admin';
 
 // Define the API base URL
@@ -85,5 +92,11 @@ interface CraftTemplate {
 export function listCraftTemplates(): Promise<APIResponse<CraftTemplate[]>> {
   return axios
     .get<APIResponse<CraftTemplate[]>>(`${adminApiBase}/craft-templates`)
+    .then((res) => res.data);
+}
+
+export function listAllCrafts(): Promise<APIResponse<CraftItem[]>> {
+  return axios
+    .get<APIResponse<CraftItem[]>>('/api/list-all-craft')
     .then((res) => res.data);
 }

--- a/web/admin/src/components/craft/CraftManagePage.vue
+++ b/web/admin/src/components/craft/CraftManagePage.vue
@@ -1,0 +1,57 @@
+<template>
+  <div class="craft-manage-page">
+    <x-header :title="title" :description="description" />
+
+    <a-card class="craft-manage-page__card" :bordered="false">
+      <template v-if="$slots.toolbar" #extra>
+        <slot name="toolbar" />
+      </template>
+      <slot />
+    </a-card>
+  </div>
+</template>
+
+<script setup lang="ts">
+  import XHeader from '@/components/header/x-header.vue';
+
+  defineProps<{
+    title: string;
+    description?: string;
+  }>();
+</script>
+
+<script lang="ts">
+  export default {
+    name: 'CraftManagePage',
+  };
+</script>
+
+<style scoped lang="less">
+  .craft-manage-page {
+    padding: 32px 64px;
+  }
+
+  .craft-manage-page__card {
+    border: 1px solid var(--color-border-2);
+    border-radius: 14px;
+    box-shadow: 0 8px 24px rgba(15, 23, 42, 0.04);
+  }
+
+  :deep(.arco-card-header) {
+    min-height: 64px;
+  }
+
+  :deep(.arco-card-body) {
+    padding: 20px;
+  }
+
+  :deep(.arco-table-th) {
+    background: var(--color-fill-1);
+  }
+
+  @media (max-width: 768px) {
+    .craft-manage-page {
+      padding: 20px 16px;
+    }
+  }
+</style>

--- a/web/admin/src/components/craft/CraftManagePage.vue
+++ b/web/admin/src/components/craft/CraftManagePage.vue
@@ -3,9 +3,9 @@
     <x-header :title="title" :description="description" />
 
     <a-card class="craft-manage-page__card" :bordered="false">
-      <template v-if="$slots.toolbar" #extra>
+      <div v-if="$slots.toolbar" class="craft-manage-page__toolbar">
         <slot name="toolbar" />
-      </template>
+      </div>
       <slot />
     </a-card>
   </div>
@@ -37,8 +37,10 @@
     box-shadow: 0 8px 24px rgba(15, 23, 42, 0.04);
   }
 
-  :deep(.arco-card-header) {
-    min-height: 64px;
+  .craft-manage-page__toolbar {
+    display: flex;
+    justify-content: flex-start;
+    margin-bottom: 16px;
   }
 
   :deep(.arco-card-body) {

--- a/web/admin/src/locale/en-US/allCraftList.ts
+++ b/web/admin/src/locale/en-US/allCraftList.ts
@@ -5,6 +5,8 @@ export default {
   'allCraftList.table.name': 'Name',
   'allCraftList.table.type': 'Type',
   'allCraftList.table.templateOnly': 'Template Only',
+  'allCraftList.table.templateOnlyYes': 'Yes',
+  'allCraftList.table.templateOnlyNo': 'No',
   'allCraftList.table.description': 'Description',
   'allCraftList.message.fetchFailed': 'Failed to fetch all Crafts',
 };

--- a/web/admin/src/locale/en-US/craftAtom.ts
+++ b/web/admin/src/locale/en-US/craftAtom.ts
@@ -20,6 +20,7 @@ export default {
   'craftAtom.form.addParam': 'Add Parameter',
   'craftAtom.form.cancel': 'Cancel',
   'craftAtom.form.save': 'Save',
+  'craftAtom.form.saveSuccess': 'Saved successfully',
   'craftAtom.form.rule.templateRequired': 'Template is required',
   'craftAtom.form.rule.nameRequired': 'Name is required',
   'craftAtom.empty.description': 'No AtomCrafts yet',

--- a/web/admin/src/locale/en-US/craftFlow.ts
+++ b/web/admin/src/locale/en-US/craftFlow.ts
@@ -13,6 +13,8 @@ export default {
   'craftFlow.form.save': 'Save',
   'craftFlow.form.saveSuccess': 'Saved successfully',
   'craftFlow.form.rule.nameRequired': 'Name is required',
+  'craftFlow.flow.start': 'Start',
+  'craftFlow.flow.end': 'End',
   'craftFlow.editModalTitle.create': 'Create FlowCraft',
   'craftFlow.editModalTitle.edit': 'Edit FlowCraft',
   'craftFlow.editor.empty': 'No AtomCrafts in this FlowCraft yet',

--- a/web/admin/src/locale/zh-CN/allCraftList.ts
+++ b/web/admin/src/locale/zh-CN/allCraftList.ts
@@ -5,6 +5,8 @@ export default {
   'allCraftList.table.name': '名称',
   'allCraftList.table.type': '类型',
   'allCraftList.table.templateOnly': '仅模板',
+  'allCraftList.table.templateOnlyYes': '是',
+  'allCraftList.table.templateOnlyNo': '否',
   'allCraftList.table.description': '描述',
   'allCraftList.message.fetchFailed': '获取所有 Craft 失败',
 };

--- a/web/admin/src/locale/zh-CN/craftAtom.ts
+++ b/web/admin/src/locale/zh-CN/craftAtom.ts
@@ -20,8 +20,9 @@ export default {
   'craftAtom.form.addParam': '添加参数',
   'craftAtom.form.cancel': '取消',
   'craftAtom.form.save': '保存',
-  'craftAtom.form.rule.templateRequired': 'template is required',
-  'craftAtom.form.rule.nameRequired': 'Name is required',
+  'craftAtom.form.saveSuccess': '保存成功',
+  'craftAtom.form.rule.templateRequired': '模板为必填项',
+  'craftAtom.form.rule.nameRequired': '名称为必填项',
   'craftAtom.empty.description': '暂无原子工艺',
   'craftAtom.empty.hint':
     '原子工艺决定如何处理 RSS，例如翻译、提取全文或生成摘要。创建第一个 AtomCraft 后即可在配方和组合工艺中复用。',

--- a/web/admin/src/locale/zh-CN/craftFlow.ts
+++ b/web/admin/src/locale/zh-CN/craftFlow.ts
@@ -13,6 +13,8 @@ export default {
   'craftFlow.form.save': '保存',
   'craftFlow.form.saveSuccess': '保存成功',
   'craftFlow.form.rule.nameRequired': '名称为必填项',
+  'craftFlow.flow.start': '开始',
+  'craftFlow.flow.end': '结束',
   'craftFlow.editModalTitle.create': '创建组合工艺 (FlowCraft)',
   'craftFlow.editModalTitle.edit': '编辑组合工艺 (FlowCraft)',
   'craftFlow.editor.empty': '暂无步骤',

--- a/web/admin/src/views/dashboard/all_craft_list/all_craft_list.vue
+++ b/web/admin/src/views/dashboard/all_craft_list/all_craft_list.vue
@@ -78,7 +78,7 @@
     try {
       const response = await listAllCrafts();
       allCrafts.value = response.data;
-    } catch (error) {
+    } catch {
       Message.error(t('allCraftList.message.fetchFailed'));
     } finally {
       isLoading.value = false;

--- a/web/admin/src/views/dashboard/all_craft_list/all_craft_list.vue
+++ b/web/admin/src/views/dashboard/all_craft_list/all_craft_list.vue
@@ -1,55 +1,77 @@
 <template>
-  <div class="py-8 px-16">
-    <x-header
-      :title="t('menu.allCraftList')"
-      :description="t('allCraftList.description')"
-    ></x-header>
-
-    <a-space direction="horizontal" class="mb-6">
-      <a-button type="primary" :loading="isLoading" @click="listAllCrafts">
+  <CraftManagePage
+    :title="t('menu.allCraftList')"
+    :description="t('allCraftList.description')"
+  >
+    <template #toolbar>
+      <a-button :loading="isLoading" @click="fetchAllCrafts">
+        <template #icon>
+          <icon-refresh />
+        </template>
         {{ t('allCraftList.query') }}
       </a-button>
-    </a-space>
+    </template>
 
     <a-table
+      row-key="name"
       :data="allCrafts"
       :columns="columns"
       :loading="isLoading"
-    ></a-table>
-  </div>
+      :bordered="false"
+      :pagination="{ pageSize: 10, showTotal: true }"
+    >
+      <template #type="{ record }">
+        <a-tag :color="getCraftTypeColor(record.type)">
+          {{ record.type }}
+        </a-tag>
+      </template>
+      <template #templateOnly="{ record }">
+        <a-tag :color="record.template_only ? 'orange' : 'green'">
+          {{
+            record.template_only
+              ? t('allCraftList.table.templateOnlyYes')
+              : t('allCraftList.table.templateOnlyNo')
+          }}
+        </a-tag>
+      </template>
+    </a-table>
+  </CraftManagePage>
 </template>
 
 <script setup lang="ts">
-  import XHeader from '@/components/header/x-header.vue';
+  import CraftManagePage from '@/components/craft/CraftManagePage.vue';
   import { onBeforeMount, ref } from 'vue';
   import { Message } from '@arco-design/web-vue';
-  import axios from 'axios';
   import { useI18n } from 'vue-i18n';
+  import { CraftItem, listAllCrafts } from '@/api/craft_flow';
 
   const { t } = useI18n();
-
-  interface CraftItem {
-    name: string;
-    description: string;
-    type: string;
-    template_only?: boolean;
-  }
 
   const isLoading = ref(false);
   const allCrafts = ref<CraftItem[]>([]);
 
   const columns = [
     { title: t('allCraftList.table.name'), dataIndex: 'name' },
-    { title: t('allCraftList.table.type'), dataIndex: 'type' },
-    { title: t('allCraftList.table.templateOnly'), dataIndex: 'template_only' },
+    { title: t('allCraftList.table.type'), slotName: 'type', width: 160 },
+    {
+      title: t('allCraftList.table.templateOnly'),
+      slotName: 'templateOnly',
+      width: 140,
+    },
     { title: t('allCraftList.table.description'), dataIndex: 'description' },
   ];
 
-  const listAllCrafts = async () => {
+  const getCraftTypeColor = (type: string) => {
+    if (type?.toLowerCase().includes('flow')) return 'purple';
+    if (type?.toLowerCase().includes('atom')) return 'arcoblue';
+    return 'gray';
+  };
+
+  const fetchAllCrafts = async () => {
     isLoading.value = true;
     try {
-      const response = await axios.get('/api/list-all-craft');
-      allCrafts.value = response.data.data;
+      const response = await listAllCrafts();
+      allCrafts.value = response.data;
     } catch (error) {
       Message.error(t('allCraftList.message.fetchFailed'));
     } finally {
@@ -58,7 +80,7 @@
   };
 
   onBeforeMount(() => {
-    listAllCrafts();
+    fetchAllCrafts();
   });
 </script>
 

--- a/web/admin/src/views/dashboard/all_craft_list/all_craft_list.vue
+++ b/web/admin/src/views/dashboard/all_craft_list/all_craft_list.vue
@@ -13,8 +13,8 @@
     </template>
 
     <a-table
-      row-key="name"
-      :data="allCrafts"
+      row-key="row_key"
+      :data="allCraftRows"
       :columns="columns"
       :loading="isLoading"
       :bordered="false"
@@ -40,7 +40,7 @@
 
 <script setup lang="ts">
   import CraftManagePage from '@/components/craft/CraftManagePage.vue';
-  import { onBeforeMount, ref } from 'vue';
+  import { computed, onBeforeMount, ref } from 'vue';
   import { Message } from '@arco-design/web-vue';
   import { useI18n } from 'vue-i18n';
   import { CraftItem, listAllCrafts } from '@/api/craft_flow';
@@ -49,6 +49,12 @@
 
   const isLoading = ref(false);
   const allCrafts = ref<CraftItem[]>([]);
+  const allCraftRows = computed(() =>
+    allCrafts.value.map((item) => ({
+      ...item,
+      row_key: `${item.type}:${item.name}`,
+    }))
+  );
 
   const columns = [
     { title: t('allCraftList.table.name'), dataIndex: 'name' },

--- a/web/admin/src/views/dashboard/craft_atom/craft_atom.vue
+++ b/web/admin/src/views/dashboard/craft_atom/craft_atom.vue
@@ -1,56 +1,70 @@
 <template>
-  <div class="py-8 px-16">
-    <x-header
-      :title="t('menu.craftAtom')"
-      :description="t('craftAtom.description')"
-    ></x-header>
+  <CraftManagePage
+    :title="t('menu.craftAtom')"
+    :description="t('craftAtom.description')"
+  >
+    <template #toolbar>
+      <a-space wrap>
+        <a-button :loading="isLoading" @click="listAllCraftAtoms">
+          <template #icon>
+            <icon-refresh />
+          </template>
+          {{ t('craftAtom.query') }}
+        </a-button>
+        <a-button type="primary" @click="handleAdd">
+          <template #icon>
+            <icon-plus />
+          </template>
+          {{ t('craftAtom.create') }}
+        </a-button>
+      </a-space>
+    </template>
 
-    <a-card class="general-card" :title="t('menu.craftAtom')">
-      <template #extra>
-        <a-space>
-          <a-button :loading="isLoading" @click="listAllCraftAtoms">
-            {{ t('craftAtom.query') }}
+    <a-table
+      v-if="isLoading || craftAtoms.length > 0"
+      row-key="name"
+      :data="craftAtoms"
+      :columns="columns"
+      :loading="isLoading"
+      :bordered="false"
+      :pagination="{ pageSize: 10, showTotal: true }"
+    >
+      <template #params="{ record }">
+        <a-space v-if="Object.keys(record.params || {}).length" wrap>
+          <a-tag v-for="(_, key) in record.params" :key="key" color="gray">
+            {{ key }}
+          </a-tag>
+        </a-space>
+        <span v-else class="text-gray-400">{{
+          t('craftAtom.form.noParams')
+        }}</span>
+      </template>
+      <template #actions="{ record }">
+        <a-space wrap>
+          <a-button type="text" size="small" @click="editBtnHandler(record)">
+            {{ t('craftAtom.edit') }}
           </a-button>
-          <a-button type="primary" @click="handleAdd">
-            <template #icon>
-              <icon-plus />
-            </template>
-            {{ t('craftAtom.create') }}
-          </a-button>
+          <a-popconfirm
+            :content="t('craftAtom.deleteConfirm')"
+            @ok="deleteCraftAtomHandler(record.name)"
+          >
+            <a-button type="text" status="danger" size="small">
+              {{ t('craftAtom.delete') }}
+            </a-button>
+          </a-popconfirm>
         </a-space>
       </template>
+    </a-table>
 
-      <a-table
-        v-if="isLoading || craftAtoms.length > 0"
-        :data="craftAtoms"
-        :columns="columns"
-        :loading="isLoading"
-      >
-        <template #actions="{ record }">
-          <a-space>
-            <a-button type="outline" @click="editBtnHandler(record)"
-              >{{ t('craftAtom.edit') }}
-            </a-button>
-            <a-popconfirm
-              :content="t('craftAtom.deleteConfirm')"
-              @ok="deleteCraftAtomHandler(record.name)"
-            >
-              <a-button status="danger">{{ t('craftAtom.delete') }}</a-button>
-            </a-popconfirm>
-          </a-space>
-        </template>
-      </a-table>
-
-      <ListEmptyGuide
-        v-else-if="!listFailed"
-        :description="t('craftAtom.empty.description')"
-        :hint="t('craftAtom.empty.hint')"
-        :create-label="t('craftAtom.empty.createFirst')"
-        :docs-label="t('craftAtom.empty.docs')"
-        :docs-href="atomDocsHref"
-        @create="handleAdd"
-      />
-    </a-card>
+    <ListEmptyGuide
+      v-else-if="!listFailed"
+      :description="t('craftAtom.empty.description')"
+      :hint="t('craftAtom.empty.hint')"
+      :create-label="t('craftAtom.empty.createFirst')"
+      :docs-label="t('craftAtom.empty.docs')"
+      :docs-href="atomDocsHref"
+      @create="handleAdd"
+    />
 
     <a-modal
       v-model:visible="showEditModal"
@@ -234,11 +248,11 @@
         }}</a-button>
       </template>
     </a-modal>
-  </div>
+  </CraftManagePage>
 </template>
 
 <script setup lang="ts">
-  import XHeader from '@/components/header/x-header.vue';
+  import CraftManagePage from '@/components/craft/CraftManagePage.vue';
   import ListEmptyGuide from '@/components/list-empty-guide/index.vue';
   import { computed, onBeforeMount, ref } from 'vue';
   import { buildDocsUrl } from '@/utils/docsUrl';
@@ -292,8 +306,13 @@
     { title: t('craftAtom.form.name'), dataIndex: 'name' },
     { title: t('craftAtom.form.description'), dataIndex: 'description' },
     { title: t('craftAtom.form.template'), dataIndex: 'template_name' },
-    { title: t('craftAtom.form.params'), dataIndex: 'params' },
-    { title: t('craftAtom.edit'), slotName: 'actions' },
+    { title: t('craftAtom.form.params'), slotName: 'params' },
+    {
+      title: t('craftAtom.edit'),
+      slotName: 'actions',
+      width: 140,
+      align: 'right',
+    },
   ];
   const rules = {
     template_name: [
@@ -438,6 +457,7 @@
     } else {
       await createCraftAtom(editedCraftAtom.value);
     }
+    Message.success(t('craftAtom.form.saveSuccess'));
     showEditModal.value = false;
     await listAllCraftAtoms();
     isUpdating.value = false;

--- a/web/admin/src/views/dashboard/craft_flow/craft_flow.vue
+++ b/web/admin/src/views/dashboard/craft_flow/craft_flow.vue
@@ -1,70 +1,76 @@
 <template>
-  <div class="py-8 px-16">
-    <x-header
-      :title="t('menu.craftFlow')"
-      :description="t('craftFlow.description')"
-    ></x-header>
+  <CraftManagePage
+    :title="t('menu.craftFlow')"
+    :description="t('craftFlow.description')"
+  >
+    <template #toolbar>
+      <a-space wrap>
+        <a-button :loading="isLoading" @click="listAllCraftFlow">
+          <template #icon>
+            <icon-refresh />
+          </template>
+          {{ t('craftFlow.query') }}
+        </a-button>
+        <a-button type="primary" @click="handleAdd">
+          <template #icon>
+            <icon-plus />
+          </template>
+          {{ t('craftFlow.create') }}
+        </a-button>
+      </a-space>
+    </template>
 
-    <a-card class="general-card" :title="t('menu.craftFlow')">
-      <template #extra>
-        <a-space>
-          <a-button :loading="isLoading" @click="listAllCraftFlow">
-            {{ t('craftFlow.query') }}
-          </a-button>
-          <a-button type="primary" @click="handleAdd">
-            <template #icon>
-              <icon-plus />
-            </template>
-            {{ t('craftFlow.create') }}
-          </a-button>
-        </a-space>
-      </template>
-
-      <a-table
-        v-if="isLoading || craftFlows.length > 0"
-        :data="craftFlows"
-        :columns="columns"
-        :loading="isLoading"
-      >
-        <template #craft-flow-item-list="{ record }">
-          <a-tag>开始</a-tag>
-          >
+    <a-table
+      v-if="isLoading || craftFlows.length > 0"
+      row-key="name"
+      :data="craftFlows"
+      :columns="columns"
+      :loading="isLoading"
+      :bordered="false"
+      :pagination="{ pageSize: 10, showTotal: true }"
+    >
+      <template #craft-flow-item-list="{ record }">
+        <div class="craft-flow-chain">
+          <a-tag color="gray">{{ t('craftFlow.flow.start') }}</a-tag>
           <template
             v-for="(item, index) in record.craft_flow_config"
             :key="index"
           >
+            <span class="craft-flow-chain__arrow">/</span>
             <a-tooltip :content="getCraftDescription(item.craft_name)">
               <a-tag color="arcoblue">{{ item.craft_name }}</a-tag>
             </a-tooltip>
-            >
           </template>
-          <a-tag>结束</a-tag>
-        </template>
-        <template #actions="{ record }">
-          <a-space>
-            <a-button type="outline" @click="editBtnHandler(record)"
-              >{{ t('craftFlow.edit') }}
+          <span class="craft-flow-chain__arrow">/</span>
+          <a-tag color="gray">{{ t('craftFlow.flow.end') }}</a-tag>
+        </div>
+      </template>
+      <template #actions="{ record }">
+        <a-space wrap>
+          <a-button type="text" size="small" @click="editBtnHandler(record)">
+            {{ t('craftFlow.edit') }}
+          </a-button>
+          <a-popconfirm
+            :content="t('craftFlow.deleteConfirm')"
+            @ok="deleteCraftFlowHandler(record.name)"
+          >
+            <a-button type="text" status="danger" size="small">
+              {{ t('craftFlow.delete') }}
             </a-button>
-            <a-popconfirm
-              :content="t('craftFlow.deleteConfirm')"
-              @ok="deleteCraftFlowHandler(record.name)"
-            >
-              <a-button status="danger">{{ t('craftFlow.delete') }}</a-button>
-            </a-popconfirm>
-          </a-space>
-        </template>
-      </a-table>
+          </a-popconfirm>
+        </a-space>
+      </template>
+    </a-table>
 
-      <ListEmptyGuide
-        v-else-if="!listFailed"
-        :description="t('craftFlow.empty.description')"
-        :hint="t('craftFlow.empty.hint')"
-        :create-label="t('craftFlow.empty.createFirst')"
-        :docs-label="t('craftFlow.empty.docs')"
-        :docs-href="flowDocsHref"
-        @create="handleAdd"
-      />
-    </a-card>
+    <ListEmptyGuide
+      v-else-if="!listFailed"
+      :description="t('craftFlow.empty.description')"
+      :hint="t('craftFlow.empty.hint')"
+      :create-label="t('craftFlow.empty.createFirst')"
+      :docs-label="t('craftFlow.empty.docs')"
+      :docs-href="flowDocsHref"
+      @create="handleAdd"
+    />
 
     <a-modal
       v-model:visible="showEditModal"
@@ -80,6 +86,7 @@
         :rules="rules"
         :label-col="{ span: 6 }"
         :wrapper-col="{ span: 18 }"
+        layout="vertical"
       >
         <a-form-item :label="t('craftFlow.form.name')" field="name">
           <a-input v-model="editedCraftFlow.name" />
@@ -109,11 +116,11 @@
         }}</a-button>
       </template>
     </a-modal>
-  </div>
+  </CraftManagePage>
 </template>
 
 <script setup lang="ts">
-  import XHeader from '@/components/header/x-header.vue';
+  import CraftManagePage from '@/components/craft/CraftManagePage.vue';
   import ListEmptyGuide from '@/components/list-empty-guide/index.vue';
   import { onBeforeMount, ref, computed } from 'vue';
   import { buildDocsUrl } from '@/utils/docsUrl';
@@ -136,21 +143,11 @@
     buildDocsUrl(locale.value, 'guides/advanced/customization')
   );
 
-  const handleAdd = () => {
-    editedCraftFlow.value = {
-      name: '',
-      description: '',
-      craftList: [],
-    };
-    showEditModal.value = true;
-    isUpdating.value = false;
-  };
-
   const rules = {
     name: [
       {
         required: true,
-        message: 'Name is required',
+        message: t('craftFlow.form.rule.nameRequired'),
         trigger: 'blur',
       },
       namingValidator,
@@ -176,8 +173,24 @@
     { title: t('craftFlow.form.name'), dataIndex: 'name' },
     { title: t('craftFlow.form.description'), dataIndex: 'description' },
     { title: t('craftFlow.form.flow'), slotName: 'craft-flow-item-list' },
-    { title: t('craftFlow.edit'), slotName: 'actions' },
+    {
+      title: t('craftFlow.edit'),
+      slotName: 'actions',
+      width: 140,
+      align: 'right',
+    },
   ];
+
+  const handleAdd = () => {
+    editedCraftFlow.value = {
+      name: '',
+      description: '',
+      craftList: [],
+      craft_flow_config: [],
+    };
+    showEditModal.value = true;
+    isUpdating.value = false;
+  };
 
   const editBtnHandler = (craftFlow: CraftFlow) => {
     // Clone and ensure craftList exists
@@ -302,3 +315,16 @@
     name: 'CraftFlow',
   };
 </script>
+
+<style scoped lang="less">
+  .craft-flow-chain {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 6px;
+  }
+
+  .craft-flow-chain__arrow {
+    color: var(--color-text-4);
+  }
+</style>

--- a/web/admin/src/views/dashboard/craft_flow/craft_flow.vue
+++ b/web/admin/src/views/dashboard/craft_flow/craft_flow.vue
@@ -271,7 +271,7 @@
         craftList: [],
         craft_flow_config: [],
       };
-    } catch (err) {
+    } catch {
       // Error handling is done by interceptor or default handling
     } finally {
       saving.value = false;

--- a/web/admin/vitest.config.ts
+++ b/web/admin/vitest.config.ts
@@ -1,5 +1,4 @@
 import { fileURLToPath, URL } from 'node:url';
-import { resolve } from 'path';
 import { defineConfig } from 'vitest/config';
 
 export default defineConfig({


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Rebase the craft admin UI unification onto the latest `dev` branch.
- Keep the existing empty-state guides on AtomCraft and FlowCraft while applying the shared `CraftManagePage` layout.
- Align AtomCraft, FlowCraft, and All Craft List pages with the same header, card, toolbar, and table treatment.
- Move craft page action buttons (query / create) to the left of the card body instead of the card header extra slot.

This replaces the previous PR that targeted `main`: https://github.com/Colin-XKL/FeedCraft/pull/839

### Testing
- `pnpm run test`
- `pnpm run type:check`
- `pnpm run lint` (passes with existing unused-var / `v-html` warnings outside these pages)
- `pnpm run build`
- `go test ./...`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-59879eaa-7809-426e-9359-2d6a52f5570d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-59879eaa-7809-426e-9359-2d6a52f5570d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

## Summary by Sourcery

Unify the craft administration pages with a consistent management experience while strengthening craft-list handling and localized feedback.

New Features:
- Provide a shared craft management page layout with consistent headers, cards, toolbars, tables, and responsive styling.
- Add a consolidated all-crafts listing with typed API access, refresh handling, pagination, and visual craft type and template-status indicators.

Bug Fixes:
- Validate all-crafts API responses before consuming craft items.
- Preserve AtomCraft and FlowCraft empty-state guides while integrating the unified page layout.

Enhancements:
- Improve AtomCraft and FlowCraft table presentation, action controls, flow visualization, and save feedback.
- Complete English and Chinese localization for craft statuses, flow endpoints, validation, and save messages.

Tests:
- Add unit tests covering craft list response normalization and malformed API data.