### PR TITLE
fix(docs): 修复 Inbox 指南页面显示异常

### DIFF
--- a/doc-site/AGENTS.md
+++ b/doc-site/AGENTS.md
@@ -25,7 +25,8 @@ FeedCraft documentation MUST be kept in sync across all supported languages (`en
 
 Since we use the [Starlight](https://starlight.astro.build/components/using-components/) framework, you should leverage its built-in components to create more readable and interactive documentation:
 
-- **Asides**: Use `:::note`, `:::tip`, `:::caution`, or `:::danger` for callouts.
+- **File extension**: Pages that `import` or use JSX components (`<Steps>`, `<Tabs>`, `<Card>`, etc.) MUST use the `.mdx` extension. Regular `.md` files will render `import` statements and component tags as raw text.
+- **Asides**: Use `:::note`, `:::tip`, `:::caution`, or `:::danger` for callouts. These work in both `.md` and `.mdx`.
 - **Steps**: Use the `<Steps>` component for multi-step instructions (e.g., deployment or configuration).
 - **Tabs**: Use the `<Tabs>` and `<TabItem>` components when showing multiple options (e.g., different deployment methods or model configurations).
 - **Cards**: Use `<Card>` or `<CardGrid>` for high-level overviews or navigation.

--- a/doc-site/src/content/docs/en/guides/advanced/inbox.mdx
+++ b/doc-site/src/content/docs/en/guides/advanced/inbox.mdx
@@ -29,6 +29,7 @@ Navigate to **Worktable > Inbox Management** in the admin dashboard.
 ### Creating an Inbox
 
 <Steps>
+
 1. Click **Create Inbox**.
 2. Fill in the required fields:
    - **Inbox ID**: A unique, URL-safe identifier (lowercase letters, numbers, hyphens, underscores). Cannot be changed after creation.
@@ -36,6 +37,7 @@ Navigate to **Worktable > Inbox Management** in the admin dashboard.
    - **Max Items**: Maximum number of articles to retain. When the limit is exceeded, the items with the oldest **creation time** are pruned first (default: 100). Set to `0` to impose no limit — note that `0` actually deletes all items immediately, so use a large number instead.
    - **Public Access**: If enabled, article content can be fetched without authentication. If disabled, a valid System Auth Token must be provided.
 3. Click **OK** to save.
+
 </Steps>
 
 ### Editing an Inbox
@@ -55,9 +57,11 @@ Click **Delete** in the actions column. This permanently removes the inbox and *
 Navigate to **Settings > System Auth Token** to create API tokens that authorise push requests.
 
 <Steps>
+
 1. Click **Generate Token**.
 2. Enter a descriptive label (e.g., "iPhone Shortcut", "Home Assistant").
 3. Copy the generated token immediately — it is only shown once and cannot be retrieved later.
+
 </Steps>
 
 Tokens can be revoked at any time by clicking **Delete**. All integrations using the revoked token will stop working immediately.
@@ -151,6 +155,7 @@ Copy this URL and paste it directly into your RSS reader. For a **private inbox*
 Create a Custom Recipe if you want to apply Craft processing on top of the inbox (e.g., AI translation, summarization, or filtering).
 
 <Steps>
+
 1. Navigate to **Worktable > Custom Recipe** and click **Create Recipe**.
 2. Set **Source Type** to `inbox`.
 3. In the **Source Config JSON** field, enter:
@@ -159,6 +164,7 @@ Create a Custom Recipe if you want to apply Craft processing on top of the inbox
    ```
 4. Set **Craft** to the desired processing chain (e.g., `translate-content`, `summary`).
 5. Save the recipe and click **Copy Link** in the recipe list to get the RSS URL.
+
 </Steps>
 
 :::tip

--- a/doc-site/src/content/docs/en/guides/advanced/inbox.mdx
+++ b/doc-site/src/content/docs/en/guides/advanced/inbox.mdx
@@ -8,7 +8,7 @@ sidebar:
     variant: success
 ---
 
-import { Steps } from '@astrojs/starlight/components';
+import { Steps } from "@astrojs/starlight/components";
 
 The **Inbox** feature lets external services, scripts, or automations push articles directly into FeedCraft over HTTP. Each inbox is then exposed as an RSS feed through a Custom Recipe, making it easy to subscribe in any RSS reader.
 

--- a/doc-site/src/content/docs/zh-tw/guides/advanced/inbox.mdx
+++ b/doc-site/src/content/docs/zh-tw/guides/advanced/inbox.mdx
@@ -8,7 +8,7 @@ sidebar:
     variant: success
 ---
 
-import { Steps } from '@astrojs/starlight/components';
+import { Steps } from "@astrojs/starlight/components";
 
 **收件箱**功能允許外部服務、腳本或自動化工具透過 HTTP 主動將文章推送到 FeedCraft。每個收件箱都可以透過自訂配方產生 RSS 訂閱位址，方便在任何 RSS 閱讀器中訂閱。
 

--- a/doc-site/src/content/docs/zh-tw/guides/advanced/inbox.mdx
+++ b/doc-site/src/content/docs/zh-tw/guides/advanced/inbox.mdx
@@ -29,6 +29,7 @@ import { Steps } from '@astrojs/starlight/components';
 ### 建立收件箱
 
 <Steps>
+
 1. 點擊**新建收件箱**。
 2. 填寫必要欄位：
    - **收件箱 ID**：唯一的 URL 安全識別符（只允許小寫字母、數字、連字號、底線）。建立後無法修改。
@@ -36,6 +37,7 @@ import { Steps } from '@astrojs/starlight/components';
    - **最大保存數**：最多保留的文章數量，超出後按**建立時間**從舊到新自動刪除（預設 100）。若設為 `0` 會立即刪除該收件箱的所有條目，請用大數值代替「無限制」。
    - **公開可見性**：開啟後，任何人可直接拉取文章內容；關閉後需提供系統授權令牌。
 3. 點擊**確定**儲存。
+
 </Steps>
 
 ### 編輯收件箱
@@ -55,9 +57,11 @@ import { Steps } from '@astrojs/starlight/components';
 前往 **設定 > 系統授權令牌**，建立用於鑑權推送請求的 API 令牌。
 
 <Steps>
+
 1. 點擊**產生新令牌**。
 2. 輸入描述性標籤（例如「iPhone 捷徑」、「Home Assistant」）。
 3. 立即複製產生的令牌——它只會顯示一次，之後無法再次查看。
+
 </Steps>
 
 隨時可點擊**刪除**撤銷令牌。使用該令牌的所有整合將立即失效。
@@ -151,6 +155,7 @@ GET /inbox/{inbox_id}/rss
 若需要對收件箱內容進行 Craft 處理（如 AI 翻譯、摘要產生、內容過濾），則建立自訂配方。
 
 <Steps>
+
 1. 前往**工作台 > 自訂配方**，點擊**新建配方**。
 2. 將**資料來源類型 (Source Type)** 設定為 `inbox`。
 3. 在 **Source Config JSON** 欄位中輸入：
@@ -159,6 +164,7 @@ GET /inbox/{inbox_id}/rss
    ```
 4. 將 **Craft** 設定為所需的處理鏈（例如 `translate-content`、`summary`）。
 5. 儲存配方後，在配方列表中點擊**複製連結**即可取得 RSS 訂閱位址。
+
 </Steps>
 
 :::tip

--- a/doc-site/src/content/docs/zh/guides/advanced/inbox.mdx
+++ b/doc-site/src/content/docs/zh/guides/advanced/inbox.mdx
@@ -29,6 +29,7 @@ import { Steps } from '@astrojs/starlight/components';
 ### 创建收件箱
 
 <Steps>
+
 1. 点击**新建收件箱**。
 2. 填写必要字段：
    - **收件箱 ID**：唯一的 URL 安全标识符（只允许小写字母、数字、连字符、下划线）。创建后无法修改。
@@ -36,6 +37,7 @@ import { Steps } from '@astrojs/starlight/components';
    - **最大保存数**：最多保留的文章数量，超出后按**创建时间**从旧到新自动删除（默认 100）。若设为 `0` 会立即删除该收件箱的所有条目，请用大数值代替"无限制"。
    - **公开可见性**：开启后，任何人可直接拉取文章内容；关闭后需提供系统授权令牌。
 3. 点击**确定**保存。
+
 </Steps>
 
 ### 编辑收件箱
@@ -55,9 +57,11 @@ import { Steps } from '@astrojs/starlight/components';
 前往 **设置 > 系统授权令牌**，创建用于鉴权推送请求的 API 令牌。
 
 <Steps>
+
 1. 点击**生成新令牌**。
 2. 输入描述性标签（例如"iPhone 快捷指令"、"Home Assistant"）。
 3. 立即复制生成的令牌——它只会显示一次，之后无法再次查看。
+
 </Steps>
 
 随时可点击**删除**撤销令牌。使用该令牌的所有集成将立即失效。
@@ -151,6 +155,7 @@ GET /inbox/{inbox_id}/rss
 若需要对收件箱内容进行 Craft 处理（如 AI 翻译、摘要生成、内容过滤），则创建自定义配方。
 
 <Steps>
+
 1. 前往**工作台 > 自定义配方**，点击**新建配方**。
 2. 将**数据源类型 (Source Type)** 设置为 `inbox`。
 3. 在 **Source Config JSON** 字段中输入：
@@ -159,6 +164,7 @@ GET /inbox/{inbox_id}/rss
    ```
 4. 将 **Craft** 设置为所需的处理链（例如 `translate-content`、`summary`）。
 5. 保存配方后，在配方列表中点击**复制链接**即可获取 RSS 订阅地址。
+
 </Steps>
 
 :::tip

--- a/doc-site/src/content/docs/zh/guides/advanced/inbox.mdx
+++ b/doc-site/src/content/docs/zh/guides/advanced/inbox.mdx
@@ -8,7 +8,7 @@ sidebar:
     variant: success
 ---
 
-import { Steps } from '@astrojs/starlight/components';
+import { Steps } from "@astrojs/starlight/components";
 
 **收件箱**功能允许外部服务、脚本或自动化工具通过 HTTP 主动将文章推送到 FeedCraft。每个收件箱都可以通过自定义配方生成 RSS 订阅地址，方便在任何 RSS 阅读器中订阅。
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 问题

`/zh/guides/advanced/inbox/`（以及 en / zh-tw 对应页面）显示异常：

- 页面顶部把 `import { Steps } from '@astrojs/starlight/components';` 当正文渲染
- `<Steps>` 未作为 Starlight 组件处理，步骤里的 Markdown（加粗、列表）保持源码形态

根因：Inbox 指南使用了 MDX 组件语法，但文件扩展名是 `.md`。Starlight 只在 `.mdx` 中解析 `import` 和 JSX 组件。

## 修复

- 将 `en` / `zh` / `zh-tw` 三份 Inbox 文档从 `.md` 改为 `.mdx`
- 为 `<Steps>` 内部有序列表补上 MDX 所需空行，确保编译为 `ol.sl-steps`
- 在 `doc-site/AGENTS.md` 中补充说明：使用 Starlight 组件的页面必须使用 `.mdx`

## 验证

本地 `pnpm run build` 后，三语页面均满足：

- 不再出现 `import { Steps }` 原文
- 不再出现未解析的 `<steps>` 标签
- 每页 3 组步骤渲染为 `ol.sl-steps`，内部加粗、嵌套列表和代码块正常

浏览器预览（`http://localhost:4321/zh/guides/advanced/inbox/`）已核对简体中文、英文、繁体中文三语页面。

[简体中文 Inbox 页顶部，无 import 泄漏](https://cursor.com/agents/bc-e66227a5-7fec-495f-9fb8-6c7c34ee0038/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Finbox_zh_page_top.webp)
[简体中文创建收件箱步骤列表](https://cursor.com/agents/bc-e66227a5-7fec-495f-9fb8-6c7c34ee0038/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Finbox_zh_create_steps.webp)
[英文 Creating an Inbox 步骤列表](https://cursor.com/agents/bc-e66227a5-7fec-495f-9fb8-6c7c34ee0038/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Finbox_en_create_steps.webp)
[繁体中文 Inbox 页](https://cursor.com/agents/bc-e66227a5-7fec-495f-9fb8-6c7c34ee0038/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Finbox_zh_tw_page.webp)
[inbox_docs_page_fixed.mp4](https://cursor.com/agents/bc-e66227a5-7fec-495f-9fb8-6c7c34ee0038/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Finbox_docs_page_fixed.mp4)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e66227a5-7fec-495f-9fb8-6c7c34ee0038?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e66227a5-7fec-495f-9fb8-6c7c34ee0038&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

## Summary by Sourcery

将多语言 Inbox 指南迁移至 MDX，恢复 Starlight 步骤组件的正确渲染。

Bug Fixes:
- 修复英文、简体中文和繁体中文 Inbox 指南中 Starlight `Steps` 组件未解析、导入语句泄漏为正文的问题。

Enhancements:
- 将三份 Inbox 指南转换为 MDX 并调整步骤内容格式，确保 Markdown 在步骤组件中正确渲染。

Documentation:
- 补充文档编写规范，明确使用 Starlight JSX 组件的页面必须采用 `.mdx` 扩展名。