### PR TITLE
fix(recipe): 重复配方名称返回 409 而非暴露 SQL 错误

### DIFF
--- a/internal/controller/custom_recipe.go
+++ b/internal/controller/custom_recipe.go
@@ -27,6 +27,10 @@ func CreateCustomRecipe(c *gin.Context) {
 	db := util.GetDatabase()
 
 	if err := dao.CreateCustomRecipeV2(db, &recipeData); err != nil {
+		if errors.Is(err, dao.ErrRecipeAlreadyExists) {
+			c.JSON(http.StatusConflict, util.APIResponse[any]{Msg: "A recipe with this name already exists. Please choose a different name."})
+			return
+		}
 		c.JSON(http.StatusInternalServerError, util.APIResponse[any]{Msg: err.Error()})
 		return
 	}

--- a/internal/controller/custom_recipe.go
+++ b/internal/controller/custom_recipe.go
@@ -12,6 +12,8 @@ import (
 	"time"
 )
 
+const msgRecipeNameExists = "A recipe with this name already exists. Please choose a different name."
+
 func CreateCustomRecipe(c *gin.Context) {
 	var recipeData dao.CustomRecipeV2
 	if err := c.ShouldBindJSON(&recipeData); err != nil {
@@ -28,7 +30,7 @@ func CreateCustomRecipe(c *gin.Context) {
 
 	if err := dao.CreateCustomRecipeV2(db, &recipeData); err != nil {
 		if errors.Is(err, dao.ErrRecipeAlreadyExists) {
-			c.JSON(http.StatusConflict, util.APIResponse[any]{Msg: "A recipe with this name already exists. Please choose a different name."})
+			c.JSON(http.StatusConflict, util.APIResponse[any]{Msg: msgRecipeNameExists})
 			return
 		}
 		c.JSON(http.StatusInternalServerError, util.APIResponse[any]{Msg: err.Error()})

--- a/internal/controller/custom_recipe_test.go
+++ b/internal/controller/custom_recipe_test.go
@@ -44,11 +44,10 @@ func TestCreateCustomRecipe_DuplicateIDReturnsConflictWithoutSQL(t *testing.T) {
 
 	var response util.APIResponse[any]
 	require.NoError(t, json.Unmarshal(second.Body.Bytes(), &response))
-	assert.NotEmpty(t, response.Msg)
+	assert.Equal(t, msgRecipeNameExists, response.Msg)
 	assert.NotContains(t, strings.ToLower(response.Msg), "unique constraint")
 	assert.NotContains(t, strings.ToLower(response.Msg), "sqlite")
 	assert.NotContains(t, response.Msg, "custom_recipes_v2")
-	assert.Contains(t, strings.ToLower(response.Msg), "already exists")
 }
 
 func TestCreateCustomRecipe_InvalidID(t *testing.T) {

--- a/internal/controller/custom_recipe_test.go
+++ b/internal/controller/custom_recipe_test.go
@@ -1,0 +1,93 @@
+package controller
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"FeedCraft/internal/dao"
+	"FeedCraft/internal/util"
+
+	"github.com/gin-gonic/gin"
+	"github.com/glebarez/sqlite"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+func TestCreateCustomRecipe_DuplicateIDReturnsConflictWithoutSQL(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	db := customRecipeTestDatabase(t)
+	require.NoError(t, db.AutoMigrate(&dao.CustomRecipeV2{}))
+
+	router := gin.New()
+	router.POST("/api/admin/recipes", CreateCustomRecipe)
+
+	payload := map[string]string{
+		"id":            "e2e-ai-recipe-887",
+		"description":   "first recipe",
+		"craft":         "fulltext",
+		"source_type":   "rss",
+		"source_config": `{"http_fetcher":{"url":"https://example.com/rss.xml"}}`,
+	}
+
+	first := postCustomRecipe(t, router, payload)
+	require.Equal(t, http.StatusCreated, first.Code, first.Body.String())
+
+	payload["description"] = "duplicate recipe"
+	second := postCustomRecipe(t, router, payload)
+
+	assert.Equal(t, http.StatusConflict, second.Code, second.Body.String())
+
+	var response util.APIResponse[any]
+	require.NoError(t, json.Unmarshal(second.Body.Bytes(), &response))
+	assert.NotEmpty(t, response.Msg)
+	assert.NotContains(t, strings.ToLower(response.Msg), "unique constraint")
+	assert.NotContains(t, strings.ToLower(response.Msg), "sqlite")
+	assert.NotContains(t, response.Msg, "custom_recipes_v2")
+	assert.Contains(t, strings.ToLower(response.Msg), "already exists")
+}
+
+func TestCreateCustomRecipe_InvalidID(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	db := customRecipeTestDatabase(t)
+	require.NoError(t, db.AutoMigrate(&dao.CustomRecipeV2{}))
+
+	router := gin.New()
+	router.POST("/api/admin/recipes", CreateCustomRecipe)
+
+	recorder := postCustomRecipe(t, router, map[string]string{
+		"id":            "Bad Name",
+		"craft":         "fulltext",
+		"source_type":   "rss",
+		"source_config": `{"http_fetcher":{"url":"https://example.com/rss.xml"}}`,
+	})
+
+	assert.Equal(t, http.StatusBadRequest, recorder.Code)
+	assertJSONMessageContains(t, recorder, "lowercase")
+}
+
+func customRecipeTestDatabase(t *testing.T) *gorm.DB {
+	t.Helper()
+
+	db, err := gorm.Open(sqlite.Open("file:"+t.Name()+"?mode=memory&cache=shared"), &gorm.Config{})
+	require.NoError(t, err)
+	util.SetDatabaseForTest(db)
+	return db
+}
+
+func postCustomRecipe(t *testing.T, router *gin.Engine, payload map[string]string) *httptest.ResponseRecorder {
+	t.Helper()
+
+	body, err := json.Marshal(payload)
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/admin/recipes", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	recorder := httptest.NewRecorder()
+	router.ServeHTTP(recorder, req)
+	return recorder
+}

--- a/internal/dao/errors.go
+++ b/internal/dao/errors.go
@@ -1,0 +1,25 @@
+package dao
+
+import (
+	"errors"
+	"strings"
+
+	"gorm.io/gorm"
+)
+
+// ErrRecipeAlreadyExists is returned when creating a recipe whose id is already taken.
+var ErrRecipeAlreadyExists = errors.New("a recipe with this name already exists")
+
+// IsUniqueConstraintError reports whether err is a SQL unique/primary-key conflict.
+func IsUniqueConstraintError(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, gorm.ErrDuplicatedKey) {
+		return true
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "unique constraint failed") ||
+		strings.Contains(msg, "duplicate key") ||
+		strings.Contains(msg, "duplicated key")
+}

--- a/internal/dao/recipe.go
+++ b/internal/dao/recipe.go
@@ -2,7 +2,6 @@ package dao
 
 import (
 	"database/sql"
-	"errors"
 	"time"
 
 	"gorm.io/gorm"
@@ -44,14 +43,6 @@ func CreateCustomRecipe(db *gorm.DB, recipe *CustomRecipe) error {
 
 // CreateCustomRecipeV2 creates a new CustomRecipeV2 record
 func CreateCustomRecipeV2(db *gorm.DB, recipe *CustomRecipeV2) error {
-	_, err := GetCustomRecipeByIDV2(db, recipe.ID)
-	if err == nil {
-		return ErrRecipeAlreadyExists
-	}
-	if !errors.Is(err, gorm.ErrRecordNotFound) {
-		return err
-	}
-
 	if err := db.Create(recipe).Error; err != nil {
 		if IsUniqueConstraintError(err) {
 			return ErrRecipeAlreadyExists

--- a/internal/dao/recipe.go
+++ b/internal/dao/recipe.go
@@ -2,8 +2,10 @@ package dao
 
 import (
 	"database/sql"
-	"gorm.io/gorm"
+	"errors"
 	"time"
+
+	"gorm.io/gorm"
 )
 
 type BaseModelWithoutPK struct {
@@ -42,7 +44,21 @@ func CreateCustomRecipe(db *gorm.DB, recipe *CustomRecipe) error {
 
 // CreateCustomRecipeV2 creates a new CustomRecipeV2 record
 func CreateCustomRecipeV2(db *gorm.DB, recipe *CustomRecipeV2) error {
-	return db.Create(recipe).Error
+	_, err := GetCustomRecipeByIDV2(db, recipe.ID)
+	if err == nil {
+		return ErrRecipeAlreadyExists
+	}
+	if !errors.Is(err, gorm.ErrRecordNotFound) {
+		return err
+	}
+
+	if err := db.Create(recipe).Error; err != nil {
+		if IsUniqueConstraintError(err) {
+			return ErrRecipeAlreadyExists
+		}
+		return err
+	}
+	return nil
 }
 
 // GetCustomRecipeByID retrieves a CustomRecipe record by its ID

--- a/internal/dao/recipe_create_test.go
+++ b/internal/dao/recipe_create_test.go
@@ -1,0 +1,38 @@
+package dao
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/glebarez/sqlite"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+func TestCreateCustomRecipeV2_DuplicateID(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open("file:"+t.Name()+"?mode=memory&cache=shared"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&CustomRecipeV2{}))
+
+	recipe := &CustomRecipeV2{
+		ID:           "e2e-ai-recipe-887",
+		Craft:        "fulltext",
+		SourceType:   "rss",
+		SourceConfig: `{"http_fetcher":{"url":"https://example.com/rss.xml"}}`,
+	}
+	require.NoError(t, CreateCustomRecipeV2(db, recipe))
+
+	duplicate := *recipe
+	err = CreateCustomRecipeV2(db, &duplicate)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrRecipeAlreadyExists))
+	assert.False(t, IsUniqueConstraintError(err), "typed sentinel should not leak SQL unique-constraint text")
+}
+
+func TestIsUniqueConstraintError(t *testing.T) {
+	assert.False(t, IsUniqueConstraintError(nil))
+	assert.False(t, IsUniqueConstraintError(errors.New("connection refused")))
+	assert.True(t, IsUniqueConstraintError(gorm.ErrDuplicatedKey))
+	assert.True(t, IsUniqueConstraintError(errors.New("constraint failed: UNIQUE constraint failed: custom_recipes_v2.id (1555)")))
+}

--- a/web/admin/src/views/dashboard/custom_recipe/custom_recipe.vue
+++ b/web/admin/src/views/dashboard/custom_recipe/custom_recipe.vue
@@ -503,8 +503,8 @@
       selectedRecipe.value = null;
       quickCreate.value = false;
       rssUrl.value = '';
-    } catch (e) {
-      Message.error(t('customRecipe.form.error.saveFailed'));
+    } catch {
+      // Axios interceptor already displays the API error toast.
     } finally {
       saving.value = false;
     }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
对应 Linear issue [COL-25](https://linear.app/colin-x-studio/issue/COL-25/保存自定义配方时重复-id-返回-500-toast-暴露原始-sql-错误unique-constraint-failed)。

## 问题

保存自定义配方时，如果名称（id）已存在，`POST /api/admin/recipes` 会返回 HTTP 500，响应体直接透传 SQLite 原始错误：

```
constraint failed: UNIQUE constraint failed: custom_recipes_v2.id (1555)
```

前端 Toast 会把这段内部 SQL 展示给用户。

## 修复

- DAO 把 UNIQUE / 主键冲突映射为 `ErrRecipeAlreadyExists`，不再把 SQL 错误交给 controller
- Controller 返回 **409 Conflict** 与可读提示：`A recipe with this name already exists. Please choose a different name.`
- 自定义配方页去掉重复的「保存失败」Toast（axios 拦截器已经会展示后端 `msg`）

## 测试

- `TestCreateCustomRecipe_DuplicateIDReturnsConflictWithoutSQL`：重复保存返回 409，且 `msg` 不含 `UNIQUE constraint` / 表名
- `TestCreateCustomRecipeV2_DuplicateID`：DAO 层返回 typed sentinel error
- `go test ./...` 通过
- `golangci-lint`（改动包）0 issues
- `task backend-build` 通过

`task fix` / `task frontend-build` 失败原因是仓库里已有的前端工具链问题（vitest `import/no-unresolved`、`tsconfig` 的 `resolveJsonModule`），不是这次改动引入的。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4ced4bab-9b7a-4f13-9b40-6ec52d165116?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4ced4bab-9b7a-4f13-9b40-6ec52d165116&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

## Summary by Sourcery

Handle duplicate custom recipe names as a safe, user-facing conflict rather than an internal server error.

Bug Fixes:
- Return HTTP 409 Conflict with a user-friendly message when creating a custom recipe with a duplicate name instead of exposing the database error.
- Prevent duplicate save failures from generating a redundant frontend error toast.

Enhancements:
- Normalize unique and primary-key conflicts into a typed DAO error for safe handling by higher layers.

Tests:
- Add DAO and controller coverage for duplicate recipe handling and protection against leaking SQL or table details.