### PR TITLE
fix(admin): 修复全部 Craft 列表名称列英文中途折行

### DIFF
--- a/web/admin/src/views/dashboard/all_craft_list/all_craft_list.columns.test.ts
+++ b/web/admin/src/views/dashboard/all_craft_list/all_craft_list.columns.test.ts
@@ -12,8 +12,9 @@ describe('all craft list table columns', () => {
       (column) => column.dataIndex === 'name'
     );
 
-    expect(name?.width).toBeGreaterThanOrEqual(240);
+    expect(name?.width).toBeGreaterThanOrEqual(320);
     expect(name?.ellipsis).toBe(true);
+    expect(name?.bodyCellClass).toBe('all-craft-id-cell');
   });
 
   it('keeps type identifiers like @sys/atom from wrapping mid-token', () => {
@@ -23,6 +24,7 @@ describe('all craft list table columns', () => {
 
     expect(type?.width).toBeGreaterThanOrEqual(120);
     expect(type?.ellipsis).toBe(true);
+    expect(type?.bodyCellClass).toBe('all-craft-id-cell');
   });
 
   it('enables horizontal scroll so fixed identifier columns are not crushed', () => {

--- a/web/admin/src/views/dashboard/all_craft_list/all_craft_list.columns.test.ts
+++ b/web/admin/src/views/dashboard/all_craft_list/all_craft_list.columns.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import {
+  ALL_CRAFT_LIST_SCROLL_X,
+  getAllCraftListColumns,
+} from './all_craft_list.columns';
+
+const t = (key: string) => key;
+
+describe('all craft list table columns', () => {
+  it('reserves enough width so long English craft names stay on one line', () => {
+    const name = getAllCraftListColumns(t).find(
+      (column) => column.dataIndex === 'name'
+    );
+
+    expect(name?.width).toBeGreaterThanOrEqual(240);
+    expect(name?.ellipsis).toBe(true);
+  });
+
+  it('keeps type identifiers like @sys/atom from wrapping mid-token', () => {
+    const type = getAllCraftListColumns(t).find(
+      (column) => column.dataIndex === 'type'
+    );
+
+    expect(type?.width).toBeGreaterThanOrEqual(120);
+    expect(type?.ellipsis).toBe(true);
+  });
+
+  it('enables horizontal scroll so fixed identifier columns are not crushed', () => {
+    expect(ALL_CRAFT_LIST_SCROLL_X).toBeGreaterThanOrEqual(800);
+  });
+});

--- a/web/admin/src/views/dashboard/all_craft_list/all_craft_list.columns.ts
+++ b/web/admin/src/views/dashboard/all_craft_list/all_craft_list.columns.ts
@@ -1,0 +1,29 @@
+export const ALL_CRAFT_LIST_SCROLL_X = 900;
+
+export function getAllCraftListColumns(t: (key: string) => string) {
+  return [
+    {
+      title: t('allCraftList.table.name'),
+      dataIndex: 'name',
+      width: 280,
+      ellipsis: true,
+      tooltip: true,
+    },
+    {
+      title: t('allCraftList.table.type'),
+      dataIndex: 'type',
+      width: 140,
+      ellipsis: true,
+      tooltip: true,
+    },
+    {
+      title: t('allCraftList.table.templateOnly'),
+      dataIndex: 'template_only',
+      width: 120,
+    },
+    {
+      title: t('allCraftList.table.description'),
+      dataIndex: 'description',
+    },
+  ];
+}

--- a/web/admin/src/views/dashboard/all_craft_list/all_craft_list.columns.ts
+++ b/web/admin/src/views/dashboard/all_craft_list/all_craft_list.columns.ts
@@ -1,13 +1,15 @@
-export const ALL_CRAFT_LIST_SCROLL_X = 900;
+export const ALL_CRAFT_LIST_SCROLL_X = 1000;
+export const ALL_CRAFT_ID_CELL_CLASS = 'all-craft-id-cell';
 
 export function getAllCraftListColumns(t: (key: string) => string) {
   return [
     {
       title: t('allCraftList.table.name'),
       dataIndex: 'name',
-      width: 280,
+      width: 360,
       ellipsis: true,
       tooltip: true,
+      bodyCellClass: ALL_CRAFT_ID_CELL_CLASS,
     },
     {
       title: t('allCraftList.table.type'),
@@ -15,6 +17,7 @@ export function getAllCraftListColumns(t: (key: string) => string) {
       width: 140,
       ellipsis: true,
       tooltip: true,
+      bodyCellClass: ALL_CRAFT_ID_CELL_CLASS,
     },
     {
       title: t('allCraftList.table.templateOnly'),
@@ -24,6 +27,7 @@ export function getAllCraftListColumns(t: (key: string) => string) {
     {
       title: t('allCraftList.table.description'),
       dataIndex: 'description',
+      bodyCellClass: 'all-craft-desc-cell',
     },
   ];
 }

--- a/web/admin/src/views/dashboard/all_craft_list/all_craft_list.vue
+++ b/web/admin/src/views/dashboard/all_craft_list/all_craft_list.vue
@@ -12,9 +12,11 @@
     </a-space>
 
     <a-table
+      class="all-craft-list-table"
       :data="allCrafts"
       :columns="columns"
       :loading="isLoading"
+      :scroll="{ x: ALL_CRAFT_LIST_SCROLL_X }"
     ></a-table>
   </div>
 </template>
@@ -25,6 +27,10 @@
   import { Message } from '@arco-design/web-vue';
   import axios from 'axios';
   import { useI18n } from 'vue-i18n';
+  import {
+    ALL_CRAFT_LIST_SCROLL_X,
+    getAllCraftListColumns,
+  } from './all_craft_list.columns';
 
   const { t } = useI18n();
 
@@ -37,13 +43,7 @@
 
   const isLoading = ref(false);
   const allCrafts = ref<CraftItem[]>([]);
-
-  const columns = [
-    { title: t('allCraftList.table.name'), dataIndex: 'name' },
-    { title: t('allCraftList.table.type'), dataIndex: 'type' },
-    { title: t('allCraftList.table.templateOnly'), dataIndex: 'template_only' },
-    { title: t('allCraftList.table.description'), dataIndex: 'description' },
-  ];
+  const columns = getAllCraftListColumns(t);
 
   const listAllCrafts = async () => {
     isLoading.value = true;
@@ -62,4 +62,12 @@
   });
 </script>
 
-<style scoped></style>
+<style scoped>
+  /* Arco Table defaults to word-break: break-all, which splits English
+     identifiers mid-token when a column is squeezed. Prefer wrapping at
+     word/hyphen boundaries; identifier columns also use nowrap+ellipsis. */
+  .all-craft-list-table :deep(.arco-table-td) {
+    word-break: normal;
+    overflow-wrap: break-word;
+  }
+</style>

--- a/web/admin/src/views/dashboard/all_craft_list/all_craft_list.vue
+++ b/web/admin/src/views/dashboard/all_craft_list/all_craft_list.vue
@@ -63,11 +63,23 @@
 </script>
 
 <style scoped>
-  /* Arco Table defaults to word-break: break-all, which splits English
-     identifiers mid-token when a column is squeezed. Prefer wrapping at
-     word/hyphen boundaries; identifier columns also use nowrap+ellipsis. */
+  /* Arco Table defaults to word-break: break-all. Identifier columns must
+     stay on one line; description may wrap at word/hyphen boundaries. */
   .all-craft-list-table :deep(.arco-table-td) {
     word-break: normal;
+  }
+
+  .all-craft-list-table :deep(.all-craft-id-cell),
+  .all-craft-list-table :deep(.all-craft-id-cell .arco-table-td-content),
+  .all-craft-list-table :deep(.all-craft-id-cell .arco-auto-tooltip-content) {
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    word-break: keep-all;
+    overflow-wrap: normal;
+  }
+
+  .all-craft-list-table :deep(.all-craft-desc-cell) {
     overflow-wrap: break-word;
   }
 </style>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes [COL-18](https://linear.app/colin-x-studio/issue/COL-18/全部-craft-列表表格名称列宽不足长英文名折行断裂)

Related: [COL-19](https://linear.app/colin-x-studio/issue/COL-19/全部-craft-列表表格类型列折行断裂sysatom-断成-sysat-om)

## 问题

`/dashboard/all_craft_list` 表格「名称」列过窄，长英文 craft 名被 Arco Table 默认的 `word-break: break-all` 从单词中间切断，例如：

- `beautify-content` → `beautify-conte` / `nt`
- `relative-link-fix` → `relative-li` / `nk-fix`
- `translate-content-immersive` 末尾字母掉到下一行

同一张表的「类型」列 `@sys/atom` 也有同类问题（COL-19）。

## 改动

- 名称列 360px、类型列 140px，标识列强制 `nowrap` + ellipsis + tooltip
- 覆盖 Arco 默认 `word-break: break-all`；描述列仍可按词边界换行
- 表格 `scroll.x = 1000`，窄视口横向滚动而不压缩标识列
- 抽出列配置并补充 vitest 断言，防止标识列宽度回退

## 验证

- `pnpm test`：22 passed
- `task frontend-build`：通过
- 浏览器登录后遍历全部 Craft 列表 3 页，确认 `translate-content-immersive`、`ignore-advertorial`、`beautify-content`、`relative-link-fix` 以及 `@sys/atom` 均为单行

[修复后名称列单行显示](https://cursor.com/agents/bc-6c0e11d7-4387-4763-800b-9272ebf941f1/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcol18_name_column_after_translate_content_immersive.webp)
[col18_craft_list_names_single_line_after_fix.mp4](https://cursor.com/agents/bc-6c0e11d7-4387-4763-800b-9272ebf941f1/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcol18_craft_list_names_single_line_after_fix.mp4)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6c0e11d7-4387-4763-800b-9272ebf941f1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6c0e11d7-4387-4763-800b-9272ebf941f1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

## Summary by Sourcery

Keep Craft list identifiers readable by preventing mid-word wrapping and preserving usable column widths on narrow screens.

Bug Fixes:
- Prevent long Craft names and type identifiers from breaking mid-token in the all-Craft list table.

Enhancements:
- Improve identifier column readability with dedicated widths, single-line ellipsis, tooltips, and horizontal scrolling while preserving natural wrapping for descriptions.
- Extract all-Craft table column configuration into a reusable module.

Tests:
- Add Vitest coverage for identifier column sizing, ellipsis behavior, and horizontal scroll requirements.