### PR TITLE
fix(admin): 自定义配方空表单保存前校验 (COL-27)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/gin-contrib/cors v1.7.5
 	github.com/gin-gonic/gin v1.10.0
 	github.com/glebarez/sqlite v1.11.0
+	github.com/go-playground/validator/v10 v10.26.0
 	github.com/go-resty/resty/v2 v2.16.5
 	github.com/go-shiori/go-readability v0.0.0-20240204090920-819593fddc6b
 	github.com/golang-jwt/jwt/v5 v5.2.2
@@ -58,7 +59,6 @@ require (
 	github.com/go-json-experiment/json v0.0.0-20250725192818-e39067aee2d2 // indirect
 	github.com/go-playground/locales v0.14.1 // indirect
 	github.com/go-playground/universal-translator v0.18.1 // indirect
-	github.com/go-playground/validator/v10 v10.26.0 // indirect
 	github.com/go-shiori/dom v0.0.0-20230515143342-73569d674e1c // indirect
 	github.com/go-viper/mapstructure/v2 v2.4.0 // indirect
 	github.com/gobwas/httphead v0.1.0 // indirect

--- a/internal/controller/custom_recipe.go
+++ b/internal/controller/custom_recipe.go
@@ -15,7 +15,7 @@ import (
 func CreateCustomRecipe(c *gin.Context) {
 	var recipeData dao.CustomRecipeV2
 	if err := c.ShouldBindJSON(&recipeData); err != nil {
-		c.JSON(http.StatusBadRequest, util.APIResponse[any]{Msg: err.Error()})
+		c.JSON(http.StatusBadRequest, util.APIResponse[any]{Msg: util.FriendlyJSONBindError(err)})
 		return
 	}
 
@@ -89,7 +89,7 @@ func UpdateCustomRecipe(c *gin.Context) {
 	id := c.Param("id")
 	var recipeData dao.CustomRecipeV2
 	if err := c.ShouldBindJSON(&recipeData); err != nil {
-		c.JSON(http.StatusBadRequest, util.APIResponse[any]{Msg: err.Error()})
+		c.JSON(http.StatusBadRequest, util.APIResponse[any]{Msg: util.FriendlyJSONBindError(err)})
 		return
 	}
 	db := util.GetDatabase()

--- a/internal/controller/custom_recipe_test.go
+++ b/internal/controller/custom_recipe_test.go
@@ -1,0 +1,56 @@
+package controller
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"FeedCraft/internal/dao"
+	"FeedCraft/internal/util"
+
+	"github.com/gin-gonic/gin"
+	"github.com/glebarez/sqlite"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+func setupCustomRecipeTestRouter(t *testing.T) *gin.Engine {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open("file:custom_recipe_test?mode=memory&cache=shared"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&dao.CustomRecipeV2{}))
+	util.SetDatabaseForTest(db)
+
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	router.POST("/recipes", CreateCustomRecipe)
+	return router
+}
+
+func TestCreateCustomRecipeRejectsEmptyRequiredFields(t *testing.T) {
+	router := setupCustomRecipeTestRouter(t)
+
+	body, err := json.Marshal(map[string]string{
+		"id":            "",
+		"craft":         "",
+		"source_type":   "rss",
+		"source_config": `{"http_fetcher":{"url":"https://example.com/rss.xml"}}`,
+	})
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodPost, "/recipes", bytes.NewBuffer(body))
+	req.Header.Set("Content-Type", "application/json")
+	recorder := httptest.NewRecorder()
+	router.ServeHTTP(recorder, req)
+
+	require.Equal(t, http.StatusBadRequest, recorder.Code)
+
+	var resp util.APIResponse[any]
+	require.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &resp))
+	require.Contains(t, resp.Msg, "name is required")
+	require.Contains(t, resp.Msg, "craft is required")
+	require.NotContains(t, resp.Msg, "Field validation")
+	require.NotContains(t, resp.Msg, "CustomRecipeV2")
+}

--- a/internal/util/bind_error.go
+++ b/internal/util/bind_error.go
@@ -1,0 +1,52 @@
+package util
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/go-playground/validator/v10"
+)
+
+// FriendlyJSONBindError converts gin/validator bind failures into a short
+// user-facing message, without leaking struct names or validator tag dumps.
+func FriendlyJSONBindError(err error) string {
+	if err == nil {
+		return "invalid request body"
+	}
+	var verrs validator.ValidationErrors
+	if errors.As(err, &verrs) {
+		msgs := make([]string, 0, len(verrs))
+		for _, fe := range verrs {
+			msgs = append(msgs, friendlyValidationMessage(fe))
+		}
+		if len(msgs) > 0 {
+			return strings.Join(msgs, "; ")
+		}
+	}
+	return "invalid request body"
+}
+
+func friendlyValidationMessage(fe validator.FieldError) string {
+	field := friendlyFieldName(fe.Field())
+	switch fe.Tag() {
+	case "required":
+		return fmt.Sprintf("%s is required", field)
+	default:
+		return fmt.Sprintf("%s is invalid", field)
+	}
+}
+
+func friendlyFieldName(field string) string {
+	switch field {
+	case "ID":
+		return "name"
+	case "Craft":
+		return "craft"
+	default:
+		if field == "" {
+			return "field"
+		}
+		return strings.ToLower(field)
+	}
+}

--- a/internal/util/bind_error_test.go
+++ b/internal/util/bind_error_test.go
@@ -1,0 +1,34 @@
+package util
+
+import (
+	"testing"
+
+	"github.com/go-playground/validator/v10"
+	"github.com/stretchr/testify/require"
+)
+
+type bindSample struct {
+	ID    string `validate:"required"`
+	Craft string `validate:"required"`
+}
+
+func TestFriendlyJSONBindErrorRequiredFields(t *testing.T) {
+	validate := validator.New()
+	err := validate.Struct(bindSample{})
+	require.Error(t, err)
+
+	msg := FriendlyJSONBindError(err)
+	require.Contains(t, msg, "name is required")
+	require.Contains(t, msg, "craft is required")
+	require.NotContains(t, msg, "CustomRecipeV2")
+	require.NotContains(t, msg, "Field validation")
+}
+
+func TestFriendlyJSONBindErrorNonValidator(t *testing.T) {
+	require.Equal(t, "invalid request body", FriendlyJSONBindError(nil))
+	require.Equal(t, "invalid request body", FriendlyJSONBindError(assertErr("syntax")))
+}
+
+type assertErr string
+
+func (e assertErr) Error() string { return string(e) }

--- a/web/admin/src/utils/validator.test.ts
+++ b/web/admin/src/utils/validator.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { namingValidator } from '@/utils/validator';
+
+describe('namingValidator', () => {
+  it('skips empty values so required rules can own that case', () => {
+    let called: string | undefined = 'unset';
+    namingValidator.validator('', (err) => {
+      called = err;
+    });
+    expect(called).toBeUndefined();
+  });
+
+  it('rejects uppercase and other invalid characters', () => {
+    let message: string | undefined;
+    namingValidator.validator('Bad Name', (err) => {
+      message = err;
+    });
+    expect(message).toMatch(/lowercase letters/);
+  });
+
+  it('accepts lowercase ids', () => {
+    let called = false;
+    namingValidator.validator('e2e-ai-recipe-887', (err) => {
+      called = true;
+      expect(err).toBeUndefined();
+    });
+    expect(called).toBe(true);
+  });
+});

--- a/web/admin/src/utils/validator.ts
+++ b/web/admin/src/utils/validator.ts
@@ -1,6 +1,10 @@
 // eslint-disable-next-line import/prefer-default-export
 export const namingValidator = {
   validator: (value: string, cb: (err?: string) => void) => {
+    if (!value) {
+      cb();
+      return;
+    }
     const regex = /^[a-z0-9-_]+$/;
     if (!regex.test(value)) {
       cb(

--- a/web/admin/src/views/dashboard/custom_recipe/custom_recipe.vue
+++ b/web/admin/src/views/dashboard/custom_recipe/custom_recipe.vue
@@ -136,6 +136,7 @@
       "
     >
       <a-form
+        ref="formRef"
         :model="form"
         :label-col="{ span: 6 }"
         :rules="rules"
@@ -150,7 +151,11 @@
         >
           <a-input v-model="form.description" />
         </a-form-item>
-        <a-form-item :label="t('customRecipe.form.craft')" field="craft">
+        <a-form-item
+          :label="t('customRecipe.form.craft')"
+          field="craft"
+          :validate-trigger="['change', 'blur']"
+        >
           <CraftSelector
             v-model="craftList"
             mode="multiple"
@@ -160,18 +165,9 @@
 
         <!-- Quick Create Fields -->
         <template v-if="quickCreate">
-          <a-form-item
-            :label="t('customRecipe.form.feedURL')"
-            field="feed_url"
-            :rules="[
-              {
-                required: true,
-                message: t('customRecipe.form.rule.rssUrlRequired'),
-              },
-            ]"
-          >
+          <a-form-item :label="t('customRecipe.form.feedURL')" field="feed_url">
             <a-input
-              v-model="rssUrl"
+              v-model="form.feed_url"
               :placeholder="t('customRecipe.form.placeholder.rssUrl')"
             />
           </a-form-item>
@@ -255,6 +251,7 @@
 
 <script setup lang="ts">
   import { ref, onMounted, computed } from 'vue';
+  import type { FormInstance } from '@arco-design/web-vue';
   import {
     createCustomRecipe,
     CustomRecipe,
@@ -276,21 +273,26 @@
   const { t } = useI18n();
   const router = useRouter();
 
+  type RecipeForm = CustomRecipe & { feed_url: string };
+
+  const emptyForm = (): RecipeForm => ({
+    id: '',
+    description: '',
+    craft: '',
+    source_type: 'rss',
+    source_config: '',
+    feed_url: '',
+  });
+
   const recipes = ref<CustomRecipe[]>([]);
   const showModal = ref(false);
   const showConfigModal = ref(false);
   const currentConfig = ref('');
   const currentLink = ref('');
   const quickCreate = ref(false);
-  const rssUrl = ref('');
+  const formRef = ref<FormInstance>();
 
-  const form = ref<CustomRecipe>({
-    id: '',
-    description: '',
-    craft: '',
-    source_type: 'rss',
-    source_config: '',
-  });
+  const form = ref<RecipeForm>(emptyForm());
 
   const craftList = computed({
     get: () =>
@@ -374,37 +376,54 @@
   onMounted(() => {
     listCustomRecipes();
   });
-  const rules = {
-    id: [
-      {
-        required: true,
-        message: t('customRecipe.form.rule.nameRequired'),
-        trigger: 'blur',
-      },
-      namingValidator,
-    ],
-    craft: [
-      {
-        required: true,
-        message: t('customRecipe.form.rule.craftRequired'),
-        trigger: 'blur',
-      },
-    ],
-    source_type: [
-      {
-        required: true,
-        message: t('customRecipe.form.rule.sourceTypeRequired'),
-        trigger: 'change',
-      },
-    ],
-    source_config: [
-      {
-        required: true,
-        message: t('customRecipe.form.rule.sourceConfigRequired'),
-        trigger: 'blur',
-      },
-    ],
-  };
+  const rules = computed(() => {
+    const requiredNameAndCraft = {
+      id: [
+        {
+          required: true,
+          message: t('customRecipe.form.rule.nameRequired'),
+          trigger: ['blur', 'input'],
+        },
+        namingValidator,
+      ],
+      craft: [
+        {
+          required: true,
+          message: t('customRecipe.form.rule.craftRequired'),
+          trigger: ['change', 'blur'],
+        },
+      ],
+    };
+    if (quickCreate.value) {
+      return {
+        ...requiredNameAndCraft,
+        feed_url: [
+          {
+            required: true,
+            message: t('customRecipe.form.rule.rssUrlRequired'),
+            trigger: ['blur', 'input'],
+          },
+        ],
+      };
+    }
+    return {
+      ...requiredNameAndCraft,
+      source_type: [
+        {
+          required: true,
+          message: t('customRecipe.form.rule.sourceTypeRequired'),
+          trigger: 'change',
+        },
+      ],
+      source_config: [
+        {
+          required: true,
+          message: t('customRecipe.form.rule.sourceConfigRequired'),
+          trigger: 'blur',
+        },
+      ],
+    };
+  });
 
   const humanReadableConfig = (configStr: string) => {
     try {
@@ -452,22 +471,34 @@
       craft: recipe.craft,
       source_type: recipe.source_type,
       source_config: prettyConfig,
+      feed_url: '',
     };
     showModal.value = true;
   };
 
+  const toRecipePayload = (): CustomRecipe => ({
+    id: form.value.id,
+    description: form.value.description,
+    craft: form.value.craft,
+    source_type: form.value.source_type,
+    source_config: form.value.source_config,
+  });
+
   const saveRecipe = async () => {
+    const errors = await formRef.value?.validate();
+    if (errors) {
+      return;
+    }
+
     if (quickCreate.value && !editing.value) {
-      // Construct JSON for Quick Create
       const config = {
         http_fetcher: {
-          url: rssUrl.value,
+          url: form.value.feed_url,
         },
       };
       form.value.source_config = JSON.stringify(config);
       form.value.source_type = 'rss';
     } else {
-      // Validate JSON before saving in Advanced mode
       try {
         JSON.parse(form.value.source_config);
       } catch (e) {
@@ -478,33 +509,27 @@
 
     saving.value = true;
     try {
+      const payload = toRecipePayload();
       if (editing.value) {
         if (selectedRecipe.value) {
-          await updateCustomRecipe(form.value);
-          selectedRecipe.value.description = form.value.description;
-          selectedRecipe.value.craft = form.value.craft;
-          selectedRecipe.value.source_type = form.value.source_type;
-          selectedRecipe.value.source_config = form.value.source_config;
+          await updateCustomRecipe(payload);
+          selectedRecipe.value.description = payload.description;
+          selectedRecipe.value.craft = payload.craft;
+          selectedRecipe.value.source_type = payload.source_type;
+          selectedRecipe.value.source_config = payload.source_config;
         }
       } else {
-        await createCustomRecipe(form.value as CustomRecipe);
+        await createCustomRecipe(payload);
         await listCustomRecipes();
       }
       showModal.value = false;
-      form.value = {
-        id: '',
-        description: '',
-        craft: '',
-        source_type: 'rss',
-        source_config: '',
-      };
+      form.value = emptyForm();
       editing.value = false;
       isUpdating.value = false;
       selectedRecipe.value = null;
       quickCreate.value = false;
-      rssUrl.value = '';
-    } catch (e) {
-      Message.error(t('customRecipe.form.error.saveFailed'));
+    } catch {
+      // Axios interceptor already shows the API error toast.
     } finally {
       saving.value = false;
     }
@@ -523,15 +548,9 @@
   };
 
   function resetForm() {
-    form.value = {
-      id: '',
-      description: '',
-      craft: '',
-      source_type: 'rss',
-      source_config: '',
-    };
+    form.value = emptyForm();
     quickCreate.value = false;
-    rssUrl.value = '';
+    formRef.value?.clearValidate();
   }
 </script>
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 背景

Linear [COL-27](https://linear.app/colin-x-studio/issue/COL-27/自定义配方弹窗必填校验缺失空表单提交后-toast-暴露后端-validator-原始错误field-validation-for)：工作台 → 自定义配方 → 快速创建 (RSS) 在名称/工艺为空时直接点保存，前端不拦截，Toast 会展示 gin validator 原文：

`Key: 'CustomRecipeV2.ID' Error:Field validation for 'ID' failed...`

## 根因

表单虽定义了 `rules`，但自定义 footer 的「保存」没有调用 `form.validate()`（与原子工艺/流程页不一致）。请求会打到 `POST /api/admin/recipes`，`ShouldBindJSON` 失败后把 `err.Error()` 原样返回。

## 改动

- 自定义配方弹窗保存前调用 Arco `validate()`，快速创建场景同时校验 RSS URL
- 空名称不再误触发 `namingValidator` 的英文格式错误
- 后端绑定失败改为可读提示（`name is required; craft is required`），不再返回 validator dump

## 验证

- `go test ./...` 通过
- Admin 手动复现：空表单保存出现「名称必填 / 工艺必填 / RSS URL 必填」，Network 无 `POST /api/admin/recipes`
- 填写有效数据后可成功保存

## 关联

- Linear: COL-27
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a6587120-db77-43c3-9abe-0f79098eecd5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a6587120-db77-43c3-9abe-0f79098eecd5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

## Summary by Sourcery

Add client- and server-side validation to provide clear feedback when saving incomplete custom recipes.

Bug Fixes:
- Prevent custom recipe submissions with missing required fields from reaching the API, including RSS URL validation during quick creation.
- Replace raw Gin validator errors with concise, user-facing validation messages for custom recipe create and update requests.
- Ensure empty recipe names are handled by required-field validation instead of triggering naming-format errors.

Enhancements:
- Align custom recipe form validation and payload handling across quick-create and advanced editing flows.

Build:
- Promote the validator dependency to a direct Go module dependency.

Tests:
- Add backend tests for friendly validation messages and rejection of empty required recipe fields.
- Add frontend tests covering empty, invalid, and valid recipe names.