### PR TITLE
fix(admin): 修复自定义配方表格单元格英文逐字竖排

### DIFF
--- a/web/admin/src/views/dashboard/custom_recipe/custom_recipe.vue
+++ b/web/admin/src/views/dashboard/custom_recipe/custom_recipe.vue
@@ -38,10 +38,13 @@
     </a-space>
 
     <a-table
+      class="custom-recipe-table"
       :data="recipes"
       :columns="columns"
       :bordered="true"
       :loading="isLoading"
+      :scroll="{ x: 1180 }"
+      column-resizable
     >
       <template #status="{ record }">
         <a-tooltip
@@ -352,17 +355,49 @@
   const saving = ref(false);
 
   const columns = [
-    { title: t('customRecipe.form.name'), dataIndex: 'id' },
-    { title: t('customRecipe.form.description'), dataIndex: 'description' },
-    { title: t('customRecipe.form.craft'), dataIndex: 'craft' },
-    { title: t('customRecipe.status.active'), slotName: 'status' },
-    { title: t('customRecipe.form.sourceType'), dataIndex: 'source_type' },
+    {
+      title: t('customRecipe.form.name'),
+      dataIndex: 'id',
+      width: 200,
+      ellipsis: true,
+      tooltip: true,
+    },
+    {
+      title: t('customRecipe.form.description'),
+      dataIndex: 'description',
+      width: 180,
+      ellipsis: true,
+      tooltip: true,
+    },
+    {
+      title: t('customRecipe.form.craft'),
+      dataIndex: 'craft',
+      width: 220,
+      ellipsis: true,
+      tooltip: true,
+    },
+    {
+      title: t('customRecipe.status.active'),
+      slotName: 'status',
+      width: 90,
+    },
+    {
+      title: t('customRecipe.form.sourceType'),
+      dataIndex: 'source_type',
+      width: 100,
+    },
     {
       title: t('customRecipe.form.sourceConfig'),
       dataIndex: 'source_config',
       slotName: 'source_config',
+      width: 220,
     },
-    { title: t('customRecipe.actions'), slotName: 'actions' },
+    {
+      title: t('customRecipe.actions'),
+      slotName: 'actions',
+      width: 240,
+      fixed: 'right',
+    },
   ];
 
   async function listCustomRecipes() {
@@ -535,4 +570,23 @@
   }
 </script>
 
-<style scoped></style>
+<style scoped lang="less">
+  .custom-recipe-table {
+    :deep(.arco-table-td) {
+      word-break: break-word;
+      overflow-wrap: anywhere;
+    }
+
+    :deep(.arco-table-cell) {
+      min-width: 0;
+    }
+
+    :deep(.arco-table-cell-text-ellipsis),
+    :deep(.arco-table-text-ellipsis) {
+      overflow: hidden;
+      white-space: nowrap;
+      text-overflow: ellipsis;
+      word-break: normal;
+    }
+  }
+</style>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 背景

Linear [COL-26](https://linear.app/colin-x-studio/issue/COL-26)：工作台「自定义配方」列表在窄视口下，名称/描述/工艺列会被压到约单字符宽度，`e2e-ai-recipe-887` 显示成逐字竖排，无法阅读。

已在当前 `dev` 上复现：Arco Table 默认 `word-break: break-all`，该页 7 列未设宽度/`scroll`，窄屏时单元格被压缩。宽屏时横向显示正常。

## 改动

- 为各列设置宽度，名称/描述/工艺启用 ellipsis + tooltip
- 表格 `scroll.x` 避免列被压到单字符宽
- 覆盖单元格换行策略为 `break-word`，省略号列保持 `nowrap`

## 验证

- 登录 admin 后台，工作台 → 自定义配方
- 创建名称 `e2e-ai-recipe-887`、工艺 `fulltext,introduction` 的 RSS 配方
- 在约 1100px 及更窄视口下，名称/工艺横向可读，不再逐字竖排

修复前（逐字竖排）：
[修复前名称工艺竖排](https://cursor.com/agents/bc-92dbc6bb-96c6-44bb-ae83-3000f83bbae9/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcol-26-before-vertical-stack.webp)

修复后（横向可读）：
[修复后表格横向显示](https://cursor.com/agents/bc-92dbc6bb-96c6-44bb-ae83-3000f83bbae9/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcol-26-after-1280.webp)
[1100px 设备模式下横向可读](https://cursor.com/agents/bc-92dbc6bb-96c6-44bb-ae83-3000f83bbae9/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcol-26-after-device-1100.webp)

演示：
[col-26-recipe-table-fix-demo.mp4](https://cursor.com/agents/bc-92dbc6bb-96c6-44bb-ae83-3000f83bbae9/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcol-26-recipe-table-fix-demo.mp4)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-92dbc6bb-96c6-44bb-ae83-3000f83bbae9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-92dbc6bb-96c6-44bb-ae83-3000f83bbae9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

## Summary by Sourcery

Fix narrow-screen custom recipe table readability by preserving usable column widths and applying appropriate text wrapping and truncation.

Bug Fixes:
- Prevent custom recipe table content from collapsing into one-character vertical text on narrow viewports.
- Keep long recipe names, descriptions, and craft values readable with truncation and tooltips.

Enhancements:
- Improve custom recipe table layout with defined column sizing, horizontal scrolling, and a fixed actions column.