### PR TITLE
fix(admin): 恢复 /tools/feed_compare 兼容路由（COL-23）

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -74,7 +74,8 @@ http://localhost:5173
 Useful routes:
 
 - AtomCraft management: `http://localhost:5173/worktable/craft_atom`
-- Feed Compare: `http://localhost:5173/tools/feed_compare`
+- RSS Viewer: `http://localhost:5173/tools/viewer`
+- Feed Compare (legacy URL, opens RSS Viewer compare mode): `http://localhost:5173/tools/feed_compare`
 
 ## Mocking LLM and Feeds for Manual Testing
 

--- a/web/admin/src/router/routes/modules/tools.ts
+++ b/web/admin/src/router/routes/modules/tools.ts
@@ -22,6 +22,17 @@ const TOOLS: AppRouteRecordRaw = {
       },
     },
     {
+      path: 'feed_compare',
+      name: 'FeedCompare',
+      component: () => import('@/views/dashboard/feed_viewer/feed_viewer.vue'),
+      meta: {
+        locale: 'menu.feedViewer',
+        requiresAuth: false,
+        hideInMenu: true,
+        activeMenu: 'FeedViewer',
+      },
+    },
+    {
       path: 'example_rss_feeds',
       name: 'ExampleRssFeeds',
       component: () => import('@/views/dashboard/example_rss_feeds/index.vue'),

--- a/web/admin/src/views/dashboard/feed_viewer/feedViewerRoute.test.ts
+++ b/web/admin/src/views/dashboard/feed_viewer/feedViewerRoute.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+import TOOLS from '@/router/routes/modules/tools';
+import { resolveFeedViewerRouteState } from './feedViewerRoute';
+
+describe('resolveFeedViewerRouteState', () => {
+  it('opens compare mode for the legacy /tools/feed_compare path', () => {
+    expect(
+      resolveFeedViewerRouteState('/tools/feed_compare', {}).pageMode
+    ).toBe('compare');
+  });
+
+  it('keeps preview mode on /tools/viewer without page_mode', () => {
+    expect(resolveFeedViewerRouteState('/tools/viewer', {}).pageMode).toBe(
+      'preview'
+    );
+  });
+
+  it('opens compare mode when page_mode=compare is present', () => {
+    expect(
+      resolveFeedViewerRouteState('/tools/viewer', { page_mode: 'compare' })
+        .pageMode
+    ).toBe('compare');
+  });
+
+  it('still resolves recipe preview targets and can combine with compare mode', () => {
+    const state = resolveFeedViewerRouteState('/tools/feed_compare', {
+      target: 'recipe',
+      id: 'demo-recipe',
+    });
+    expect(state.previewMode).toBe('recipe');
+    expect(state.selectedRecipeId).toBe('demo-recipe');
+    expect(state.pageMode).toBe('compare');
+  });
+
+  it('fills url and craft query params used by the old compare page', () => {
+    const state = resolveFeedViewerRouteState('/tools/feed_compare', {
+      url: 'https://hnrss.org/frontpage',
+      craft: 'fulltext',
+    });
+    expect(state.previewMode).toBe('url');
+    expect(state.feedUrl).toBe('https://hnrss.org/frontpage');
+    expect(state.selectedCraft).toBe('fulltext');
+  });
+});
+
+describe('tools routes', () => {
+  it('keeps a hidden /tools/feed_compare route for compatibility', () => {
+    const child = TOOLS.children?.find(
+      (route) => route.path === 'feed_compare'
+    );
+    expect(child).toBeDefined();
+    expect(child?.name).toBe('FeedCompare');
+    expect(child?.meta?.hideInMenu).toBe(true);
+  });
+});

--- a/web/admin/src/views/dashboard/feed_viewer/feedViewerRoute.ts
+++ b/web/admin/src/views/dashboard/feed_viewer/feedViewerRoute.ts
@@ -72,8 +72,10 @@ export function resolveFeedViewerRouteState(
       ? 'compare'
       : 'preview';
 
-  let state = emptyState(pageMode);
-  state.selectedCraft = firstQueryValue(query.craft || query.craft_name);
+  const state = {
+    ...emptyState(pageMode),
+    selectedCraft: firstQueryValue(query.craft || query.craft_name),
+  };
 
   const target = firstQueryValue(query.target || query.mode);
   const id = firstQueryValue(query.id);

--- a/web/admin/src/views/dashboard/feed_viewer/feedViewerRoute.ts
+++ b/web/admin/src/views/dashboard/feed_viewer/feedViewerRoute.ts
@@ -1,0 +1,107 @@
+export type PreviewMode = 'url' | 'recipe' | 'topic' | 'inbox' | 'uri';
+export type PageMode = 'preview' | 'compare';
+
+export type FeedViewerQuery = Record<string, unknown>;
+
+export type FeedViewerRouteState = {
+  pageMode: PageMode;
+  previewMode: PreviewMode;
+  feedUrl: string;
+  advancedURI: string;
+  selectedRecipeId: string;
+  selectedTopicId: string;
+  selectedInboxId: string;
+  selectedCraft: string;
+};
+
+function firstQueryValue(value: unknown): string {
+  if (Array.isArray(value)) return String(value[0] || '');
+  return typeof value === 'string' ? value : '';
+}
+
+function emptyState(pageMode: PageMode): FeedViewerRouteState {
+  return {
+    pageMode,
+    previewMode: 'url',
+    feedUrl: '',
+    advancedURI: '',
+    selectedRecipeId: '',
+    selectedTopicId: '',
+    selectedInboxId: '',
+    selectedCraft: '',
+  };
+}
+
+function isComparePath(path: string): boolean {
+  return /\/feed_compare\/?$/.test(path);
+}
+
+function selectInputURI(
+  inputURI: string,
+  state: FeedViewerRouteState
+): FeedViewerRouteState {
+  try {
+    const parsed = new URL(inputURI);
+    if (parsed.protocol === 'feedcraft:') {
+      const id = parsed.pathname.replace(/^\/+/, '');
+      if (parsed.hostname === 'recipe') {
+        return { ...state, previewMode: 'recipe', selectedRecipeId: id };
+      }
+      if (parsed.hostname === 'topic') {
+        return { ...state, previewMode: 'topic', selectedTopicId: id };
+      }
+      if (parsed.hostname === 'inbox') {
+        return { ...state, previewMode: 'inbox', selectedInboxId: id };
+      }
+    }
+    if (parsed.protocol === 'http:' || parsed.protocol === 'https:') {
+      return { ...state, previewMode: 'url', feedUrl: inputURI };
+    }
+  } catch {
+    // Fall through to advanced URI mode.
+  }
+  return { ...state, previewMode: 'uri', advancedURI: inputURI };
+}
+
+export function resolveFeedViewerRouteState(
+  path: string,
+  query: FeedViewerQuery
+): FeedViewerRouteState {
+  const pageMode: PageMode =
+    isComparePath(path) || firstQueryValue(query.page_mode) === 'compare'
+      ? 'compare'
+      : 'preview';
+
+  let state = emptyState(pageMode);
+  state.selectedCraft = firstQueryValue(query.craft || query.craft_name);
+
+  const target = firstQueryValue(query.target || query.mode);
+  const id = firstQueryValue(query.id);
+  if (target === 'recipe') {
+    return {
+      ...state,
+      previewMode: 'recipe',
+      selectedRecipeId: id || firstQueryValue(query.recipe_id),
+    };
+  }
+  if (target === 'topic') {
+    return {
+      ...state,
+      previewMode: 'topic',
+      selectedTopicId: id || firstQueryValue(query.topic_id),
+    };
+  }
+  if (target === 'inbox') {
+    return {
+      ...state,
+      previewMode: 'inbox',
+      selectedInboxId: id || firstQueryValue(query.inbox_id),
+    };
+  }
+
+  const inputURI = firstQueryValue(query.input_uri || query.uri || query.url);
+  if (inputURI) {
+    return selectInputURI(inputURI, state);
+  }
+  return state;
+}

--- a/web/admin/src/views/dashboard/feed_viewer/feed_viewer.vue
+++ b/web/admin/src/views/dashboard/feed_viewer/feed_viewer.vue
@@ -221,9 +221,11 @@
   import { listTopicFeeds, type TopicFeed } from '@/api/topic';
   import { listInboxes, type Inbox } from '@/api/inbox';
   import { Message } from '@arco-design/web-vue';
-
-  type PreviewMode = 'url' | 'recipe' | 'topic' | 'inbox' | 'uri';
-  type PageMode = 'preview' | 'compare';
+  import {
+    resolveFeedViewerRouteState,
+    type PageMode,
+    type PreviewMode,
+  } from './feedViewerRoute';
 
   const { t } = useI18n();
   const route = useRoute();
@@ -360,82 +362,17 @@
     }
   }
 
-  function firstQueryValue(value: unknown): string {
-    if (Array.isArray(value)) return String(value[0] || '');
-    return typeof value === 'string' ? value : '';
-  }
-
-  function selectInputURI(inputURI: string) {
-    if (!inputURI) return;
-    try {
-      const parsed = new URL(inputURI);
-      if (parsed.protocol === 'feedcraft:') {
-        const id = parsed.pathname.replace(/^\/+/, '');
-        if (parsed.hostname === 'recipe') {
-          previewMode.value = 'recipe';
-          selectedRecipeId.value = id;
-          return;
-        }
-        if (parsed.hostname === 'topic') {
-          previewMode.value = 'topic';
-          selectedTopicId.value = id;
-          return;
-        }
-        if (parsed.hostname === 'inbox') {
-          previewMode.value = 'inbox';
-          selectedInboxId.value = id;
-          return;
-        }
-      }
-      if (parsed.protocol === 'http:' || parsed.protocol === 'https:') {
-        previewMode.value = 'url';
-        feedUrl.value = inputURI;
-        return;
-      }
-    } catch {
-      // Fall through to advanced URI mode.
-    }
-    previewMode.value = 'uri';
-    advancedURI.value = inputURI;
-  }
-
-  function resetPreviewTarget() {
-    previewMode.value = 'url';
-    feedUrl.value = '';
-    advancedURI.value = '';
-    selectedRecipeId.value = '';
-    selectedTopicId.value = '';
-    selectedInboxId.value = '';
-    clearPreviewState();
-  }
-
   function applyRouteQuery() {
-    const target = firstQueryValue(route.query.target || route.query.mode);
-    const id = firstQueryValue(route.query.id);
-    if (target === 'recipe') {
-      previewMode.value = 'recipe';
-      selectedRecipeId.value = id || firstQueryValue(route.query.recipe_id);
-      return;
-    }
-    if (target === 'topic') {
-      previewMode.value = 'topic';
-      selectedTopicId.value = id || firstQueryValue(route.query.topic_id);
-      return;
-    }
-    if (target === 'inbox') {
-      previewMode.value = 'inbox';
-      selectedInboxId.value = id || firstQueryValue(route.query.inbox_id);
-      return;
-    }
-
-    const inputURI = firstQueryValue(
-      route.query.input_uri || route.query.uri || route.query.url
-    );
-    if (inputURI) {
-      selectInputURI(inputURI);
-      return;
-    }
-    resetPreviewTarget();
+    const state = resolveFeedViewerRouteState(route.path, route.query);
+    pageMode.value = state.pageMode;
+    previewMode.value = state.previewMode;
+    feedUrl.value = state.feedUrl;
+    advancedURI.value = state.advancedURI;
+    selectedRecipeId.value = state.selectedRecipeId;
+    selectedTopicId.value = state.selectedTopicId;
+    selectedInboxId.value = state.selectedInboxId;
+    selectedCraft.value = state.selectedCraft;
+    clearPreviewState();
   }
 
   async function loadPreviewResources() {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 背景

Linear [COL-23](https://linear.app/colin-x-studio/issue/COL-23/toolsfeed-compare-路由-404-feed-对比配方预览页消失前端重构删除-无替代路由)：访问 `/tools/feed_compare` 返回 SPA 404。

已在 `dev` 上确认：独立 Feed 对比页已合并进 RSS 预览（`/tools/viewer` 的 compare 模式），但旧路由未保留，E2E 与 `DEVELOPMENT.md` 仍引用旧路径。

## 改动

- 重新注册隐藏路由 `/tools/feed_compare`，复用 RSS 预览页并默认进入对比模式
- 解析 `url` / `craft` / `page_mode=compare` 等查询参数
- 更新 `DEVELOPMENT.md` 说明旧 URL 与 RSS Viewer 的关系
- 增加 `feedViewerRoute` 单测

## 验证

- `pnpm test`：7 files / 25 tests passed（含新增 6 条）
- `task frontend-build` 成功
- `go test ./...` 成功
- 浏览器：登录后访问 `/tools/feed_compare` 进入 Craft 对比模式（非 404）；带 `url`/`craft` 查询参数会预填；`/tools/viewer` 仍默认直接预览

[feed_compare 进入对比模式](https://cursor.com/agents/bc-e0c49ec3-d933-4861-a9d0-868a759d34b9/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ffeed_compare_compare_mode.webp)
[col23_feed_compare_compat_route.mp4](https://cursor.com/agents/bc-e0c49ec3-d933-4861-a9d0-868a759d34b9/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcol23_feed_compare_compat_route.mp4)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e0c49ec3-d933-4861-a9d0-868a759d34b9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e0c49ec3-d933-4861-a9d0-868a759d34b9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

## Summary by Sourcery

Restore Feed Compare route compatibility by routing the legacy URL through RSS Viewer’s compare mode while preserving preview and query-parameter behavior.

Bug Fixes:
- Restore the hidden `/tools/feed_compare` compatibility route and open it directly in RSS Viewer compare mode instead of returning an SPA 404.

Enhancements:
- Centralize RSS Viewer route-state handling while preserving legacy query parameters and existing preview behavior.
- Document the relationship between the legacy Feed Compare URL and RSS Viewer.

Documentation:
- Update development route documentation for RSS Viewer and the legacy Feed Compare URL.

Tests:
- Add unit coverage for route compatibility, compare-mode selection, preview targets, query prefill, and hidden route registration.