### PR TITLE
fix(craft): 上游抓取失败不再返回 HTTP 500

### DIFF
--- a/internal/craft/common.go
+++ b/internal/craft/common.go
@@ -106,7 +106,8 @@ func CommonCraftHandlerUsingCraftOptionList(c *gin.Context, optionList []LegacyC
 
 	rawCraftFeed, err := sourceInstance.Fetch(c.Request.Context())
 	if err != nil {
-		c.String(http.StatusInternalServerError, err.Error())
+		status, msg := httpStatusForCraftSourceError(err)
+		c.String(status, msg)
 		return
 	}
 

--- a/internal/craft/source_error.go
+++ b/internal/craft/source_error.go
@@ -1,0 +1,31 @@
+package craft
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"strings"
+)
+
+func httpStatusForCraftSourceError(err error) (int, string) {
+	if err == nil {
+		return http.StatusOK, ""
+	}
+
+	msg := err.Error()
+	lower := strings.ToLower(msg)
+
+	switch {
+	case errors.Is(err, context.DeadlineExceeded) || strings.Contains(lower, "context deadline exceeded") || strings.Contains(lower, "client.timeout"):
+		return http.StatusGatewayTimeout, msg
+	case strings.Contains(lower, "parse failed:") || strings.Contains(lower, "failed to detect feed type") || strings.Contains(lower, "invalid xml"):
+		return http.StatusUnprocessableEntity, msg
+	case strings.Contains(lower, "http status not ok:"),
+		strings.Contains(lower, "http get failed:"),
+		strings.Contains(lower, "failed to read response body:"),
+		strings.Contains(lower, "response body exceeds"):
+		return http.StatusBadGateway, msg
+	default:
+		return http.StatusInternalServerError, msg
+	}
+}

--- a/internal/craft/source_error_test.go
+++ b/internal/craft/source_error_test.go
@@ -1,0 +1,82 @@
+package craft
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+func TestCommonCraftHandlerMapsUpstreamHTTPErrorToBadGateway(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	source := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "Forbidden", http.StatusForbidden)
+	}))
+	t.Cleanup(source.Close)
+
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = httptest.NewRequest(http.MethodGet, "/craft/proxy?input_url="+source.URL, nil)
+
+	CommonCraftHandlerUsingCraftOptionList(c, nil)
+
+	if recorder.Code != http.StatusBadGateway {
+		t.Fatalf("status = %d, want %d, body = %s", recorder.Code, http.StatusBadGateway, recorder.Body.String())
+	}
+	if !strings.Contains(recorder.Body.String(), "http status not ok") {
+		t.Fatalf("expected upstream status in body, got %s", recorder.Body.String())
+	}
+}
+
+func TestCommonCraftHandlerMapsInvalidFeedToUnprocessableEntity(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	source := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		_, _ = w.Write([]byte("<html><body>not a feed</body></html>"))
+	}))
+	t.Cleanup(source.Close)
+
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = httptest.NewRequest(http.MethodGet, "/craft/proxy?input_url="+source.URL, nil)
+
+	CommonCraftHandlerUsingCraftOptionList(c, nil)
+
+	if recorder.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("status = %d, want %d, body = %s", recorder.Code, http.StatusUnprocessableEntity, recorder.Body.String())
+	}
+	if !strings.Contains(strings.ToLower(recorder.Body.String()), "parse failed") {
+		t.Fatalf("expected parse failure in body, got %s", recorder.Body.String())
+	}
+}
+
+func TestHTTPStatusForCraftSourceError(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		err  string
+		want int
+	}{
+		{name: "upstream 403", err: "fetch failed: http status not ok: 403 Forbidden", want: http.StatusBadGateway},
+		{name: "connect failed", err: "fetch failed: http get failed: dial tcp: lookup hnrss.org", want: http.StatusBadGateway},
+		{name: "timeout", err: "fetch failed: http get failed: context deadline exceeded", want: http.StatusGatewayTimeout},
+		{name: "parse", err: "parse failed: Failed to detect feed type", want: http.StatusUnprocessableEntity},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, _ := httpStatusForCraftSourceError(errString(tt.err))
+			if got != tt.want {
+				t.Fatalf("httpStatusForCraftSourceError(%q) = %d, want %d", tt.err, got, tt.want)
+			}
+		})
+	}
+}
+
+type errString string
+
+func (e errString) Error() string { return string(e) }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 背景

Linear [COL-15](https://linear.app/colin-x-studio/issue/COL-15/proxy-craft-返回-500回归-col-13-记录时-proxy-正常-200)：`GET /craft/proxy?input_url=https://hnrss.org/frontpage` 返回 500。

## 验证结论

问题存在，但不是 proxy craft 自身处理逻辑回归。

- 对本地合法 RSS，`/craft/proxy` 仍返回 200（已有 `TestCommonCraftHandlerServesRSSForReaders`）。
- `CommonCraftHandlerUsingCraftOptionList` 把 **所有** `Fetch` 失败都写成 `500`。源站 403、TLS/连接失败、超时、非 RSS 内容都会被冒烟脚本当成 craft 挂了。
- Feed 预览页已经把同类错误当成源站问题，craft 端点没有对齐。

本次无法从本环境直连 `https://hnrss.org`（HTTPS 被拦截；HTTP 返回 403），与 issue 里「上游不可达 vs 代码回归」的疑点一致。

## 改动

- 按错误类型映射 HTTP 状态：
  - 上游 HTTP/网络失败 → **502 Bad Gateway**
  - 超时 → **504 Gateway Timeout**
  - 内容无法解析为 feed → **422 Unprocessable Entity**
  - 其余内部错误仍为 500
- 覆盖 403 源站与非法 HTML 的 handler 测试。

合法 RSS 的 proxy 行为不变。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a358ff5d-00fa-4d57-ad60-7d00307817f0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a358ff5d-00fa-4d57-ad60-7d00307817f0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

## Summary by Sourcery

Return source-specific HTTP errors from craft proxy requests so upstream failures no longer appear as HTTP 500 errors.

Bug Fixes:
- Map upstream HTTP and network failures to 502, timeouts to 504, and invalid feed content to 422 instead of treating all fetch failures as internal server errors.

Tests:
- Add handler and mapping tests covering upstream 403 responses, connection failures, timeouts, and invalid feed content.