### PR TITLE
fix(llm): 可配置超时、请求取消、缓存防击穿与 prompt 截断

### DIFF
--- a/doc-site/src/content/docs/en/guides/advanced/customization.md
+++ b/doc-site/src/content/docs/en/guides/advanced/customization.md
@@ -76,6 +76,8 @@ You can configure FeedCraft using environment variables in `docker-compose.yml`.
 - **FC_LLM_API_BASE**: API endpoint address. For OpenAI-compatible APIs, usually ends with `/v1`.
 - **FC_LLM_API_TYPE**: (Optional) `openai` (default) or `ollama`.
 - **FC_LLM_MAX_CONCURRENCY**: (Optional) Global maximum concurrency for LLM requests (default: `3`). Limits concurrent API calls to prevent rate limits.
+- **FC_LLM_CALL_TIMEOUT**: (Optional) Per-call LLM timeout in seconds (default: `180`). Timed-out or canceled calls are not retried, so a hung upstream cannot occupy a concurrency slot for 10+ minutes.
+- **FC_LLM_PROMPT_MAX_CHARS**: (Optional) Maximum rune count of article text sent to the LLM (default: `12000`). Longer inputs keep the head and tail and insert a truncation marker.
 - **FC_DOMAIN_MAX_CONCURRENCY**: (Optional) Maximum concurrent requests per target domain during web scraping like fulltext extraction (default: `3`). Prevents overwhelming target servers.
 - **FC_PREHEATING_MAX_CONCURRENCY**: (Optional) Maximum concurrent background preheating tasks (default: `2`).
 - **FC_PREHEATING_QUEUE_SIZE**: (Optional) Maximum pending preheating tasks; defaults to the preheating concurrency.

--- a/doc-site/src/content/docs/zh-tw/guides/advanced/customization.md
+++ b/doc-site/src/content/docs/zh-tw/guides/advanced/customization.md
@@ -76,6 +76,8 @@ sidebar:
 - **FC_LLM_API_BASE**: API 介面地址。如果是相容 OpenAI 的 API，通常以 `/v1` 結尾。
 - **FC_LLM_API_TYPE**: (可選) `openai` (預設) 或 `ollama`.
 - **FC_LLM_MAX_CONCURRENCY**: (可選) 全局最大 LLM 併發請求數（預設: `3`）。用於限制併發請求數量以防止觸發 API 速率限制。
+- **FC_LLM_CALL_TIMEOUT**: (可選) 單次 LLM 呼叫逾時秒數（預設: `180`）。逾時或請求取消後不再重試，避免掛起的上游長時間占用併發額度。
+- **FC_LLM_PROMPT_MAX_CHARS**: (可選) 送入 LLM 的文章正文最大字元數（以 rune 計，預設: `12000`）。超長內容會保留頭尾並插入截斷標記。
 - **FC_DOMAIN_MAX_CONCURRENCY**: (可選) 網頁抓取（如全文提取）時每個目標域名的最大併發數（預設: `3`）。防止抓取目標伺服器負載過高。
 - **FC_PREHEATING_MAX_CONCURRENCY**: （可選）背景預熱工作的最大併發數（預設：`2`）。
 - **FC_PREHEATING_QUEUE_SIZE**: （可選）預熱等候佇列的最大工作數；預設與預熱併發數相同。

--- a/doc-site/src/content/docs/zh/guides/advanced/customization.md
+++ b/doc-site/src/content/docs/zh/guides/advanced/customization.md
@@ -76,6 +76,8 @@ sidebar:
 - **FC_LLM_API_BASE**: API 接口地址。如果是兼容 OpenAI 的 API，通常以 `/v1` 结尾。
 - **FC_LLM_API_TYPE**: (可选) `openai` (默认) 或 `ollama`.
 - **FC_LLM_MAX_CONCURRENCY**: (可选) 全局最大 LLM 并发请求数（默认: `3`）。用于限制并发请求数量以防止触发 API 速率限制。
+- **FC_LLM_CALL_TIMEOUT**: (可选) 单次 LLM 调用超时秒数（默认: `180`）。超时或请求取消后不再重试，避免挂起的上游长时间占用并发额度。
+- **FC_LLM_PROMPT_MAX_CHARS**: (可选) 送入 LLM 的文章正文最大字符数（按 rune 计，默认: `12000`）。超长内容会保留头尾并插入截断标记。
 - **FC_DOMAIN_MAX_CONCURRENCY**: (可选) 网页抓取（如全文提取）时每个目标域名的最大并发数（默认: `3`）。防止抓取目标服务器负载过高。
 - **FC_PREHEATING_MAX_CONCURRENCY**: （可选）后台预热任务的最大并发数（默认：`2`）。
 - **FC_PREHEATING_QUEUE_SIZE**: （可选）预热等待队列的最大任务数；默认与预热并发数相同。

--- a/internal/adapter/common_llm.go
+++ b/internal/adapter/common_llm.go
@@ -3,6 +3,7 @@ package adapter
 import (
 	"FeedCraft/internal/util"
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"math/rand"
@@ -24,7 +25,10 @@ Handle LLM calling and processing, support OpenAI and all compatible services.
 
 const UseDefaultModel = ""
 
-var llmCallTimeout = 10 * time.Minute
+const defaultLLMCallTimeout = 3 * time.Minute
+
+// llmCallTimeout, when > 0, overrides env/default. Tests use this to inject a short deadline.
+var llmCallTimeout time.Duration
 var (
 	// llmClients acts as a lazy-loaded singleton registry, NOT a traditional acquire/release connection pool.
 	// It maps configuration keys to a single llms.Model instance.
@@ -60,12 +64,24 @@ func getLLMDispatcher() *util.PriorityDispatcher[string] {
 			concurrency = 3
 		}
 		llmDispatcher = util.NewPriorityDispatcher[string](concurrency)
-		// Fallback timeout to prevent tasks from sticking forever
-		// llmCallTimeout is 10 min, we set fallback to 11 min
-		llmDispatcher.MaxTaskDuration = llmCallTimeout + time.Minute
 		logrus.Infof("LLM Global Priority Dispatcher initialized with max concurrency: %d", concurrency)
 	})
+	// Keep fallback slightly above the per-call timeout so GenerateContent can fail first.
+	llmDispatcher.MaxTaskDuration = currentLLMCallTimeout() + time.Minute
 	return llmDispatcher
+}
+
+func currentLLMCallTimeout() time.Duration {
+	if llmCallTimeout > 0 {
+		return llmCallTimeout
+	}
+	envClient := util.GetEnvClient()
+	if envClient != nil {
+		if seconds := envClient.GetInt("LLM_CALL_TIMEOUT"); seconds > 0 {
+			return time.Duration(seconds) * time.Second
+		}
+	}
+	return defaultLLMCallTimeout
 }
 
 type llmModelClient struct {
@@ -74,18 +90,29 @@ type llmModelClient struct {
 }
 
 func SimpleLLMCall(model string, promptInput string) (string, error) {
-	return simpleLLMCallWithOptions(model, promptInput, defaultLLMRetryConfig, nil)
+	return SimpleLLMCallContext(context.Background(), model, promptInput)
+}
+
+func SimpleLLMCallContext(ctx context.Context, model string, promptInput string) (string, error) {
+	return simpleLLMCallWithOptions(ctx, model, promptInput, defaultLLMRetryConfig, nil)
 }
 
 func SimpleLLMCallWithOptions(model string, promptInput string, callOptions ...llms.CallOption) (string, error) {
-	return simpleLLMCallWithOptions(model, promptInput, defaultLLMRetryConfig, callOptions)
+	return SimpleLLMCallWithOptionsContext(context.Background(), model, promptInput, callOptions...)
+}
+
+func SimpleLLMCallWithOptionsContext(ctx context.Context, model string, promptInput string, callOptions ...llms.CallOption) (string, error) {
+	return simpleLLMCallWithOptions(ctx, model, promptInput, defaultLLMRetryConfig, callOptions)
 }
 
 func simpleLLMCall(model string, promptInput string, retryConfig llmRetryConfig) (string, error) {
-	return simpleLLMCallWithOptions(model, promptInput, retryConfig, nil)
+	return simpleLLMCallWithOptions(context.Background(), model, promptInput, retryConfig, nil)
 }
 
-func simpleLLMCallWithOptions(model string, promptInput string, retryConfig llmRetryConfig, callOptions []llms.CallOption) (string, error) {
+func simpleLLMCallWithOptions(ctx context.Context, model string, promptInput string, retryConfig llmRetryConfig, callOptions []llms.CallOption) (string, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	envClient := util.GetEnvClient()
 	if envClient == nil {
 		log.Fatalf("get env client error.")
@@ -203,21 +230,23 @@ func simpleLLMCallWithOptions(model string, promptInput string, retryConfig llmR
 	currentModel := ""
 	maxAttempts := uint(len(modelClients)) * retryConfig.attemptsPerModel
 
+	callTimeout := currentLLMCallTimeout()
+	requestCtx := ctx
 	result, err := retry.DoWithData(
 		func() (string, error) {
 			modelClient := modelClients[attemptIndex%len(modelClients)]
 			attemptIndex++
 			currentModel = modelClient.model
 
-			return dispatcher.Execute(context.Background(), isUrgent, func(ctx context.Context) (string, error) {
-				ctx, cancel := context.WithTimeout(ctx, llmCallTimeout)
+			return dispatcher.Execute(requestCtx, isUrgent, func(taskCtx context.Context) (string, error) {
+				callCtx, cancel := context.WithTimeout(taskCtx, callTimeout)
 				defer cancel()
 
 				content := []llms.MessageContent{
 					llms.TextParts(llms.ChatMessageTypeHuman, promptInput),
 				}
 
-				resp, err := modelClient.llm.GenerateContent(ctx, content, callOptions...)
+				resp, err := modelClient.llm.GenerateContent(callCtx, content, callOptions...)
 				if err != nil {
 					return "", err
 				}
@@ -231,6 +260,9 @@ func simpleLLMCallWithOptions(model string, promptInput string, retryConfig llmR
 		retry.DelayType(modelRotationBackoffDelay(len(modelClients))),
 		retry.Delay(retryConfig.delay),
 		retry.MaxDelay(retryConfig.maxDelay),
+		retry.RetryIf(func(err error) bool {
+			return !isNonRetryableLLMContextError(err)
+		}),
 		retry.OnRetry(func(n uint, err error) {
 			isUrgent = true // Elevate priority on retry
 			nextModel := modelClients[attemptIndex%len(modelClients)].model
@@ -245,6 +277,10 @@ func simpleLLMCallWithOptions(model string, promptInput string, retryConfig llmR
 	lastErr = err
 	logrus.Warnf("LLM call failed after retries: %v", err)
 	return "", fmt.Errorf("all models failed, last error: %v", lastErr)
+}
+
+func isNonRetryableLLMContextError(err error) bool {
+	return errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)
 }
 
 func modelRotationBackoffDelay(modelCount int) retry.DelayTypeFunc {

--- a/internal/adapter/common_llm.go
+++ b/internal/adapter/common_llm.go
@@ -64,10 +64,11 @@ func getLLMDispatcher() *util.PriorityDispatcher[string] {
 			concurrency = 3
 		}
 		llmDispatcher = util.NewPriorityDispatcher[string](concurrency)
+		// This fallback is immutable after publication; the per-call deadline
+		// remains the authoritative timeout for GenerateContent.
+		llmDispatcher.MaxTaskDuration = currentLLMCallTimeout() + time.Minute
 		logrus.Infof("LLM Global Priority Dispatcher initialized with max concurrency: %d", concurrency)
 	})
-	// Keep fallback slightly above the per-call timeout so GenerateContent can fail first.
-	llmDispatcher.MaxTaskDuration = currentLLMCallTimeout() + time.Minute
 	return llmDispatcher
 }
 
@@ -260,6 +261,7 @@ func simpleLLMCallWithOptions(ctx context.Context, model string, promptInput str
 		retry.DelayType(modelRotationBackoffDelay(len(modelClients))),
 		retry.Delay(retryConfig.delay),
 		retry.MaxDelay(retryConfig.maxDelay),
+		retry.Context(requestCtx),
 		retry.RetryIf(func(err error) bool {
 			return !isNonRetryableLLMContextError(err)
 		}),

--- a/internal/adapter/common_llm_scenarios_test.go
+++ b/internal/adapter/common_llm_scenarios_test.go
@@ -1,6 +1,7 @@
 package adapter
 
 import (
+	"context"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -380,4 +381,47 @@ func TestSimpleLLMCallFailsOverToHealthyModel(t *testing.T) {
 	mu.Lock()
 	defer mu.Unlock()
 	require.Contains(t, requested, "model-good", "应当在坏模型失败后切换到健康模型")
+}
+
+func TestCurrentLLMCallTimeoutDefaultAndEnv(t *testing.T) {
+	old := llmCallTimeout
+	llmCallTimeout = 0
+	t.Cleanup(func() { llmCallTimeout = old })
+
+	t.Setenv("FC_LLM_CALL_TIMEOUT", "")
+	require.Equal(t, defaultLLMCallTimeout, currentLLMCallTimeout())
+	require.Equal(t, 3*time.Minute, defaultLLMCallTimeout)
+
+	t.Setenv("FC_LLM_CALL_TIMEOUT", "90")
+	require.Equal(t, 90*time.Second, currentLLMCallTimeout())
+
+	llmCallTimeout = 50 * time.Millisecond
+	require.Equal(t, 50*time.Millisecond, currentLLMCallTimeout(), "测试注入的 llmCallTimeout 应覆盖环境变量")
+}
+
+func TestSimpleLLMCallContextCanceledDoesNotRetry(t *testing.T) {
+	resetLLMClients(t)
+
+	var calls int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		select {
+		case <-r.Context().Done():
+		case <-time.After(2 * time.Second):
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	setOpenAILLMEnv(t, server.URL)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 80*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	_, err := SimpleLLMCallContext(ctx, "model-a", "hi")
+	elapsed := time.Since(start)
+
+	require.Error(t, err)
+	require.Less(t, elapsed, 2*time.Second)
+	require.LessOrEqual(t, atomic.LoadInt32(&calls), int32(1), "请求取消后不应再重试占用并发额度")
 }

--- a/internal/adapter/common_llm_scenarios_test.go
+++ b/internal/adapter/common_llm_scenarios_test.go
@@ -425,3 +425,40 @@ func TestSimpleLLMCallContextCanceledDoesNotRetry(t *testing.T) {
 	require.Less(t, elapsed, 2*time.Second)
 	require.LessOrEqual(t, atomic.LoadInt32(&calls), int32(1), "请求取消后不应再重试占用并发额度")
 }
+
+func TestSimpleLLMCallContextCanceledDuringBackoffDoesNotRetry(t *testing.T) {
+	resetLLMClients(t)
+
+	firstCall := make(chan struct{})
+	var calls int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if atomic.AddInt32(&calls, 1) == 1 {
+			close(firstCall)
+		}
+		http.Error(w, "retryable", http.StatusServiceUnavailable)
+	}))
+	t.Cleanup(server.Close)
+	setOpenAILLMEnv(t, server.URL)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		_, err := simpleLLMCallWithOptions(ctx, "model-a", "hi", llmRetryConfig{
+			attemptsPerModel: 3,
+			delay:            time.Second,
+			maxDelay:         time.Second,
+		}, nil)
+		done <- err
+	}()
+
+	<-firstCall
+	time.Sleep(20 * time.Millisecond)
+	cancel()
+	select {
+	case err := <-done:
+		require.Error(t, err)
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("cancellation did not interrupt retry backoff")
+	}
+	require.Equal(t, int32(1), atomic.LoadInt32(&calls))
+}

--- a/internal/adapter/llm.go
+++ b/internal/adapter/llm.go
@@ -26,13 +26,13 @@ func CallLLMUsingRequestContext(ctx context.Context, prompt, articleContext stri
 
 	finalPrompt := fmt.Sprintf("%s \n```\n%s\n```", prompt, processedContext)
 	cacheKey := fmt.Sprintf("llm_call_%s_%s", util.GetTextContentHash(finalPrompt), llmCallTemperatureCachePart(option))
-	valFunc := func() (string, error) {
+	valFunc := func(sharedCtx context.Context) (string, error) {
 		if option.Temperature != nil {
-			return SimpleLLMCallWithOptionsContext(ctx, UseDefaultModel, finalPrompt, llms.WithTemperature(*option.Temperature))
+			return SimpleLLMCallWithOptionsContext(sharedCtx, UseDefaultModel, finalPrompt, llms.WithTemperature(*option.Temperature))
 		}
-		return SimpleLLMCallContext(ctx, UseDefaultModel, finalPrompt)
+		return SimpleLLMCallContext(sharedCtx, UseDefaultModel, finalPrompt)
 	}
-	return util.CachedFunc(cacheKey, valFunc)
+	return util.CachedFuncContext(ctx, cacheKey, valFunc)
 }
 
 func llmCallTemperatureCachePart(option util.ContentProcessOption) string {

--- a/internal/adapter/llm.go
+++ b/internal/adapter/llm.go
@@ -2,6 +2,7 @@ package adapter
 
 import (
 	"FeedCraft/internal/util"
+	"context"
 	"fmt"
 	"strings"
 
@@ -9,18 +10,27 @@ import (
 )
 
 // CallLLMUsingContext using openai compatible api
-func CallLLMUsingContext(prompt, context string, option util.ContentProcessOption) (string, error) {
-	processedContext := util.ProcessContent(context, option)
+func CallLLMUsingContext(prompt, articleContext string, option util.ContentProcessOption) (string, error) {
+	return CallLLMUsingRequestContext(context.Background(), prompt, articleContext, option)
+}
+
+// CallLLMUsingRequestContext is CallLLMUsingContext bound to a request/task context.
+func CallLLMUsingRequestContext(ctx context.Context, prompt, articleContext string, option util.ContentProcessOption) (string, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	processedContext := util.ProcessContent(articleContext, option)
 	// Remove backticks to avoid breaking the markdown code block
 	processedContext = strings.ReplaceAll(processedContext, "`", "")
+	processedContext = util.TruncateHeadTail(processedContext, util.LLMPromptMaxChars())
 
 	finalPrompt := fmt.Sprintf("%s \n```\n%s\n```", prompt, processedContext)
 	cacheKey := fmt.Sprintf("llm_call_%s_%s", util.GetTextContentHash(finalPrompt), llmCallTemperatureCachePart(option))
 	valFunc := func() (string, error) {
 		if option.Temperature != nil {
-			return SimpleLLMCallWithOptions(UseDefaultModel, finalPrompt, llms.WithTemperature(*option.Temperature))
+			return SimpleLLMCallWithOptionsContext(ctx, UseDefaultModel, finalPrompt, llms.WithTemperature(*option.Temperature))
 		}
-		return SimpleLLMCall(UseDefaultModel, finalPrompt)
+		return SimpleLLMCallContext(ctx, UseDefaultModel, finalPrompt)
 	}
 	return util.CachedFunc(cacheKey, valFunc)
 }

--- a/internal/admin/debug.go
+++ b/internal/admin/debug.go
@@ -28,7 +28,7 @@ func LLMDebug(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, util.APIResponse[any]{Msg: err.Error()})
 		return
 	}
-	ret, err := adapter.SimpleLLMCall(reqBody.Model, reqBody.Input)
+	ret, err := adapter.SimpleLLMCallContext(c.Request.Context(), reqBody.Model, reqBody.Input)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, util.APIResponse[any]{Msg: err.Error()})
 		return

--- a/internal/craft/adapter.go
+++ b/internal/craft/adapter.go
@@ -12,9 +12,10 @@ func AdaptLegacyOption(option LegacyCraftOption, extra ExtraPayload) CraftOption
 	}
 
 	return func(ctx context.Context, feed *model.CraftFeed) (*model.CraftFeed, error) {
-		_ = ctx
+		requestExtra := extra
+		requestExtra.ctx = ctx
 		legacyFeed := feed.ToFeedsFeed()
-		if err := option(legacyFeed, extra); err != nil {
+		if err := option(legacyFeed, requestExtra); err != nil {
 			return nil, err
 		}
 		return model.FromFeedsFeed(legacyFeed), nil

--- a/internal/craft/advertorial.go
+++ b/internal/craft/advertorial.go
@@ -2,14 +2,15 @@ package craft
 
 import (
 	"FeedCraft/internal/util"
+	"context"
 	"fmt"
+	"net/http"
+	"time"
+
 	"github.com/gin-gonic/gin"
 	"github.com/gorilla/feeds"
 	"github.com/samber/lo"
 	"github.com/samber/lo/parallel"
-
-	"net/http"
-	"time"
 )
 
 /**
@@ -38,7 +39,7 @@ const promptCheckIfAdvertorial = "请阅读下面的文章, 并判断是不是�
 
 // CheckIfAdvertorial 判断是否为软文, 非常有把握则返回true, 如果不是或者不确定或是发生错误则返回false
 func CheckIfAdvertorial(title string, content string, prompt string) bool {
-	res, _ := CheckConditionWithLLM(title, content, prompt)
+	res, _ := CheckConditionWithLLM(context.Background(), title, content, prompt)
 	return res
 }
 

--- a/internal/craft/advertorial.go
+++ b/internal/craft/advertorial.go
@@ -39,7 +39,11 @@ const promptCheckIfAdvertorial = "请阅读下面的文章, 并判断是不是�
 
 // CheckIfAdvertorial 判断是否为软文, 非常有把握则返回true, 如果不是或者不确定或是发生错误则返回false
 func CheckIfAdvertorial(title string, content string, prompt string) bool {
-	res, _ := CheckConditionWithLLM(context.Background(), title, content, prompt)
+	return CheckIfAdvertorialContext(context.Background(), title, content, prompt)
+}
+
+func CheckIfAdvertorialContext(ctx context.Context, title string, content string, prompt string) bool {
+	res, _ := CheckConditionWithLLM(ctx, title, content, prompt)
 	return res
 }
 
@@ -64,7 +68,7 @@ func OptionIgnoreAdvertorial(prompt string) LegacyCraftOption {
 			if len(content) == 0 {
 				content = itm.Description
 			}
-			return CheckIfAdvertorial(itm.Title, content, prompt)
+			return CheckIfAdvertorialContext(payload.Context(), itm.Title, content, prompt)
 		})
 
 		// 2. 同步过滤
@@ -129,7 +133,7 @@ func DebugCheckIfAdvertorial(c *gin.Context) {
 	}
 	prompt := fmt.Sprintf("%s\n%s\n", judgePrompt, promptCheckIfAdvertorial)
 
-	result := CheckIfAdvertorial("", webContent, prompt)
+	result := CheckIfAdvertorialContext(c.Request.Context(), "", webContent, prompt)
 	ret := CheckIfAdvertorialDebugResp{
 		Url:            reqBody.Url,
 		IsAdvertorial:  result,

--- a/internal/craft/ai_content_process.go
+++ b/internal/craft/ai_content_process.go
@@ -53,19 +53,19 @@ func OptionAIContentProcess(rule string, extraPayloadRaw string, placementRaw st
 	placement := parseAIContentProcessPlacement(placementRaw)
 	prompt := buildAIContentProcessPrompt(rule)
 
-	transFunc := func(item *feeds.Item) (string, error) {
+	transFunc := func(ctx context.Context, item *feeds.Item) (string, error) {
 		if rule == "" {
 			return "", fmt.Errorf("ai-content-process requires rule param")
 		}
-		return cachedAIContentProcessItem(item, prompt, payloadTypes, placement)
+		return cachedAIContentProcessItem(ctx, item, prompt, payloadTypes, placement)
 	}
 
-	return OptionTransformFeedItem(GetArticleContentProcessor(transFunc))
+	return OptionTransformFeedItem(GetArticleContentProcessorWithContext(transFunc))
 }
 
-func cachedAIContentProcessItem(item *feeds.Item, prompt string, payloadTypes []aiFilterExtraPayloadType, placement aiContentProcessPlacement) (string, error) {
+func cachedAIContentProcessItem(ctx context.Context, item *feeds.Item, prompt string, payloadTypes []aiFilterExtraPayloadType, placement aiContentProcessPlacement) (string, error) {
 	original := getPrimaryFeedItemContent(item)
-	articleContext, err := buildAIContentProcessArticlePayload(item, payloadTypes)
+	articleContext, err := buildAIContentProcessArticlePayload(ctx, item, payloadTypes)
 	if err != nil {
 		return "", err
 	}
@@ -76,8 +76,8 @@ func cachedAIContentProcessItem(item *feeds.Item, prompt string, payloadTypes []
 		util.GetTextContentHash(original),
 	}, "|")))
 
-	return util.CachedFuncWithPreLog(cacheKey, func() (string, error) {
-		result, callErr := llmContextCaller(context.Background(), prompt, articleContext, util.ContentProcessOption{
+	return util.CachedFuncWithPreLogContext(ctx, cacheKey, func(sharedCtx context.Context) (string, error) {
+		result, callErr := llmContextCaller(sharedCtx, prompt, articleContext, util.ContentProcessOption{
 			RemoveImage: true,
 			ConvertToMd: true,
 			Temperature: util.LowestLLMTemperaturePtr(),
@@ -96,10 +96,10 @@ func cachedAIContentProcessItem(item *feeds.Item, prompt string, payloadTypes []
 	})
 }
 
-func buildAIContentProcessArticlePayload(item *feeds.Item, payloadTypes []aiFilterExtraPayloadType) (string, error) {
+func buildAIContentProcessArticlePayload(ctx context.Context, item *feeds.Item, payloadTypes []aiFilterExtraPayloadType) (string, error) {
 	summary := ""
 	if loContainsAIFilterPayload(payloadTypes, aiFilterExtraPayloadArticleSummary) {
-		generated, err := generateAIFilterArticleSummary(item)
+		generated, err := generateAIFilterArticleSummary(ctx, item)
 		if err != nil {
 			return "", err
 		}

--- a/internal/craft/ai_content_process.go
+++ b/internal/craft/ai_content_process.go
@@ -1,6 +1,7 @@
 package craft
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -64,19 +65,19 @@ func OptionAIContentProcess(rule string, extraPayloadRaw string, placementRaw st
 
 func cachedAIContentProcessItem(item *feeds.Item, prompt string, payloadTypes []aiFilterExtraPayloadType, placement aiContentProcessPlacement) (string, error) {
 	original := getPrimaryFeedItemContent(item)
-	context, err := buildAIContentProcessArticlePayload(item, payloadTypes)
+	articleContext, err := buildAIContentProcessArticlePayload(item, payloadTypes)
 	if err != nil {
 		return "", err
 	}
 	cacheKey := getCraftCacheKey("ai-content-process-result", util.GetTextContentHash(strings.Join([]string{
 		util.GetTextContentHash(prompt),
-		util.GetTextContentHash(context),
+		util.GetTextContentHash(articleContext),
 		string(placement),
 		util.GetTextContentHash(original),
 	}, "|")))
 
 	return util.CachedFuncWithPreLog(cacheKey, func() (string, error) {
-		result, callErr := llmContextCaller(prompt, context, util.ContentProcessOption{
+		result, callErr := llmContextCaller(context.Background(), prompt, articleContext, util.ContentProcessOption{
 			RemoveImage: true,
 			ConvertToMd: true,
 			Temperature: util.LowestLLMTemperaturePtr(),

--- a/internal/craft/ai_content_process_test.go
+++ b/internal/craft/ai_content_process_test.go
@@ -1,6 +1,7 @@
 package craft
 
 import (
+	"context"
 	"strings"
 	"testing"
 	"time"
@@ -18,7 +19,7 @@ func TestOptionAIContentProcessPrependsGeneratedMarkdownAsHTML(t *testing.T) {
 	original := llmContextCaller
 	var seenPrompt string
 	var seenContext string
-	llmContextCaller = func(prompt, context string, option util.ContentProcessOption) (string, error) {
+	llmContextCaller = func(_ context.Context, prompt, context string, option util.ContentProcessOption) (string, error) {
 		seenPrompt = prompt
 		seenContext = context
 		assert.True(t, option.ConvertToMd)
@@ -60,7 +61,7 @@ func TestOptionAIContentProcessSupportsReplaceAndAppendPlacements(t *testing.T) 
 	setupTestRedis(t)
 
 	original := llmContextCaller
-	llmContextCaller = func(prompt, context string, option util.ContentProcessOption) (string, error) {
+	llmContextCaller = func(_ context.Context, prompt, context string, option util.ContentProcessOption) (string, error) {
 		return "### Generated\n\nreplacement or appendix", nil
 	}
 	t.Cleanup(func() { llmContextCaller = original })
@@ -108,7 +109,7 @@ func TestOptionAIContentProcessCacheKeyIncludesPlacement(t *testing.T) {
 	setupTestRedis(t)
 
 	original := llmContextCaller
-	llmContextCaller = func(prompt, context string, option util.ContentProcessOption) (string, error) {
+	llmContextCaller = func(_ context.Context, prompt, context string, option util.ContentProcessOption) (string, error) {
 		return "Generated note", nil
 	}
 	t.Cleanup(func() { llmContextCaller = original })
@@ -138,7 +139,7 @@ func TestOptionAIContentProcessCacheKeyIncludesArticleDatePayload(t *testing.T) 
 
 	original := llmContextCaller
 	calls := 0
-	llmContextCaller = func(prompt, context string, option util.ContentProcessOption) (string, error) {
+	llmContextCaller = func(_ context.Context, prompt, context string, option util.ContentProcessOption) (string, error) {
 		calls += 1
 		if strings.Contains(context, "2026-05-02") {
 			return "Generated for May 2", nil
@@ -182,7 +183,7 @@ func TestAIContentProcessCraftLoadParamUsesDefaultsAndRegistersTemplate(t *testi
 
 	original := llmContextCaller
 	var seenContext string
-	llmContextCaller = func(prompt, context string, option util.ContentProcessOption) (string, error) {
+	llmContextCaller = func(_ context.Context, prompt, context string, option util.ContentProcessOption) (string, error) {
 		seenContext = context
 		return "Generated default summary", nil
 	}

--- a/internal/craft/ai_filter.go
+++ b/internal/craft/ai_filter.go
@@ -7,6 +7,7 @@ import (
 
 	"FeedCraft/internal/constant"
 	"FeedCraft/internal/util"
+	"context"
 
 	"github.com/gorilla/feeds"
 	"github.com/samber/lo"
@@ -157,15 +158,15 @@ Examples:
 {"reason":"The article is unrelated to the requested topic.","result":"drop"}`, rule)
 }
 
-func cachedAIFilterDecision(title string, prompt string, context string) (aiFilterDecision, error) {
+func cachedAIFilterDecision(title string, prompt string, articleContext string) (aiFilterDecision, error) {
 	hashVal := util.GetTextContentHash(strings.Join([]string{
 		util.GetTextContentHash(prompt),
-		util.GetTextContentHash(context),
+		util.GetTextContentHash(articleContext),
 	}, "|"))
 	cacheKey := getCraftCacheKey("ai-filter", hashVal)
 
 	cached, err := util.CachedFuncWithPreLog(cacheKey, func() (string, error) {
-		result, err := llmContextCaller(prompt, context, util.ContentProcessOption{
+		result, err := llmContextCaller(context.Background(), prompt, articleContext, util.ContentProcessOption{
 			RemoveImage: true,
 			ConvertToMd: true,
 			Temperature: util.LowestLLMTemperaturePtr(),
@@ -254,7 +255,7 @@ func generateAIFilterArticleSummary(item *feeds.Item) (string, error) {
 		if strings.TrimSpace(cleanedContent) != "" {
 			processedContent = cleanedContent
 		}
-		return llmContextCaller(summaryPrompt, processedContent, util.ContentProcessOption{
+		return llmContextCaller(context.Background(), summaryPrompt, processedContent, util.ContentProcessOption{
 			Temperature: util.LowestLLMTemperaturePtr(),
 		})
 	}, func(isCached bool) {

--- a/internal/craft/ai_filter.go
+++ b/internal/craft/ai_filter.go
@@ -72,7 +72,7 @@ func OptionAIFilter(rule string, extraPayloadRaw string) LegacyCraftOption {
 		}
 
 		drops := parallel.Map(items, func(item *feeds.Item, _ int) bool {
-			decision, err := evaluateAIFilterItem(item, rule, payloadTypes)
+			decision, err := evaluateAIFilterItem(payload.Context(), item, rule, payloadTypes)
 			if err != nil {
 				logrus.Warnf("failed to evaluate ai-filter for article [%s], err: %v", item.Title, err)
 				return false
@@ -87,10 +87,10 @@ func OptionAIFilter(rule string, extraPayloadRaw string) LegacyCraftOption {
 	}
 }
 
-func evaluateAIFilterItem(item *feeds.Item, rule string, payloadTypes []aiFilterExtraPayloadType) (aiFilterDecision, error) {
+func evaluateAIFilterItem(ctx context.Context, item *feeds.Item, rule string, payloadTypes []aiFilterExtraPayloadType) (aiFilterDecision, error) {
 	summary := ""
 	if lo.Contains(payloadTypes, aiFilterExtraPayloadArticleSummary) {
-		generated, err := generateAIFilterArticleSummary(item)
+		generated, err := generateAIFilterArticleSummary(ctx, item)
 		if err != nil {
 			return aiFilterDecision{}, err
 		}
@@ -102,7 +102,7 @@ func evaluateAIFilterItem(item *feeds.Item, rule string, payloadTypes []aiFilter
 		return aiFilterDecision{}, err
 	}
 
-	return cachedAIFilterDecision(item.Title, buildAIFilterPrompt(rule), context)
+	return cachedAIFilterDecision(ctx, item.Title, buildAIFilterPrompt(rule), context)
 }
 
 func parseAIFilterExtraPayload(raw string) []aiFilterExtraPayloadType {
@@ -158,15 +158,15 @@ Examples:
 {"reason":"The article is unrelated to the requested topic.","result":"drop"}`, rule)
 }
 
-func cachedAIFilterDecision(title string, prompt string, articleContext string) (aiFilterDecision, error) {
+func cachedAIFilterDecision(ctx context.Context, title string, prompt string, articleContext string) (aiFilterDecision, error) {
 	hashVal := util.GetTextContentHash(strings.Join([]string{
 		util.GetTextContentHash(prompt),
 		util.GetTextContentHash(articleContext),
 	}, "|"))
 	cacheKey := getCraftCacheKey("ai-filter", hashVal)
 
-	cached, err := util.CachedFuncWithPreLog(cacheKey, func() (string, error) {
-		result, err := llmContextCaller(context.Background(), prompt, articleContext, util.ContentProcessOption{
+	cached, err := util.CachedFuncWithPreLogContext(ctx, cacheKey, func(sharedCtx context.Context) (string, error) {
+		result, err := llmContextCaller(sharedCtx, prompt, articleContext, util.ContentProcessOption{
 			RemoveImage: true,
 			ConvertToMd: true,
 			Temperature: util.LowestLLMTemperaturePtr(),
@@ -229,7 +229,7 @@ func buildAIFilterArticlePayload(item *feeds.Item, payloadTypes []aiFilterExtraP
 	return builder.String(), nil
 }
 
-func generateAIFilterArticleSummary(item *feeds.Item) (string, error) {
+func generateAIFilterArticleSummary(ctx context.Context, item *feeds.Item) (string, error) {
 	content := getPrimaryFeedItemContent(item)
 	if strings.TrimSpace(content) == "" {
 		return "", nil
@@ -243,7 +243,7 @@ func generateAIFilterArticleSummary(item *feeds.Item) (string, error) {
 	}, "|"))
 	cacheKey := getCraftCacheKey("ai-filter-article-summary", hashVal)
 
-	return util.CachedFuncWithPreLog(cacheKey, func() (string, error) {
+	return util.CachedFuncWithPreLogContext(ctx, cacheKey, func(sharedCtx context.Context) (string, error) {
 		processedContent := content
 		domain := ""
 		if item.Link != nil {
@@ -255,7 +255,7 @@ func generateAIFilterArticleSummary(item *feeds.Item) (string, error) {
 		if strings.TrimSpace(cleanedContent) != "" {
 			processedContent = cleanedContent
 		}
-		return llmContextCaller(context.Background(), summaryPrompt, processedContent, util.ContentProcessOption{
+		return llmContextCaller(sharedCtx, summaryPrompt, processedContent, util.ContentProcessOption{
 			Temperature: util.LowestLLMTemperaturePtr(),
 		})
 	}, func(isCached bool) {

--- a/internal/craft/ai_filter_test.go
+++ b/internal/craft/ai_filter_test.go
@@ -157,9 +157,9 @@ func TestEvaluateAIFilterItemCachesDecision(t *testing.T) {
 	}
 	payloadTypes := []aiFilterExtraPayloadType{aiFilterExtraPayloadArticleContent}
 
-	first, err := evaluateAIFilterItem(item, "只保留科技有关的文章", payloadTypes)
+	first, err := evaluateAIFilterItem(context.Background(), item, "只保留科技有关的文章", payloadTypes)
 	require.NoError(t, err)
-	second, err := evaluateAIFilterItem(item, "只保留科技有关的文章", payloadTypes)
+	second, err := evaluateAIFilterItem(context.Background(), item, "只保留科技有关的文章", payloadTypes)
 	require.NoError(t, err)
 
 	assert.Equal(t, aiFilterResultKeep, first.Result)

--- a/internal/craft/ai_filter_test.go
+++ b/internal/craft/ai_filter_test.go
@@ -1,6 +1,7 @@
 package craft
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"sync"
@@ -46,7 +47,7 @@ func TestOptionAIFilterDropsOnlyDropDecisionAndUsesSummaryPayload(t *testing.T) 
 	var filterContexts []string
 	var summaryContexts []string
 	var seenMu sync.Mutex
-	llmContextCaller = func(prompt, context string, option util.ContentProcessOption) (string, error) {
+	llmContextCaller = func(_ context.Context, prompt, context string, option util.ContentProcessOption) (string, error) {
 		if strings.Contains(prompt, "professional summarizer") {
 			seenMu.Lock()
 			summaryContexts = append(summaryContexts, context)
@@ -91,7 +92,7 @@ func TestOptionAIFilterKeepsArticleOnInvalidLLMResponse(t *testing.T) {
 	setupTestRedis(t)
 
 	original := llmContextCaller
-	llmContextCaller = func(prompt, context string, option util.ContentProcessOption) (string, error) {
+	llmContextCaller = func(_ context.Context, prompt, context string, option util.ContentProcessOption) (string, error) {
 		require.NotNil(t, option.Temperature)
 		assert.Equal(t, 0.0, *option.Temperature)
 		return "not json", nil
@@ -115,7 +116,7 @@ func TestAIFilterCraftLoadParamUsesRuleParam(t *testing.T) {
 	setupTestRedis(t)
 
 	original := llmContextCaller
-	llmContextCaller = func(prompt, context string, option util.ContentProcessOption) (string, error) {
+	llmContextCaller = func(_ context.Context, prompt, context string, option util.ContentProcessOption) (string, error) {
 		assert.Contains(t, prompt, "只保留科技有关的文章")
 		return `{"reason":"not a tech article","result":"drop"}`, nil
 	}
@@ -144,7 +145,7 @@ func TestEvaluateAIFilterItemCachesDecision(t *testing.T) {
 
 	original := llmContextCaller
 	filterCalls := 0
-	llmContextCaller = func(prompt, context string, option util.ContentProcessOption) (string, error) {
+	llmContextCaller = func(_ context.Context, prompt, context string, option util.ContentProcessOption) (string, error) {
 		filterCalls += 1
 		return `{"reason":"cached decision","result":"keep"}`, nil
 	}

--- a/internal/craft/beautify.go
+++ b/internal/craft/beautify.go
@@ -3,6 +3,7 @@ package craft
 import (
 	"FeedCraft/internal/adapter"
 	"FeedCraft/internal/util"
+	"context"
 	"fmt"
 	"strings"
 
@@ -10,7 +11,7 @@ import (
 )
 
 // llmCaller is a variable to allow mocking in tests
-var llmCaller = adapter.SimpleLLMCall
+var llmCaller = adapter.SimpleLLMCallContext
 
 const beautifyArticleContentPrompt = `
 You are a professional editor. Your task is to reformat the following article content into clean, standard Markdown.
@@ -24,17 +25,17 @@ Follow these rules:
 6. Return ONLY the Markdown content. Do not include any explanations or conversational text.
 `
 
-func beautifyArticleContent(content string, prompt string) (string, error) {
+func beautifyArticleContent(ctx context.Context, content string, prompt string) (string, error) {
 	// 1. Prepare prompt with original HTML content
 	// Check if content is empty
 	if strings.TrimSpace(content) == "" {
 		return "", fmt.Errorf("empty content")
 	}
 
-	finalPrompt := fmt.Sprintf("%s\n\n---\n\n%s", prompt, content)
+	finalPrompt := fmt.Sprintf("%s\n\n---\n\n%s", prompt, util.TruncateHeadTail(content, util.LLMPromptMaxChars()))
 
 	// 2. Call LLM to beautify the content and convert to Markdown
-	beautifiedMd, err := llmCaller(adapter.UseDefaultModel, finalPrompt)
+	beautifiedMd, err := llmCaller(ctx, adapter.UseDefaultModel, finalPrompt)
 	if err != nil {
 		return "", err
 	}
@@ -49,7 +50,7 @@ func GetBeautifyContentCraftOptions(prompt string) []LegacyCraftOption {
 		if content == "" {
 			content = item.Description
 		}
-		return beautifyArticleContent(content, prompt)
+		return beautifyArticleContent(context.Background(), content, prompt)
 	}
 
 	cachedTransformer := GetCommonCachedTransformer(

--- a/internal/craft/beautify.go
+++ b/internal/craft/beautify.go
@@ -32,7 +32,7 @@ func beautifyArticleContent(ctx context.Context, content string, prompt string) 
 		return "", fmt.Errorf("empty content")
 	}
 
-	finalPrompt := fmt.Sprintf("%s\n\n---\n\n%s", prompt, util.TruncateHeadTail(content, util.LLMPromptMaxChars()))
+	finalPrompt := util.TruncateHeadTail(fmt.Sprintf("%s\n\n---\n\n%s", prompt, content), util.LLMPromptMaxChars())
 
 	// 2. Call LLM to beautify the content and convert to Markdown
 	beautifiedMd, err := llmCaller(ctx, adapter.UseDefaultModel, finalPrompt)
@@ -45,19 +45,19 @@ func beautifyArticleContent(ctx context.Context, content string, prompt string) 
 
 // GetBeautifyContentCraftOptions returns the craft options for beautification
 func GetBeautifyContentCraftOptions(prompt string) []LegacyCraftOption {
-	transFunc := func(item *feeds.Item) (string, error) {
+	transFunc := func(ctx context.Context, item *feeds.Item) (string, error) {
 		content := item.Content
 		if content == "" {
 			content = item.Description
 		}
-		return beautifyArticleContent(context.Background(), content, prompt)
+		return beautifyArticleContent(ctx, content, prompt)
 	}
 
-	cachedTransformer := GetCommonCachedTransformer(
+	cachedTransformer := GetCommonCachedTransformerWithContext(
 		cacheKeyForArticleContent, transFunc, "beautify article content")
 
 	craftOption := []LegacyCraftOption{
-		OptionTransformFeedItem(GetArticleContentProcessor(cachedTransformer)),
+		OptionTransformFeedItem(GetArticleContentProcessorWithContext(cachedTransformer)),
 	}
 	return craftOption
 }

--- a/internal/craft/common.go
+++ b/internal/craft/common.go
@@ -5,6 +5,7 @@ import (
 	"FeedCraft/internal/constant"
 	"FeedCraft/internal/source"
 	"FeedCraft/internal/util"
+	"context"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -128,25 +129,37 @@ func CommonCraftHandlerUsingCraftOptionList(c *gin.Context, optionList []LegacyC
 type RawTransformer func(item *feeds.Item) (string, error)
 
 func GetCommonCachedTransformer(cacheKeyGenerator ContentCacheKeyGenerator, rawTransformer TransFunc, craftName string) TransFunc {
-	ret := func(item *feeds.Item) (string, error) {
+	contextual := GetCommonCachedTransformerWithContext(
+		cacheKeyGenerator,
+		func(_ context.Context, item *feeds.Item) (string, error) {
+			return rawTransformer(item)
+		},
+		craftName,
+	)
+	return func(item *feeds.Item) (string, error) {
+		return contextual(context.Background(), item)
+	}
+}
+
+func GetCommonCachedTransformerWithContext(cacheKeyGenerator ContentCacheKeyGenerator, rawTransformer ContextTransFunc, craftName string) ContextTransFunc {
+	return func(ctx context.Context, item *feeds.Item) (string, error) {
 		originalTitle := item.Title
 
 		hashVal, _ := cacheKeyGenerator(item)
 		cacheKey := getCraftCacheKey(craftName, hashVal)
 
-		valFunc := func() (string, error) {
-			ret, err := rawTransformer(item)
+		valFunc := func(sharedCtx context.Context) (string, error) {
+			ret, err := rawTransformer(sharedCtx, item)
 			if err != nil {
 				logrus.Warnf("failed to apply craft [%s] for article [%s], err: %v\n", craftName, originalTitle, err)
 			}
 			return ret, err
 		}
 
-		return util.CachedFuncWithPreLog(cacheKey, valFunc, func(isCached bool) {
+		return util.CachedFuncWithPreLogContext(ctx, cacheKey, valFunc, func(isCached bool) {
 			logrus.Infof("applying craft [%s] to article [%s], cached: %v", craftName, originalTitle, isCached)
 		})
 	}
-	return ret
 }
 
 func TransformArticleContent(item *gofeed.Item, transFunc func(item *gofeed.Item) string) *feeds.Item {

--- a/internal/craft/common_llm_logic.go
+++ b/internal/craft/common_llm_logic.go
@@ -3,13 +3,14 @@ package craft
 import (
 	"FeedCraft/internal/adapter"
 	"FeedCraft/internal/util"
+	"context"
 	"fmt"
 	"strings"
 
 	"github.com/sirupsen/logrus"
 )
 
-var llmContextCaller = adapter.CallLLMUsingContext
+var llmContextCaller = adapter.CallLLMUsingRequestContext
 
 // CheckConditionWithLLM 检查文章内容是否符合特定条件
 // prompt: 用户提供的 prompt 模板，必须明确要求返回 'true' 或 'false'
@@ -18,7 +19,7 @@ var llmContextCaller = adapter.CallLLMUsingContext
 // 返回值: (bool, error)
 // true: 表示符合条件
 // false: 表示不符合条件或无法判断
-func CheckConditionWithLLM(title string, content string, conditionPrompt string) (bool, error) {
+func CheckConditionWithLLM(ctx context.Context, title string, content string, conditionPrompt string) (bool, error) {
 	const MinContentLength = 20
 	if len(strings.TrimSpace(content)) < MinContentLength {
 		return false, nil
@@ -34,7 +35,7 @@ func CheckConditionWithLLM(title string, content string, conditionPrompt string)
 
 	contextData := BuildLLMArticlePayload(title, content)
 
-	result, err := llmContextCaller(conditionPrompt, contextData, option)
+	result, err := llmContextCaller(ctx, conditionPrompt, contextData, option)
 	if err != nil {
 		logrus.Errorf("Error checking condition with LLM: %v", err)
 		return false, err
@@ -70,8 +71,8 @@ func BuildLLMArticlePayload(title string, content string) string {
 
 // CheckConditionWithGenericPrompt 使用通用模板构造 prompt 并调用 LLM
 // userPrompt: 用户提供的判断标准，例如 "Is this regarding politics?"
-func CheckConditionWithGenericPrompt(title string, content string, userPrompt string) (bool, error) {
-	return CheckConditionWithLLM(title, content, buildGenericConditionPrompt(userPrompt))
+func CheckConditionWithGenericPrompt(ctx context.Context, title string, content string, userPrompt string) (bool, error) {
+	return CheckConditionWithLLM(ctx, title, content, buildGenericConditionPrompt(userPrompt))
 }
 
 func buildGenericConditionPrompt(userPrompt string) string {

--- a/internal/craft/content_processors.go
+++ b/internal/craft/content_processors.go
@@ -170,8 +170,8 @@ func GetCommonCachedArticleTransformer(cacheKeyGenerator ArticleCacheKeyGenerato
 			return "", err
 		}
 		cacheKey := getCraftCacheKey(craftName, hashVal)
-		return util.CachedFuncWithPreLog(cacheKey, func() (string, error) {
-			return rawTransformer(ctx, article)
+		return util.CachedFuncWithPreLogContext(ctx, cacheKey, func(sharedCtx context.Context) (string, error) {
+			return rawTransformer(sharedCtx, article)
 		}, func(isCached bool) {
 			logrus.Infof("applying craft [%s] to article [%s], cached: %v", craftName, article.Title, isCached)
 		})

--- a/internal/craft/llm_condition_test.go
+++ b/internal/craft/llm_condition_test.go
@@ -1,6 +1,7 @@
 package craft
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"testing"
@@ -14,13 +15,13 @@ import (
 func TestCheckConditionWithLLM_ShortContentSkipsLLM(t *testing.T) {
 	called := false
 	original := llmContextCaller
-	llmContextCaller = func(prompt, context string, option util.ContentProcessOption) (string, error) {
+	llmContextCaller = func(_ context.Context, prompt, context string, option util.ContentProcessOption) (string, error) {
 		called = true
 		return "true", nil
 	}
 	t.Cleanup(func() { llmContextCaller = original })
 
-	result, err := CheckConditionWithLLM("title", "short", "is this spam?")
+	result, err := CheckConditionWithLLM(context.Background(), "title", "short", "is this spam?")
 	require.NoError(t, err)
 	assert.False(t, result)
 	assert.False(t, called, "LLM should not be called for content shorter than the minimum length")
@@ -41,12 +42,12 @@ func TestCheckConditionWithLLM_ParsesTrueFalseResponses(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			original := llmContextCaller
-			llmContextCaller = func(prompt, context string, option util.ContentProcessOption) (string, error) {
+			llmContextCaller = func(_ context.Context, prompt, context string, option util.ContentProcessOption) (string, error) {
 				return tc.response, nil
 			}
 			t.Cleanup(func() { llmContextCaller = original })
 
-			result, err := CheckConditionWithLLM("title", strings.Repeat("content ", 10), "is this spam?")
+			result, err := CheckConditionWithLLM(context.Background(), "title", strings.Repeat("content ", 10), "is this spam?")
 			require.NoError(t, err)
 			assert.Equal(t, tc.want, result)
 		})
@@ -55,12 +56,12 @@ func TestCheckConditionWithLLM_ParsesTrueFalseResponses(t *testing.T) {
 
 func TestCheckConditionWithLLM_UnexpectedResponseReturnsError(t *testing.T) {
 	original := llmContextCaller
-	llmContextCaller = func(prompt, context string, option util.ContentProcessOption) (string, error) {
+	llmContextCaller = func(_ context.Context, prompt, context string, option util.ContentProcessOption) (string, error) {
 		return "maybe", nil
 	}
 	t.Cleanup(func() { llmContextCaller = original })
 
-	result, err := CheckConditionWithLLM("title", strings.Repeat("content ", 10), "is this spam?")
+	result, err := CheckConditionWithLLM(context.Background(), "title", strings.Repeat("content ", 10), "is this spam?")
 	require.Error(t, err)
 	assert.False(t, result)
 	assert.Contains(t, err.Error(), "unexpected llm response")
@@ -68,12 +69,12 @@ func TestCheckConditionWithLLM_UnexpectedResponseReturnsError(t *testing.T) {
 
 func TestCheckConditionWithLLM_PropagatesLLMError(t *testing.T) {
 	original := llmContextCaller
-	llmContextCaller = func(prompt, context string, option util.ContentProcessOption) (string, error) {
+	llmContextCaller = func(_ context.Context, prompt, context string, option util.ContentProcessOption) (string, error) {
 		return "", fmt.Errorf("upstream timeout")
 	}
 	t.Cleanup(func() { llmContextCaller = original })
 
-	result, err := CheckConditionWithLLM("title", strings.Repeat("content ", 10), "is this spam?")
+	result, err := CheckConditionWithLLM(context.Background(), "title", strings.Repeat("content ", 10), "is this spam?")
 	require.Error(t, err)
 	assert.False(t, result)
 	assert.Contains(t, err.Error(), "upstream timeout")
@@ -82,13 +83,13 @@ func TestCheckConditionWithLLM_PropagatesLLMError(t *testing.T) {
 func TestCheckConditionWithGenericPrompt_WrapsUserCriterion(t *testing.T) {
 	var capturedPrompt string
 	original := llmContextCaller
-	llmContextCaller = func(prompt, context string, option util.ContentProcessOption) (string, error) {
+	llmContextCaller = func(_ context.Context, prompt, context string, option util.ContentProcessOption) (string, error) {
 		capturedPrompt = prompt
 		return "true", nil
 	}
 	t.Cleanup(func() { llmContextCaller = original })
 
-	result, err := CheckConditionWithGenericPrompt("title", strings.Repeat("content ", 10), "Is this about sports?")
+	result, err := CheckConditionWithGenericPrompt(context.Background(), "title", strings.Repeat("content ", 10), "Is this about sports?")
 	require.NoError(t, err)
 	assert.True(t, result)
 	assert.Contains(t, capturedPrompt, "Is this about sports?")

--- a/internal/craft/llm_filter.go
+++ b/internal/craft/llm_filter.go
@@ -1,8 +1,6 @@
 package craft
 
 import (
-	"context"
-
 	"github.com/gorilla/feeds"
 	"github.com/samber/lo"
 	"github.com/samber/lo/parallel"
@@ -45,7 +43,7 @@ func OptionLLMFilterGeneric(condition string) LegacyCraftOption {
 			if len(content) == 0 {
 				content = itm.Description
 			}
-			match, err := CheckConditionWithGenericPrompt(context.Background(), itm.Title, content, condition)
+			match, err := CheckConditionWithGenericPrompt(payload.Context(), itm.Title, content, condition)
 			if err != nil {
 				return false
 			}

--- a/internal/craft/llm_filter.go
+++ b/internal/craft/llm_filter.go
@@ -1,6 +1,8 @@
 package craft
 
 import (
+	"context"
+
 	"github.com/gorilla/feeds"
 	"github.com/samber/lo"
 	"github.com/samber/lo/parallel"
@@ -43,7 +45,7 @@ func OptionLLMFilterGeneric(condition string) LegacyCraftOption {
 			if len(content) == 0 {
 				content = itm.Description
 			}
-			match, err := CheckConditionWithGenericPrompt(itm.Title, content, condition)
+			match, err := CheckConditionWithGenericPrompt(context.Background(), itm.Title, content, condition)
 			if err != nil {
 				return false
 			}

--- a/internal/craft/llm_legacy_filter_test.go
+++ b/internal/craft/llm_legacy_filter_test.go
@@ -1,6 +1,7 @@
 package craft
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"testing"
@@ -16,7 +17,7 @@ const longBody = "this article body is long enough to exceed the minimum content
 
 func TestOptionIgnoreAdvertorial_RemovesArticlesMarkedAsAds(t *testing.T) {
 	original := llmContextCaller
-	llmContextCaller = func(prompt, context string, option util.ContentProcessOption) (string, error) {
+	llmContextCaller = func(_ context.Context, prompt, context string, option util.ContentProcessOption) (string, error) {
 		if strings.Contains(context, "Sponsored Deal") {
 			return "true", nil
 		}
@@ -40,7 +41,7 @@ func TestOptionIgnoreAdvertorial_RemovesArticlesMarkedAsAds(t *testing.T) {
 func TestOptionIgnoreAdvertorial_UsesDescriptionWhenContentEmpty(t *testing.T) {
 	var seenContexts []string
 	original := llmContextCaller
-	llmContextCaller = func(prompt, context string, option util.ContentProcessOption) (string, error) {
+	llmContextCaller = func(_ context.Context, prompt, context string, option util.ContentProcessOption) (string, error) {
 		seenContexts = append(seenContexts, context)
 		return "false", nil
 	}
@@ -61,7 +62,7 @@ func TestOptionIgnoreAdvertorial_UsesDescriptionWhenContentEmpty(t *testing.T) {
 
 func TestOptionIgnoreAdvertorial_KeepsArticleOnLLMError(t *testing.T) {
 	original := llmContextCaller
-	llmContextCaller = func(prompt, context string, option util.ContentProcessOption) (string, error) {
+	llmContextCaller = func(_ context.Context, prompt, context string, option util.ContentProcessOption) (string, error) {
 		return "", fmt.Errorf("llm down")
 	}
 	t.Cleanup(func() { llmContextCaller = original })
@@ -86,7 +87,7 @@ func TestOptionIgnoreAdvertorial_EmptyFeedIsNoop(t *testing.T) {
 
 func TestOptionLLMFilterGeneric_RemovesMatchingArticles(t *testing.T) {
 	original := llmContextCaller
-	llmContextCaller = func(prompt, context string, option util.ContentProcessOption) (string, error) {
+	llmContextCaller = func(_ context.Context, prompt, context string, option util.ContentProcessOption) (string, error) {
 		if strings.Contains(context, "Sports") {
 			return "true", nil
 		}
@@ -108,7 +109,7 @@ func TestOptionLLMFilterGeneric_RemovesMatchingArticles(t *testing.T) {
 
 func TestOptionLLMFilterGeneric_KeepsArticleWhenLLMErrors(t *testing.T) {
 	original := llmContextCaller
-	llmContextCaller = func(prompt, context string, option util.ContentProcessOption) (string, error) {
+	llmContextCaller = func(_ context.Context, prompt, context string, option util.ContentProcessOption) (string, error) {
 		return "", fmt.Errorf("llm error")
 	}
 	t.Cleanup(func() { llmContextCaller = original })

--- a/internal/craft/llm_legacy_filter_test.go
+++ b/internal/craft/llm_legacy_filter_test.go
@@ -5,7 +5,9 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 
+	"FeedCraft/internal/model"
 	"FeedCraft/internal/util"
 
 	"github.com/gorilla/feeds"
@@ -123,4 +125,29 @@ func TestOptionLLMFilterGeneric_KeepsArticleWhenLLMErrors(t *testing.T) {
 	option := OptionLLMFilterGeneric("Is this spam?")
 	require.NoError(t, option(feed, ExtraPayload{}))
 	assert.Equal(t, []string{"Kept On Error"}, itemTitles(feed.Items))
+}
+
+func TestAdaptLegacyOption_PropagatesContextToLLMFilter(t *testing.T) {
+	original := llmContextCaller
+	seen := make(chan context.Context, 1)
+	llmContextCaller = func(ctx context.Context, prompt, articleContext string, option util.ContentProcessOption) (string, error) {
+		seen <- ctx
+		return "", ctx.Err()
+	}
+	t.Cleanup(func() { llmContextCaller = original })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	adapted := AdaptLegacyOption(OptionLLMFilterGeneric("Is this spam?"), ExtraPayload{})
+	_, err := adapted(ctx, &model.CraftFeed{
+		Articles: []*model.CraftArticle{{Title: "Article", Content: longBody}},
+	})
+	require.NoError(t, err)
+
+	select {
+	case callCtx := <-seen:
+		require.ErrorIs(t, callCtx.Err(), context.Canceled)
+	case <-time.After(time.Second):
+		t.Fatal("legacy LLM call did not receive request context")
+	}
 }

--- a/internal/craft/llm_processors.go
+++ b/internal/craft/llm_processors.go
@@ -83,13 +83,13 @@ func (p *ArticlePredicateProcessor) Process(ctx context.Context, feed *model.Cra
 	return cloned, nil
 }
 
-func CallLLMForArticleTransform(prompt, title, content string, option util.ContentProcessOption) (string, error) {
+func CallLLMForArticleTransform(ctx context.Context, prompt, title, content string, option util.ContentProcessOption) (string, error) {
 	contextData := BuildLLMArticlePayload(title, content)
-	return llmContextCaller(prompt, contextData, option)
+	return llmContextCaller(ctx, prompt, contextData, option)
 }
 
-func CallLLMForArticlePredicate(prompt, title, content string) (bool, error) {
-	return CheckConditionWithLLM(title, content, prompt)
+func CallLLMForArticlePredicate(ctx context.Context, prompt, title, content string) (bool, error) {
+	return CheckConditionWithLLM(ctx, title, content, prompt)
 }
 
 func newSummaryProcessor(prompt string) *ArticleTextTransformProcessor {
@@ -102,7 +102,7 @@ func newSummaryProcessor(prompt string) *ArticleTextTransformProcessor {
 				return "", nil
 			}
 			processed := getArticleContentForPrompt(article, original)
-			generated, err := CallLLMForArticleTransform(finalPrompt, article.Title, processed, util.ContentProcessOption{})
+			generated, err := CallLLMForArticleTransform(ctx, finalPrompt, article.Title, processed, util.ContentProcessOption{})
 			if err != nil {
 				return "", err
 			}
@@ -139,7 +139,7 @@ func newIntroductionProcessor(prompt string) *ArticleTextTransformProcessor {
 				return "", nil
 			}
 			processed := getArticleContentForPrompt(article, original)
-			generated, err := CallLLMForArticleTransform(finalPrompt, article.Title, processed, util.ContentProcessOption{})
+			generated, err := CallLLMForArticleTransform(ctx, finalPrompt, article.Title, processed, util.ContentProcessOption{})
 			if err != nil {
 				return "", err
 			}
@@ -176,7 +176,7 @@ func newTranslateTitleProcessor(prompt string) *ArticleTextTransformProcessor {
 			if title == "" || util.IsSameLanguage(title, targetLangCode) {
 				return title, nil
 			}
-			return CallLLMForArticleTransform(finalPrompt, "", title, util.ContentProcessOption{})
+			return CallLLMForArticleTransform(ctx, finalPrompt, "", title, util.ContentProcessOption{})
 		},
 		"translate title",
 	)
@@ -205,7 +205,7 @@ func newRetitleProcessor(prompt string) *ArticleTextTransformProcessor {
 				return originalTitle, nil
 			}
 			contentForPrompt := getArticleContentForPrompt(article, originalContent)
-			generated, err := CallLLMForArticleTransform(finalPrompt, originalTitle, contentForPrompt, util.ContentProcessOption{})
+			generated, err := CallLLMForArticleTransform(ctx, finalPrompt, originalTitle, contentForPrompt, util.ContentProcessOption{})
 			if err != nil {
 				return "", err
 			}
@@ -248,7 +248,7 @@ func newArticleContentLLMProcessor(craftName, prompt, defaultPrompt string) *Art
 			if strings.TrimSpace(content) == "" || util.IsSameLanguage(content, targetLangCode) {
 				return content, nil
 			}
-			return CallLLMForArticleTransform(finalPrompt, "", content, util.ContentProcessOption{})
+			return CallLLMForArticleTransform(ctx, finalPrompt, "", content, util.ContentProcessOption{})
 		},
 		craftName,
 	)
@@ -279,7 +279,7 @@ func newBeautifyContentProcessor(prompt string) *ArticleTextTransformProcessor {
 			if strings.TrimSpace(content) == "" {
 				return "", nil
 			}
-			return beautifyArticleContent(content, finalPrompt)
+			return beautifyArticleContent(ctx, content, finalPrompt)
 		},
 		"beautify article content",
 	)
@@ -310,7 +310,7 @@ func newLLMFilterProcessor(condition string) *ArticlePredicateProcessor {
 		}),
 		func(ctx context.Context, article *model.CraftArticle) (bool, error) {
 			content := getPrimaryArticleContent(article)
-			return CheckConditionWithLLM(article.Title, content, fullPrompt)
+			return CheckConditionWithLLM(ctx, article.Title, content, fullPrompt)
 		},
 		"llm filter",
 	)
@@ -329,7 +329,7 @@ func newIgnoreAdvertorialProcessor(prompt string) *ArticlePredicateProcessor {
 		newArticleTitleContentCacheKeyGenerator(finalPrompt),
 		func(ctx context.Context, article *model.CraftArticle) (bool, error) {
 			content := getPrimaryArticleContent(article)
-			return CallLLMForArticlePredicate(finalPrompt, article.Title, content)
+			return CallLLMForArticlePredicate(ctx, finalPrompt, article.Title, content)
 		},
 		"ignore advertorial",
 	)
@@ -432,9 +432,9 @@ func getArticleContentForPrompt(article *model.CraftArticle, original string) st
 	domain, _ := util.ParseDomainFromUrl(article.Link)
 	cleaned := util.HTMLToMarkdown(original, domain)
 	if strings.TrimSpace(cleaned) != "" {
-		return cleaned
+		return util.TruncateHeadTail(cleaned, util.LLMPromptMaxChars())
 	}
-	return original
+	return util.TruncateHeadTail(original, util.LLMPromptMaxChars())
 }
 
 func combineArticleHTMLWithGeneratedMarkdown(originalHTML string, generatedMarkdown string) string {

--- a/internal/craft/llm_processors.go
+++ b/internal/craft/llm_processors.go
@@ -346,8 +346,8 @@ func GetCommonCachedArticlePredicate(cacheKeyGenerator ArticleCacheKeyGenerator,
 			return false, err
 		}
 		cacheKey := getCraftCacheKey(craftName, hashVal)
-		value, err := util.CachedFunc(cacheKey, func() (string, error) {
-			matched, callErr := rawPredicate(ctx, article)
+		value, err := util.CachedFuncContext(ctx, cacheKey, func(sharedCtx context.Context) (string, error) {
+			matched, callErr := rawPredicate(sharedCtx, article)
 			if callErr != nil {
 				return "", callErr
 			}
@@ -432,9 +432,9 @@ func getArticleContentForPrompt(article *model.CraftArticle, original string) st
 	domain, _ := util.ParseDomainFromUrl(article.Link)
 	cleaned := util.HTMLToMarkdown(original, domain)
 	if strings.TrimSpace(cleaned) != "" {
-		return util.TruncateHeadTail(cleaned, util.LLMPromptMaxChars())
+		return cleaned
 	}
-	return util.TruncateHeadTail(original, util.LLMPromptMaxChars())
+	return original
 }
 
 func combineArticleHTMLWithGeneratedMarkdown(originalHTML string, generatedMarkdown string) string {

--- a/internal/craft/llm_processors_test.go
+++ b/internal/craft/llm_processors_test.go
@@ -7,6 +7,7 @@ import (
 	"FeedCraft/internal/model"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 const testTinyBase64PNG = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg=="
@@ -50,4 +51,20 @@ func TestGetArticleContentForPrompt_KeepsNormalImages(t *testing.T) {
 		strings.Contains(result, "example.com/pic.png") || strings.Contains(result, "diagram"),
 		"normal image reference should be preserved",
 	)
+}
+
+func TestGetArticleContentForPrompt_TruncatesLongContent(t *testing.T) {
+	t.Setenv("FC_LLM_PROMPT_MAX_CHARS", "80")
+	article := &model.CraftArticle{
+		Title: "Long",
+		Link:  "https://example.com/post/3",
+	}
+	original := "<p>" + strings.Repeat("HeadContent", 20) + strings.Repeat("TailContent", 20) + "</p>"
+
+	result := getArticleContentForPrompt(article, original)
+
+	require.LessOrEqual(t, len([]rune(result)), 80)
+	assert.Contains(t, result, "[...truncated...]")
+	assert.Contains(t, result, "Head")
+	assert.Contains(t, result, "Tail")
 }

--- a/internal/craft/llm_processors_test.go
+++ b/internal/craft/llm_processors_test.go
@@ -53,7 +53,7 @@ func TestGetArticleContentForPrompt_KeepsNormalImages(t *testing.T) {
 	)
 }
 
-func TestGetArticleContentForPrompt_TruncatesLongContent(t *testing.T) {
+func TestGetArticleContentForPrompt_DefersTruncationToAdapterBoundary(t *testing.T) {
 	t.Setenv("FC_LLM_PROMPT_MAX_CHARS", "80")
 	article := &model.CraftArticle{
 		Title: "Long",
@@ -63,8 +63,8 @@ func TestGetArticleContentForPrompt_TruncatesLongContent(t *testing.T) {
 
 	result := getArticleContentForPrompt(article, original)
 
-	require.LessOrEqual(t, len([]rune(result)), 80)
-	assert.Contains(t, result, "[...truncated...]")
+	require.Greater(t, len([]rune(result)), 80)
+	assert.NotContains(t, result, "[...truncated...]")
 	assert.Contains(t, result, "Head")
 	assert.Contains(t, result, "Tail")
 }

--- a/internal/craft/option.go
+++ b/internal/craft/option.go
@@ -25,6 +25,14 @@ type CraftedFeed struct {
 // ExtraPayload extra info for crating feed
 type ExtraPayload struct {
 	originalFeedUrl string
+	ctx             context.Context
+}
+
+func (p ExtraPayload) Context() context.Context {
+	if p.ctx == nil {
+		return context.Background()
+	}
+	return p.ctx
 }
 
 type CraftOption func(ctx context.Context, feed *model.CraftFeed) (*model.CraftFeed, error)
@@ -97,6 +105,7 @@ func ComposeOptions(options ...CraftOption) CraftOption {
 
 // TransFunc common transform func, such as translate the article content or title
 type TransFunc func(item *feeds.Item) (string, error)
+type ContextTransFunc func(ctx context.Context, item *feeds.Item) (string, error)
 
 func GetArticleContentProcessor(transFunc TransFunc) FeedItemProcessor {
 	return func(item *feeds.Item, payload ExtraPayload) error {
@@ -113,6 +122,29 @@ func GetArticleContentProcessor(transFunc TransFunc) FeedItemProcessor {
 func GetArticleTitleProcessor(transFunc TransFunc) FeedItemProcessor {
 	return func(item *feeds.Item, payload ExtraPayload) error {
 		transformed, err := transFunc(item)
+		if err != nil {
+			return err
+		}
+		item.Title = transformed
+		return nil
+	}
+}
+
+func GetArticleContentProcessorWithContext(transFunc ContextTransFunc) FeedItemProcessor {
+	return func(item *feeds.Item, payload ExtraPayload) error {
+		transformed, err := transFunc(payload.Context(), item)
+		if err != nil {
+			return err
+		}
+		item.Content = transformed
+		item.Description = transformed
+		return nil
+	}
+}
+
+func GetArticleTitleProcessorWithContext(transFunc ContextTransFunc) FeedItemProcessor {
+	return func(item *feeds.Item, payload ExtraPayload) error {
+		transformed, err := transFunc(payload.Context(), item)
 		if err != nil {
 			return err
 		}

--- a/internal/craft/retitle.go
+++ b/internal/craft/retitle.go
@@ -1,6 +1,7 @@
 package craft
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -49,12 +50,13 @@ func getFeedsItemContentForPrompt(item *feeds.Item, original string) string {
 	if item.Link != nil {
 		link = item.Link.Href
 	}
+	original = util.RemoveBase64Images(original)
 	domain, _ := util.ParseDomainFromUrl(link)
 	cleaned := util.HTMLToMarkdown(original, domain)
 	if strings.TrimSpace(cleaned) != "" {
-		return cleaned
+		return util.TruncateHeadTail(cleaned, util.LLMPromptMaxChars())
 	}
-	return original
+	return util.TruncateHeadTail(original, util.LLMPromptMaxChars())
 }
 
 func GetRetitleCraftOptions(prompt string) []LegacyCraftOption {
@@ -81,7 +83,7 @@ func GetRetitleCraftOptions(prompt string) []LegacyCraftOption {
 			return originalTitle, nil
 		}
 		contentForPrompt := getFeedsItemContentForPrompt(item, originalContent)
-		generated, err := CallLLMForArticleTransform(finalPrompt, originalTitle, contentForPrompt, util.ContentProcessOption{})
+		generated, err := CallLLMForArticleTransform(context.Background(), finalPrompt, originalTitle, contentForPrompt, util.ContentProcessOption{})
 		if err != nil {
 			return "", err
 		}

--- a/internal/craft/retitle.go
+++ b/internal/craft/retitle.go
@@ -54,9 +54,9 @@ func getFeedsItemContentForPrompt(item *feeds.Item, original string) string {
 	domain, _ := util.ParseDomainFromUrl(link)
 	cleaned := util.HTMLToMarkdown(original, domain)
 	if strings.TrimSpace(cleaned) != "" {
-		return util.TruncateHeadTail(cleaned, util.LLMPromptMaxChars())
+		return cleaned
 	}
-	return util.TruncateHeadTail(original, util.LLMPromptMaxChars())
+	return original
 }
 
 func GetRetitleCraftOptions(prompt string) []LegacyCraftOption {
@@ -73,7 +73,7 @@ func GetRetitleCraftOptions(prompt string) []LegacyCraftOption {
 		}, "|"))
 		return payloadHash, nil
 	}
-	transFunc := func(item *feeds.Item) (string, error) {
+	transFunc := func(ctx context.Context, item *feeds.Item) (string, error) {
 		if item == nil {
 			return "", nil
 		}
@@ -83,7 +83,7 @@ func GetRetitleCraftOptions(prompt string) []LegacyCraftOption {
 			return originalTitle, nil
 		}
 		contentForPrompt := getFeedsItemContentForPrompt(item, originalContent)
-		generated, err := CallLLMForArticleTransform(context.Background(), finalPrompt, originalTitle, contentForPrompt, util.ContentProcessOption{})
+		generated, err := CallLLMForArticleTransform(ctx, finalPrompt, originalTitle, contentForPrompt, util.ContentProcessOption{})
 		if err != nil {
 			return "", err
 		}
@@ -92,9 +92,9 @@ func GetRetitleCraftOptions(prompt string) []LegacyCraftOption {
 		}
 		return strings.TrimSpace(generated), nil
 	}
-	transformer := GetCommonCachedTransformer(cacheKeyGenerator, transFunc, string(constant.ProcessorTypeRetitle))
+	transformer := GetCommonCachedTransformerWithContext(cacheKeyGenerator, transFunc, string(constant.ProcessorTypeRetitle))
 	return []LegacyCraftOption{
-		OptionTransformFeedItem(GetArticleTitleProcessor(transformer)),
+		OptionTransformFeedItem(GetArticleTitleProcessorWithContext(transformer)),
 	}
 }
 

--- a/internal/craft/runtime_test.go
+++ b/internal/craft/runtime_test.go
@@ -271,7 +271,7 @@ func TestSummaryProcessor_UsesDescriptionFallback(t *testing.T) {
 	setupTestRedis(t)
 
 	original := llmContextCaller
-	llmContextCaller = func(prompt, context string, option util.ContentProcessOption) (string, error) {
+	llmContextCaller = func(_ context.Context, prompt, context string, option util.ContentProcessOption) (string, error) {
 		assert.Contains(t, context, "Article Title:")
 		assert.Contains(t, context, "fallback body")
 		return "generated summary", nil
@@ -300,7 +300,7 @@ func TestTranslateTitleProcessor_UsesNativeLLMFlow(t *testing.T) {
 	setupTestRedis(t)
 
 	original := llmContextCaller
-	llmContextCaller = func(prompt, context string, option util.ContentProcessOption) (string, error) {
+	llmContextCaller = func(_ context.Context, prompt, context string, option util.ContentProcessOption) (string, error) {
 		assert.Contains(t, context, "Original Title")
 		return "Translated Title", nil
 	}
@@ -321,7 +321,7 @@ func TestRetitleProcessor_UsesArticleContentAndUpdatesTitle(t *testing.T) {
 	setupTestRedis(t)
 
 	original := llmContextCaller
-	llmContextCaller = func(prompt, context string, option util.ContentProcessOption) (string, error) {
+	llmContextCaller = func(_ context.Context, prompt, context string, option util.ContentProcessOption) (string, error) {
 		assert.Contains(t, prompt, "custom retitle prompt")
 		assert.Contains(t, prompt, retitleNoChangeSentinel)
 		assert.Contains(t, context, "Original Title")
@@ -348,7 +348,7 @@ func TestRetitleProcessor_KeepsOriginalTitleForNoChangeSentinel(t *testing.T) {
 	setupTestRedis(t)
 
 	original := llmContextCaller
-	llmContextCaller = func(prompt, context string, option util.ContentProcessOption) (string, error) {
+	llmContextCaller = func(_ context.Context, prompt, context string, option util.ContentProcessOption) (string, error) {
 		return retitleNoChangeSentinel, nil
 	}
 	t.Cleanup(func() { llmContextCaller = original })
@@ -370,7 +370,7 @@ func TestRetitleProcessor_SkipsEmptyContent(t *testing.T) {
 	setupTestRedis(t)
 
 	original := llmContextCaller
-	llmContextCaller = func(prompt, context string, option util.ContentProcessOption) (string, error) {
+	llmContextCaller = func(_ context.Context, prompt, context string, option util.ContentProcessOption) (string, error) {
 		t.Fatalf("llm should not be called for empty article content")
 		return "", nil
 	}
@@ -398,7 +398,7 @@ func TestRetitleTemplate_BuildsNativeProcessorWithCustomPrompt(t *testing.T) {
 	}))
 
 	original := llmContextCaller
-	llmContextCaller = func(prompt, context string, option util.ContentProcessOption) (string, error) {
+	llmContextCaller = func(_ context.Context, prompt, context string, option util.ContentProcessOption) (string, error) {
 		assert.Contains(t, prompt, "custom retitle prompt "+t.Name())
 		assert.Contains(t, prompt, retitleNoChangeSentinel)
 		return "Custom Prompt Title", nil
@@ -423,7 +423,7 @@ func TestRetitleLegacyOption_KeepsOriginalTitleForNoChangeSentinel(t *testing.T)
 	setupTestRedis(t)
 
 	original := llmContextCaller
-	llmContextCaller = func(prompt, context string, option util.ContentProcessOption) (string, error) {
+	llmContextCaller = func(_ context.Context, prompt, context string, option util.ContentProcessOption) (string, error) {
 		assert.Contains(t, context, "legacy body")
 		return retitleNoChangeSentinel, nil
 	}
@@ -451,7 +451,7 @@ func TestBeautifyContentProcessor_WritesHTML(t *testing.T) {
 	setupTestRedis(t)
 
 	original := llmCaller
-	llmCaller = func(model string, promptInput string) (string, error) {
+	llmCaller = func(_ context.Context, model string, promptInput string) (string, error) {
 		assert.Contains(t, promptInput, "<p>Body</p>")
 		return "# Heading\n\nBeautified body", nil
 	}
@@ -473,7 +473,7 @@ func TestLLMFilterProcessor_RemovesMatchedArticleAndUsesTitleContentPayload(t *t
 
 	original := llmContextCaller
 	var seen []string
-	llmContextCaller = func(prompt, context string, option util.ContentProcessOption) (string, error) {
+	llmContextCaller = func(_ context.Context, prompt, context string, option util.ContentProcessOption) (string, error) {
 		require.NotNil(t, option.Temperature)
 		assert.Equal(t, 0.0, *option.Temperature)
 		seen = append(seen, context)
@@ -505,7 +505,7 @@ func TestLLMFilterProcessor_CacheKeyUsesFullPromptAndLLMPayload(t *testing.T) {
 	redis := setupTestRedis(t)
 
 	original := llmContextCaller
-	llmContextCaller = func(prompt, context string, option util.ContentProcessOption) (string, error) {
+	llmContextCaller = func(_ context.Context, prompt, context string, option util.ContentProcessOption) (string, error) {
 		t.Fatalf("expected llm-filter to hit cache, got LLM call with prompt %q and context %q", prompt, context)
 		return "false", nil
 	}
@@ -544,7 +544,7 @@ func TestIgnoreAdvertorialProcessor_KeepsArticleOnLLMError(t *testing.T) {
 	setupTestRedis(t)
 
 	original := llmContextCaller
-	llmContextCaller = func(prompt, context string, option util.ContentProcessOption) (string, error) {
+	llmContextCaller = func(_ context.Context, prompt, context string, option util.ContentProcessOption) (string, error) {
 		return "", fmt.Errorf("temporary llm error")
 	}
 	t.Cleanup(func() { llmContextCaller = original })

--- a/internal/source/search.go
+++ b/internal/source/search.go
@@ -149,9 +149,9 @@ func (s *EnhancedSearchSource) Fetch(ctx context.Context) (*model.CraftFeed, err
 
 func expandQueryWithLLM(ctx context.Context, query string) ([]string, error) {
 	cacheKey := "search_expansion:" + query
-	jsonStr, err := util.CachedFunc(cacheKey, func() (string, error) {
+	jsonStr, err := util.CachedFuncContext(ctx, cacheKey, func(sharedCtx context.Context) (string, error) {
 		prompt := fmt.Sprintf("Analyze the following search query and generate 3-5 distinct, optimized search queries to cover different aspects, languages (if implicit), and sub-topics. Original Query: %s. Return strictly a JSON array of strings, e.g., [\"query1\", \"query2\"]. Do not output any other text, markdown formatting, or code blocks. Just the raw JSON string.", query)
-		return adapter.SimpleLLMCallContext(ctx, adapter.UseDefaultModel, prompt)
+		return adapter.SimpleLLMCallContext(sharedCtx, adapter.UseDefaultModel, prompt)
 	})
 	if err != nil {
 		return nil, err

--- a/internal/source/search.go
+++ b/internal/source/search.go
@@ -83,7 +83,7 @@ type EnhancedSearchSource struct {
 }
 
 func (s *EnhancedSearchSource) Fetch(ctx context.Context) (*model.CraftFeed, error) {
-	queries, err := expandQueryWithLLM(s.Config.SearchFetcher.Query)
+	queries, err := expandQueryWithLLM(ctx, s.Config.SearchFetcher.Query)
 	if err != nil {
 		logrus.Warnf("LLM expansion failed: %v, falling back to original query", err)
 		queries = []string{s.Config.SearchFetcher.Query}
@@ -147,11 +147,11 @@ func (s *EnhancedSearchSource) Fetch(ctx context.Context) (*model.CraftFeed, err
 	return feed, nil
 }
 
-func expandQueryWithLLM(query string) ([]string, error) {
+func expandQueryWithLLM(ctx context.Context, query string) ([]string, error) {
 	cacheKey := "search_expansion:" + query
 	jsonStr, err := util.CachedFunc(cacheKey, func() (string, error) {
 		prompt := fmt.Sprintf("Analyze the following search query and generate 3-5 distinct, optimized search queries to cover different aspects, languages (if implicit), and sub-topics. Original Query: %s. Return strictly a JSON array of strings, e.g., [\"query1\", \"query2\"]. Do not output any other text, markdown formatting, or code blocks. Just the raw JSON string.", query)
-		return adapter.SimpleLLMCall(adapter.UseDefaultModel, prompt)
+		return adapter.SimpleLLMCallContext(ctx, adapter.UseDefaultModel, prompt)
 	})
 	if err != nil {
 		return nil, err

--- a/internal/util/cache.go
+++ b/internal/util/cache.go
@@ -4,13 +4,16 @@ import (
 	"FeedCraft/internal/constant"
 	"context"
 	"errors"
+	"log"
 	"strings"
+	"time"
 
 	"github.com/redis/go-redis/v9"
 	"github.com/sirupsen/logrus"
-	"log"
-	"time"
+	"golang.org/x/sync/singleflight"
 )
+
+var cacheFlight singleflight.Group
 
 // GetRedisClient 返回一个非空的redis client
 func GetRedisClient() *redis.Client {
@@ -83,31 +86,48 @@ func CacheGetString(key string) (string, error) {
 	return rdb.Get(context.Background(), key).Result()
 }
 
-// CachedFuncWithPreLog tries to get from cache, invokes preLog if provided, and if absent, calls valFunc and saves to cache
+// CachedFuncWithPreLog tries to get from cache, invokes preLog if provided, and if absent, calls valFunc and saves to cache.
+// Concurrent misses for the same key are coalesced with singleflight to avoid cache stampede.
 func CachedFuncWithPreLog(cacheKey string, valFunc func() (string, error), preLog func(isCached bool)) (string, error) {
-	final := ""
-	cached, err := CacheGetString(cacheKey)
-	isCached := err == nil && cached != ""
+	return cachedFuncWithStore(cacheKey, CacheGetString, func(value string) error {
+		return CacheSetString(cacheKey, value, constant.WebContentExpire)
+	}, valFunc, preLog)
+}
 
+func cachedFuncWithStore(
+	cacheKey string,
+	get func(string) (string, error),
+	set func(string) error,
+	valFunc func() (string, error),
+	preLog func(isCached bool),
+) (string, error) {
+	cached, err := get(cacheKey)
+	isCached := err == nil && cached != ""
 	if preLog != nil {
 		preLog(isCached)
 	}
+	if isCached {
+		return cached, nil
+	}
 
-	if !isCached {
+	v, flightErr, _ := cacheFlight.Do(cacheKey, func() (interface{}, error) {
+		cached, err := get(cacheKey)
+		if err == nil && cached != "" {
+			return cached, nil
+		}
 		processedContent, getValErr := valFunc()
 		if getValErr != nil {
 			return "", getValErr
-		} else {
-			final = processedContent
-			cacheErr := CacheSetString(cacheKey, processedContent, constant.WebContentExpire)
-			if cacheErr != nil {
-				logrus.Warn("failed to cache result")
-			}
 		}
-	} else {
-		final = cached
+		if cacheErr := set(processedContent); cacheErr != nil {
+			logrus.Warn("failed to cache result")
+		}
+		return processedContent, nil
+	})
+	if flightErr != nil {
+		return "", flightErr
 	}
-
+	final, _ := v.(string)
 	return final, nil
 }
 

--- a/internal/util/cache.go
+++ b/internal/util/cache.go
@@ -6,14 +6,109 @@ import (
 	"errors"
 	"log"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/redis/go-redis/v9"
 	"github.com/sirupsen/logrus"
-	"golang.org/x/sync/singleflight"
 )
 
-var cacheFlight singleflight.Group
+var cacheFlight = newCacheFlightGroup()
+
+type cacheFlightCall struct {
+	ctx       context.Context
+	cancel    context.CancelFunc
+	done      chan struct{}
+	value     string
+	err       error
+	waiters   int
+	completed bool
+}
+
+type cacheFlightGroup struct {
+	mu    sync.Mutex
+	calls map[string]*cacheFlightCall
+}
+
+func newCacheFlightGroup() *cacheFlightGroup {
+	return &cacheFlightGroup{calls: make(map[string]*cacheFlightCall)}
+}
+
+func (g *cacheFlightGroup) do(
+	ctx context.Context,
+	key string,
+	fn func(context.Context) (string, error),
+) (string, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return "", err
+	}
+
+	g.mu.Lock()
+	call := g.calls[key]
+	if call != nil {
+		call.waiters++
+	} else {
+		sharedCtx, cancel := context.WithCancel(context.Background())
+		call = &cacheFlightCall{
+			ctx:     sharedCtx,
+			cancel:  cancel,
+			done:    make(chan struct{}),
+			waiters: 1,
+		}
+		g.calls[key] = call
+		go g.run(key, call, fn)
+	}
+	g.mu.Unlock()
+
+	select {
+	case <-call.done:
+		return call.value, call.err
+	default:
+	}
+
+	select {
+	case <-call.done:
+		return call.value, call.err
+	case <-ctx.Done():
+		g.leave(key, call)
+		return "", ctx.Err()
+	}
+}
+
+func (g *cacheFlightGroup) run(
+	key string,
+	call *cacheFlightCall,
+	fn func(context.Context) (string, error),
+) {
+	value, err := fn(call.ctx)
+
+	g.mu.Lock()
+	call.value = value
+	call.err = err
+	call.completed = true
+	if g.calls[key] == call {
+		delete(g.calls, key)
+	}
+	close(call.done)
+	call.cancel()
+	g.mu.Unlock()
+}
+
+func (g *cacheFlightGroup) leave(key string, call *cacheFlightCall) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	if call.completed || g.calls[key] != call {
+		return
+	}
+	call.waiters--
+	if call.waiters == 0 {
+		delete(g.calls, key)
+		call.cancel()
+	}
+}
 
 // GetRedisClient 返回一个非空的redis client
 func GetRedisClient() *redis.Client {
@@ -89,7 +184,20 @@ func CacheGetString(key string) (string, error) {
 // CachedFuncWithPreLog tries to get from cache, invokes preLog if provided, and if absent, calls valFunc and saves to cache.
 // Concurrent misses for the same key are coalesced with singleflight to avoid cache stampede.
 func CachedFuncWithPreLog(cacheKey string, valFunc func() (string, error), preLog func(isCached bool)) (string, error) {
-	return cachedFuncWithStore(cacheKey, CacheGetString, func(value string) error {
+	return CachedFuncWithPreLogContext(context.Background(), cacheKey, func(context.Context) (string, error) {
+		return valFunc()
+	}, preLog)
+}
+
+// CachedFuncWithPreLogContext coalesces same-key cache misses while keeping
+// each caller's cancellation independent. Shared work stops when all waiters leave.
+func CachedFuncWithPreLogContext(
+	ctx context.Context,
+	cacheKey string,
+	valFunc func(context.Context) (string, error),
+	preLog func(isCached bool),
+) (string, error) {
+	return cachedFuncWithStoreContext(ctx, cacheKey, CacheGetString, func(value string) error {
 		return CacheSetString(cacheKey, value, constant.WebContentExpire)
 	}, valFunc, preLog)
 }
@@ -101,6 +209,19 @@ func cachedFuncWithStore(
 	valFunc func() (string, error),
 	preLog func(isCached bool),
 ) (string, error) {
+	return cachedFuncWithStoreContext(context.Background(), cacheKey, get, set, func(context.Context) (string, error) {
+		return valFunc()
+	}, preLog)
+}
+
+func cachedFuncWithStoreContext(
+	ctx context.Context,
+	cacheKey string,
+	get func(string) (string, error),
+	set func(string) error,
+	valFunc func(context.Context) (string, error),
+	preLog func(isCached bool),
+) (string, error) {
 	cached, err := get(cacheKey)
 	isCached := err == nil && cached != ""
 	if preLog != nil {
@@ -110,12 +231,12 @@ func cachedFuncWithStore(
 		return cached, nil
 	}
 
-	v, flightErr, _ := cacheFlight.Do(cacheKey, func() (interface{}, error) {
+	return cacheFlight.do(ctx, cacheKey, func(sharedCtx context.Context) (string, error) {
 		cached, err := get(cacheKey)
 		if err == nil && cached != "" {
 			return cached, nil
 		}
-		processedContent, getValErr := valFunc()
+		processedContent, getValErr := valFunc(sharedCtx)
 		if getValErr != nil {
 			return "", getValErr
 		}
@@ -124,14 +245,14 @@ func cachedFuncWithStore(
 		}
 		return processedContent, nil
 	})
-	if flightErr != nil {
-		return "", flightErr
-	}
-	final, _ := v.(string)
-	return final, nil
 }
 
 // CachedFunc 先尝试取缓存, 如不存在, 则调用valFunc 获取值并写入缓存
 func CachedFunc(cacheKey string, valFunc func() (string, error)) (string, error) {
 	return CachedFuncWithPreLog(cacheKey, valFunc, nil)
+}
+
+// CachedFuncContext is CachedFunc with independent per-caller cancellation.
+func CachedFuncContext(ctx context.Context, cacheKey string, valFunc func(context.Context) (string, error)) (string, error) {
+	return CachedFuncWithPreLogContext(ctx, cacheKey, valFunc, nil)
 }

--- a/internal/util/cache.go
+++ b/internal/util/cache.go
@@ -182,7 +182,7 @@ func CacheGetString(key string) (string, error) {
 }
 
 // CachedFuncWithPreLog tries to get from cache, invokes preLog if provided, and if absent, calls valFunc and saves to cache.
-// Concurrent misses for the same key are coalesced with singleflight to avoid cache stampede.
+// Concurrent misses for the same key are coalesced to avoid cache stampede.
 func CachedFuncWithPreLog(cacheKey string, valFunc func() (string, error), preLog func(isCached bool)) (string, error) {
 	return CachedFuncWithPreLogContext(context.Background(), cacheKey, func(context.Context) (string, error) {
 		return valFunc()

--- a/internal/util/cache_test.go
+++ b/internal/util/cache_test.go
@@ -1,6 +1,7 @@
 package util
 
 import (
+	"context"
 	"errors"
 	"sync"
 	"sync/atomic"
@@ -58,4 +59,108 @@ func TestCachedFuncWithStore_CoalescesConcurrentMisses(t *testing.T) {
 		require.Equal(t, "computed", <-resultCh)
 	}
 	require.Equal(t, int32(1), atomic.LoadInt32(&calls), "并发缓存未命中应只计算一次")
+}
+
+func TestCachedFuncWithStoreContext_CanceledFollowerStopsWaiting(t *testing.T) {
+	get := func(string) (string, error) { return "", errors.New("cache miss") }
+	set := func(string) error { return nil }
+	started := make(chan struct{})
+	release := make(chan struct{})
+	valFunc := func(context.Context) (string, error) {
+		close(started)
+		<-release
+		return "computed", nil
+	}
+
+	leaderDone := make(chan error, 1)
+	go func() {
+		_, err := cachedFuncWithStoreContext(context.Background(), "follower-cancel", get, set, valFunc, nil)
+		leaderDone <- err
+	}()
+	<-started
+
+	followerCtx, cancelFollower := context.WithCancel(context.Background())
+	followerDone := make(chan error, 1)
+	go func() {
+		_, err := cachedFuncWithStoreContext(followerCtx, "follower-cancel", get, set, valFunc, nil)
+		followerDone <- err
+	}()
+	waitForCacheWaiters(t, "follower-cancel", 2)
+	cancelFollower()
+
+	select {
+	case err := <-followerDone:
+		require.ErrorIs(t, err, context.Canceled)
+	case <-time.After(time.Second):
+		t.Fatal("canceled follower did not stop waiting")
+	}
+	close(release)
+	require.NoError(t, <-leaderDone)
+}
+
+func TestCachedFuncWithStoreContext_CanceledLeaderDoesNotFailFollower(t *testing.T) {
+	get := func(string) (string, error) { return "", errors.New("cache miss") }
+	set := func(string) error { return nil }
+	started := make(chan struct{})
+	release := make(chan struct{})
+	var calls int32
+	valFunc := func(ctx context.Context) (string, error) {
+		if atomic.AddInt32(&calls, 1) == 1 {
+			close(started)
+		}
+		select {
+		case <-release:
+			return "computed", nil
+		case <-ctx.Done():
+			return "", ctx.Err()
+		}
+	}
+
+	leaderCtx, cancelLeader := context.WithCancel(context.Background())
+	leaderDone := make(chan error, 1)
+	go func() {
+		_, err := cachedFuncWithStoreContext(leaderCtx, "leader-cancel", get, set, valFunc, nil)
+		leaderDone <- err
+	}()
+	<-started
+
+	followerDone := make(chan struct {
+		value string
+		err   error
+	}, 1)
+	go func() {
+		value, err := cachedFuncWithStoreContext(context.Background(), "leader-cancel", get, set, valFunc, nil)
+		followerDone <- struct {
+			value string
+			err   error
+		}{value, err}
+	}()
+	waitForCacheWaiters(t, "leader-cancel", 2)
+	cancelLeader()
+	require.ErrorIs(t, <-leaderDone, context.Canceled)
+	close(release)
+
+	result := <-followerDone
+	require.NoError(t, result.err)
+	require.Equal(t, "computed", result.value)
+	require.Equal(t, int32(1), atomic.LoadInt32(&calls))
+}
+
+func waitForCacheWaiters(t *testing.T, key string, want int) {
+	t.Helper()
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		cacheFlight.mu.Lock()
+		call := cacheFlight.calls[key]
+		got := 0
+		if call != nil {
+			got = call.waiters
+		}
+		cacheFlight.mu.Unlock()
+		if got >= want {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatalf("cache flight %q did not reach %d waiters", key, want)
 }

--- a/internal/util/cache_test.go
+++ b/internal/util/cache_test.go
@@ -1,0 +1,61 @@
+package util
+
+import (
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCachedFuncWithStore_CoalescesConcurrentMisses(t *testing.T) {
+	store := sync.Map{}
+	get := func(key string) (string, error) {
+		if v, ok := store.Load(key); ok {
+			return v.(string), nil
+		}
+		return "", errors.New("cache miss")
+	}
+	set := func(value string) error {
+		store.Store("stampede-key", value)
+		return nil
+	}
+
+	var calls int32
+	started := make(chan struct{})
+	release := make(chan struct{})
+	valFunc := func() (string, error) {
+		n := atomic.AddInt32(&calls, 1)
+		if n == 1 {
+			close(started)
+			<-release
+		}
+		return "computed", nil
+	}
+
+	const workers = 8
+	errCh := make(chan error, workers)
+	resultCh := make(chan string, workers)
+	for i := 0; i < workers; i++ {
+		go func() {
+			v, err := cachedFuncWithStore("stampede-key", get, set, valFunc, nil)
+			errCh <- err
+			resultCh <- v
+		}()
+	}
+
+	select {
+	case <-started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("valFunc was not started")
+	}
+	close(release)
+
+	for i := 0; i < workers; i++ {
+		require.NoError(t, <-errCh)
+		require.Equal(t, "computed", <-resultCh)
+	}
+	require.Equal(t, int32(1), atomic.LoadInt32(&calls), "并发缓存未命中应只计算一次")
+}

--- a/internal/util/llm_prompt.go
+++ b/internal/util/llm_prompt.go
@@ -3,8 +3,10 @@ package util
 import "strings"
 
 const (
-	defaultLLMPromptMaxChars = 12000
-	llmPromptTruncationMark  = "\n\n[...truncated...]\n\n"
+	defaultLLMPromptMaxChars    = 12000
+	llmPromptTruncationMark     = "\n\n[...truncated...]\n\n"
+	llmPromptTruncationShort    = "[...]"
+	llmPromptTruncationEllipsis = "…"
 )
 
 // LLMPromptMaxChars returns the max rune count allowed in LLM article payloads.
@@ -20,7 +22,7 @@ func LLMPromptMaxChars() int {
 }
 
 // TruncateHeadTail keeps the start and end of s when it exceeds maxChars runes.
-// This preserves lead-in and conclusion while bounding LLM token cost.
+// Oversized input always includes a truncation marker so the LLM can tell content was cut.
 func TruncateHeadTail(s string, maxChars int) string {
 	if maxChars <= 0 {
 		return s
@@ -30,12 +32,15 @@ func TruncateHeadTail(s string, maxChars int) string {
 		return s
 	}
 
-	mark := []rune(llmPromptTruncationMark)
-	if maxChars <= len(mark)+2 {
-		return string(runes[:maxChars])
+	mark := truncationMarkerForLimit(maxChars)
+	remain := maxChars - len(mark)
+	if remain < 2 {
+		if remain < 0 {
+			return string(mark[:maxChars])
+		}
+		return string(runes[:remain]) + string(mark)
 	}
 
-	remain := maxChars - len(mark)
 	head := remain * 3 / 5
 	if head < 1 {
 		head = 1
@@ -49,7 +54,26 @@ func TruncateHeadTail(s string, maxChars int) string {
 	var b strings.Builder
 	b.Grow(maxChars)
 	b.WriteString(string(runes[:head]))
-	b.WriteString(llmPromptTruncationMark)
+	b.WriteString(string(mark))
 	b.WriteString(string(runes[len(runes)-tail:]))
 	return b.String()
+}
+
+func truncationMarkerForLimit(maxChars int) []rune {
+	candidates := []string{
+		llmPromptTruncationMark,
+		llmPromptTruncationShort,
+		llmPromptTruncationEllipsis,
+	}
+	for _, candidate := range candidates {
+		mark := []rune(candidate)
+		if maxChars >= len(mark)+2 {
+			return mark
+		}
+	}
+	mark := []rune(llmPromptTruncationEllipsis)
+	if len(mark) > maxChars {
+		return mark[:maxChars]
+	}
+	return mark
 }

--- a/internal/util/llm_prompt.go
+++ b/internal/util/llm_prompt.go
@@ -1,0 +1,55 @@
+package util
+
+import "strings"
+
+const (
+	defaultLLMPromptMaxChars = 12000
+	llmPromptTruncationMark  = "\n\n[...truncated...]\n\n"
+)
+
+// LLMPromptMaxChars returns the max rune count allowed in LLM article payloads.
+// Override with FC_LLM_PROMPT_MAX_CHARS. Zero or negative env values fall back to default.
+func LLMPromptMaxChars() int {
+	envClient := GetEnvClient()
+	if envClient != nil {
+		if n := envClient.GetInt("LLM_PROMPT_MAX_CHARS"); n > 0 {
+			return n
+		}
+	}
+	return defaultLLMPromptMaxChars
+}
+
+// TruncateHeadTail keeps the start and end of s when it exceeds maxChars runes.
+// This preserves lead-in and conclusion while bounding LLM token cost.
+func TruncateHeadTail(s string, maxChars int) string {
+	if maxChars <= 0 {
+		return s
+	}
+	runes := []rune(s)
+	if len(runes) <= maxChars {
+		return s
+	}
+
+	mark := []rune(llmPromptTruncationMark)
+	if maxChars <= len(mark)+2 {
+		return string(runes[:maxChars])
+	}
+
+	remain := maxChars - len(mark)
+	head := remain * 3 / 5
+	if head < 1 {
+		head = 1
+	}
+	tail := remain - head
+	if tail < 1 {
+		tail = 1
+		head = remain - tail
+	}
+
+	var b strings.Builder
+	b.Grow(maxChars)
+	b.WriteString(string(runes[:head]))
+	b.WriteString(llmPromptTruncationMark)
+	b.WriteString(string(runes[len(runes)-tail:]))
+	return b.String()
+}

--- a/internal/util/llm_prompt_test.go
+++ b/internal/util/llm_prompt_test.go
@@ -1,0 +1,32 @@
+package util
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestTruncateHeadTail_ShortInputUnchanged(t *testing.T) {
+	input := "hello 世界"
+	require.Equal(t, input, TruncateHeadTail(input, 100))
+}
+
+func TestTruncateHeadTail_KeepsHeadAndTail(t *testing.T) {
+	input := strings.Repeat("H", 40) + strings.Repeat("M", 40) + strings.Repeat("T", 40)
+	got := TruncateHeadTail(input, 50)
+
+	require.LessOrEqual(t, len([]rune(got)), 50)
+	require.True(t, strings.HasPrefix(got, "HHHH"))
+	require.True(t, strings.HasSuffix(got, "TTTT"))
+	require.Contains(t, got, "[...truncated...]")
+	require.NotContains(t, got, "MMMM")
+}
+
+func TestLLMPromptMaxChars_DefaultAndEnv(t *testing.T) {
+	t.Setenv("FC_LLM_PROMPT_MAX_CHARS", "")
+	require.Equal(t, defaultLLMPromptMaxChars, LLMPromptMaxChars())
+
+	t.Setenv("FC_LLM_PROMPT_MAX_CHARS", "8000")
+	require.Equal(t, 8000, LLMPromptMaxChars())
+}

--- a/internal/util/llm_prompt_test.go
+++ b/internal/util/llm_prompt_test.go
@@ -23,6 +23,20 @@ func TestTruncateHeadTail_KeepsHeadAndTail(t *testing.T) {
 	require.NotContains(t, got, "MMMM")
 }
 
+func TestTruncateHeadTail_TinyLimitStillMarksTruncation(t *testing.T) {
+	input := strings.Repeat("A", 50) + strings.Repeat("Z", 50)
+
+	got := TruncateHeadTail(input, 10)
+	require.LessOrEqual(t, len([]rune(got)), 10)
+	require.Contains(t, got, "[...]")
+	require.True(t, strings.HasPrefix(got, "A"))
+	require.True(t, strings.HasSuffix(got, "Z"))
+
+	got = TruncateHeadTail(input, 3)
+	require.LessOrEqual(t, len([]rune(got)), 3)
+	require.Contains(t, got, "…")
+}
+
 func TestLLMPromptMaxChars_DefaultAndEnv(t *testing.T) {
 	t.Setenv("FC_LLM_PROMPT_MAX_CHARS", "")
 	require.Equal(t, defaultLLMPromptMaxChars, LLMPromptMaxChars())


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
对应 Linear [COL-29](https://linear.app/colin-x-studio/issue/COL-29/robust-llm-调用-10min-硬编码超时-background-ctx-缓存无防击穿-输入无长度上限)。

## 问题

在 `dev` 上核对后四点均存在：

1. `llmCallTimeout` 硬编码 10 分钟，叠加 3 次重试最坏约 30 分钟占用全局并发。
2. `dispatcher.Execute(context.Background())` 不继承 HTTP 请求 context，客户端断开后 LLM 仍继续。
3. `CachedFunc` GET→SET 无合并，并发相同 key 会重复打 LLM。
4. `getArticleContentForPrompt` 无长度上限。

## 改动

- 默认单次超时改为 **3 分钟**，可用 `FC_LLM_CALL_TIMEOUT`（秒）配置；超时/取消不再重试，取消也会打断重试退避。
- 新增 request-context LLM 入口，native 与 legacy 处理链路均传播请求 context。
- 缓存 flight 合并并发未命中；每个等待者独立响应取消，仅当全部等待者退出时取消共享计算。
- 文章正文按 `FC_LLM_PROMPT_MAX_CHARS`（默认 12000 rune）在最终 LLM payload 边界做一次头尾截断；极小上限仍保留紧凑截断标记。
- `MaxTaskDuration` 只在 dispatcher 初始化期间设置，消除并发写竞态。

## 验证

- `go test ./... -count=1`
- `go test -race ./internal/util ./internal/adapter ./internal/craft -count=1`
- `golangci-lint run ./... --timeout=10m`
- `task backend-build`

均通过。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b991e3c6-a9e7-4714-8e1d-ac2c9df30dbd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b991e3c6-a9e7-4714-8e1d-ac2c9df30dbd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

## Summary by Sourcery

Harden LLM processing against long-running requests, cache stampedes, and oversized prompts.

Bug Fixes:
- Prevent LLM cache stampedes by coalescing concurrent misses for the same cache key.
- Propagate request cancellation through LLM-powered processing so disconnected clients stop work and canceled or timed-out calls are not retried.
- Limit article content sent to LLM prompts with configurable head-and-tail truncation.

Enhancements:
- Make per-call LLM timeouts configurable, reducing the default timeout to three minutes.

Documentation:
- Document the new LLM timeout and prompt-length configuration options in English, Simplified Chinese, and Traditional Chinese.

Tests:
- Add coverage for configurable timeouts, cancellation-aware retry behavior, cache miss coalescing, and prompt truncation.