### PR TITLE
feat: 将剩余 AI/Embedding craft 迁到原生 CraftFeed 处理器

### DIFF
--- a/internal/controller/feed_viewer.go
+++ b/internal/controller/feed_viewer.go
@@ -2,10 +2,12 @@ package controller
 
 import (
 	"FeedCraft/internal/craft"
+	"FeedCraft/internal/engine"
 	"FeedCraft/internal/feedruntime"
 	"FeedCraft/internal/model"
 	"FeedCraft/internal/observability"
 	"FeedCraft/internal/util"
+	"context"
 	"errors"
 	"fmt"
 	"net/http"
@@ -14,7 +16,6 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
-	"github.com/mmcdole/gofeed"
 	"gorm.io/gorm"
 )
 
@@ -144,14 +145,15 @@ func PreviewEmbeddingFilter(c *gin.Context) {
 		return
 	}
 
-	craftedFeed, err := buildCraftPreviewWithOptions(feed, cfg.inputURL, []craft.LegacyCraftOption{craft.OptionEmbeddingFilterWithContext(
-		c.Request.Context(),
-		cfg.anchors,
-		cfg.threshold,
-		cfg.maxContentLength,
-		cfg.instruction,
-		cfg.mode,
-	)})
+	craftedFeed, err := buildCraftPreviewWithOptions(c.Request.Context(), feed, []engine.CraftOption{
+		craft.WrapLocalProcessor(craft.NewEmbeddingFilterProcessor(
+			cfg.anchors,
+			cfg.threshold,
+			cfg.maxContentLength,
+			cfg.instruction,
+			cfg.mode,
+		)),
+	})
 	if err != nil {
 		status, msg := classifyFeedViewerError(err)
 		c.JSON(status, util.APIResponse[any]{StatusCode: -1, Msg: msg})
@@ -182,7 +184,7 @@ func loadFeedViewerPreview(c *gin.Context, req FeedViewerPreviewReq) (*model.Cra
 		return feed, nil
 	}
 
-	craftedFeed, err := buildCraftPreview(feed, req.InputURL, req.CraftName)
+	craftedFeed, err := buildCraftPreview(c.Request.Context(), feed, req.InputURL, req.CraftName)
 	if err != nil {
 		return nil, err
 	}
@@ -248,42 +250,22 @@ func normalizeEmbeddingFilterPreviewRequest(req EmbeddingFilterPreviewReq) (embe
 	return cfg, nil
 }
 
-func buildCraftPreview(feed *model.CraftFeed, inputURL, craftName string) (*model.CraftFeed, error) {
-	atomXML, err := feed.ToFeedsFeed().ToAtom()
+func buildCraftPreview(ctx context.Context, feed *model.CraftFeed, inputURL, craftName string) (*model.CraftFeed, error) {
+	option, err := craft.BuildOptionChain(nil, craftName, inputURL)
 	if err != nil {
 		return nil, err
 	}
-
-	parsedFeed, err := gofeed.NewParser().ParseString(atomXML)
-	if err != nil {
-		return nil, err
+	if option == nil {
+		return feed, nil
 	}
-
-	craftedFeed, err := craft.ProcessFeed(parsedFeed, inputURL, craftName)
-	if err != nil {
-		return nil, err
-	}
-
-	return model.FromFeedsFeed(craftedFeed), nil
+	return option(ctx, feed)
 }
 
-func buildCraftPreviewWithOptions(feed *model.CraftFeed, inputURL string, options []craft.LegacyCraftOption) (*model.CraftFeed, error) {
-	atomXML, err := feed.ToFeedsFeed().ToAtom()
-	if err != nil {
-		return nil, err
+func buildCraftPreviewWithOptions(ctx context.Context, feed *model.CraftFeed, options []engine.CraftOption) (*model.CraftFeed, error) {
+	if len(options) == 0 {
+		return feed, nil
 	}
-
-	parsedFeed, err := gofeed.NewParser().ParseString(atomXML)
-	if err != nil {
-		return nil, err
-	}
-
-	craftedFeed, err := craft.NewCraftedFeedFromGofeed(parsedFeed, inputURL, options...)
-	if err != nil {
-		return nil, err
-	}
-
-	return model.FromFeedsFeed(craftedFeed.OutputFeed), nil
+	return engine.ComposeOptions(options...)(ctx, feed)
 }
 
 func buildFeedViewerPreview(feed *model.CraftFeed, inputURL string) FeedViewerPreview {

--- a/internal/craft/adapter.go
+++ b/internal/craft/adapter.go
@@ -4,6 +4,8 @@ import (
 	"context"
 
 	"FeedCraft/internal/model"
+
+	"github.com/gorilla/feeds"
 )
 
 func AdaptLegacyOption(option LegacyCraftOption, extra ExtraPayload) CraftOption {
@@ -31,4 +33,39 @@ func AdaptLegacyOptions(options []LegacyCraftOption, extra ExtraPayload) CraftOp
 		adapted = append(adapted, AdaptLegacyOption(option, extra))
 	}
 	return ComposeOptions(adapted...)
+}
+
+func applyLocalProcessorToLegacyFeed(ctx context.Context, processor localProcessor, feed *feeds.Feed) error {
+	if feed == nil {
+		return nil
+	}
+	out, err := processor.Process(ctx, model.FromFeedsFeed(feed))
+	if err != nil {
+		return err
+	}
+	converted := out.ToFeedsFeed()
+	*feed = *converted
+	return nil
+}
+
+func articleFromFeedItem(item *feeds.Item) *model.CraftArticle {
+	if item == nil {
+		return nil
+	}
+	article := &model.CraftArticle{
+		Title:       item.Title,
+		Description: item.Description,
+		Id:          item.Id,
+		Updated:     item.Updated,
+		Created:     item.Created,
+		Content:     item.Content,
+	}
+	if item.Link != nil {
+		article.Link = item.Link.Href
+	}
+	if item.Author != nil {
+		article.AuthorName = item.Author.Name
+		article.AuthorEmail = item.Author.Email
+	}
+	return article
 }

--- a/internal/craft/adapter.go
+++ b/internal/craft/adapter.go
@@ -39,13 +39,54 @@ func applyLocalProcessorToLegacyFeed(ctx context.Context, processor localProcess
 	if feed == nil {
 		return nil
 	}
+	originalItems := feed.Items
 	out, err := processor.Process(ctx, model.FromFeedsFeed(feed))
 	if err != nil {
 		return err
 	}
 	converted := out.ToFeedsFeed()
+	restoreLegacyItemMetadata(originalItems, converted)
 	*feed = *converted
 	return nil
+}
+
+func restoreLegacyItemMetadata(originals []*feeds.Item, converted *feeds.Feed) {
+	if converted == nil || len(originals) == 0 {
+		return
+	}
+	index := make(map[string]*feeds.Item, len(originals))
+	for _, item := range originals {
+		if item == nil {
+			continue
+		}
+		index[legacyItemKey(item)] = item
+	}
+	for _, item := range converted.Items {
+		if item == nil {
+			continue
+		}
+		orig, ok := index[legacyItemKey(item)]
+		if !ok {
+			continue
+		}
+		if item.Enclosure == nil {
+			item.Enclosure = orig.Enclosure
+		}
+		if item.IsPermaLink == "" {
+			item.IsPermaLink = orig.IsPermaLink
+		}
+	}
+}
+
+func legacyItemKey(item *feeds.Item) string {
+	link := ""
+	if item.Link != nil {
+		link = item.Link.Href
+	}
+	if item.Id != "" {
+		return item.Id + "\x00" + link
+	}
+	return item.Title + "\x00" + link
 }
 
 func articleFromFeedItem(item *feeds.Item) *model.CraftArticle {

--- a/internal/craft/adapter.go
+++ b/internal/craft/adapter.go
@@ -67,5 +67,8 @@ func articleFromFeedItem(item *feeds.Item) *model.CraftArticle {
 		article.AuthorName = item.Author.Name
 		article.AuthorEmail = item.Author.Email
 	}
+	if item.Source != nil {
+		article.Source = item.Source.Href
+	}
 	return article
 }

--- a/internal/craft/ai_content_process.go
+++ b/internal/craft/ai_content_process.go
@@ -1,9 +1,11 @@
 package craft
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
+	"FeedCraft/internal/model"
 	"FeedCraft/internal/util"
 
 	"github.com/gorilla/feeds"
@@ -47,36 +49,52 @@ func GetAIContentProcessCraftOptions(rule string, extraPayloadRaw string, placem
 }
 
 func OptionAIContentProcess(rule string, extraPayloadRaw string, placementRaw string) LegacyCraftOption {
+	processor := newAIContentProcessProcessor(rule, extraPayloadRaw, placementRaw)
+	return func(feed *feeds.Feed, payload ExtraPayload) error {
+		_ = payload
+		return applyLocalProcessorToLegacyFeed(context.Background(), processor, feed)
+	}
+}
+
+func newAIContentProcessProcessor(rule string, extraPayloadRaw string, placementRaw string) *ArticleTextTransformProcessor {
 	rule = strings.TrimSpace(rule)
 	payloadTypes := parseAIFilterExtraPayloadWithDefault(extraPayloadRaw, []aiFilterExtraPayloadType{aiFilterExtraPayloadArticleContent})
 	placement := parseAIContentProcessPlacement(placementRaw)
 	prompt := buildAIContentProcessPrompt(rule)
 
-	transFunc := func(item *feeds.Item) (string, error) {
-		if rule == "" {
-			return "", fmt.Errorf("ai-content-process requires rule param")
-		}
-		return cachedAIContentProcessItem(item, prompt, payloadTypes, placement)
+	return &ArticleTextTransformProcessor{
+		CraftName: "ai-content-process",
+		Mutate: func(ctx context.Context, article *model.CraftArticle) error {
+			_ = ctx
+			if rule == "" {
+				return fmt.Errorf("ai-content-process requires rule param")
+			}
+			transformed, err := cachedAIContentProcessArticle(article, prompt, payloadTypes, placement)
+			if err != nil {
+				return err
+			}
+			article.Content = transformed
+			article.Description = transformed
+			return nil
+		},
 	}
-
-	return OptionTransformFeedItem(GetArticleContentProcessor(transFunc))
 }
 
-func cachedAIContentProcessItem(item *feeds.Item, prompt string, payloadTypes []aiFilterExtraPayloadType, placement aiContentProcessPlacement) (string, error) {
-	original := getPrimaryFeedItemContent(item)
-	context, err := buildAIContentProcessArticlePayload(item, payloadTypes)
+func cachedAIContentProcessArticle(article *model.CraftArticle, prompt string, payloadTypes []aiFilterExtraPayloadType, placement aiContentProcessPlacement) (string, error) {
+	original := getPrimaryArticleContent(article)
+	contextData, err := buildAIContentProcessArticlePayload(article, payloadTypes)
 	if err != nil {
 		return "", err
 	}
 	cacheKey := getCraftCacheKey("ai-content-process-result", util.GetTextContentHash(strings.Join([]string{
 		util.GetTextContentHash(prompt),
-		util.GetTextContentHash(context),
+		util.GetTextContentHash(contextData),
 		string(placement),
 		util.GetTextContentHash(original),
 	}, "|")))
 
 	return util.CachedFuncWithPreLog(cacheKey, func() (string, error) {
-		result, callErr := llmContextCaller(prompt, context, util.ContentProcessOption{
+		result, callErr := llmContextCaller(prompt, contextData, util.ContentProcessOption{
 			RemoveImage: true,
 			ConvertToMd: true,
 			Temperature: util.LowestLLMTemperaturePtr(),
@@ -88,23 +106,23 @@ func cachedAIContentProcessItem(item *feeds.Item, prompt string, payloadTypes []
 		return applyAIContentProcessPlacement(original, generated, placement), nil
 	}, func(isCached bool) {
 		title := ""
-		if item != nil {
-			title = item.Title
+		if article != nil {
+			title = article.Title
 		}
 		logrus.Infof("applying craft [ai-content-process] to article [%s], cached: %v", title, isCached)
 	})
 }
 
-func buildAIContentProcessArticlePayload(item *feeds.Item, payloadTypes []aiFilterExtraPayloadType) (string, error) {
+func buildAIContentProcessArticlePayload(article *model.CraftArticle, payloadTypes []aiFilterExtraPayloadType) (string, error) {
 	summary := ""
 	if loContainsAIFilterPayload(payloadTypes, aiFilterExtraPayloadArticleSummary) {
-		generated, err := generateAIFilterArticleSummary(item)
+		generated, err := generateAIFilterArticleSummary(article)
 		if err != nil {
 			return "", err
 		}
 		summary = generated
 	}
-	return buildAIFilterArticlePayload(item, payloadTypes, summary)
+	return buildAIFilterArticlePayload(article, payloadTypes, summary)
 }
 
 func buildAIContentProcessPrompt(rule string) string {

--- a/internal/craft/ai_filter.go
+++ b/internal/craft/ai_filter.go
@@ -81,7 +81,9 @@ func newAIFilterProcessor(rule string, extraPayloadRaw string) *AIFilterProcesso
 }
 
 func (p *AIFilterProcessor) Process(ctx context.Context, feed *model.CraftFeed) (*model.CraftFeed, error) {
-	_ = ctx
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 	if p.rule == "" {
 		return nil, fmt.Errorf("ai-filter requires rule param")
 	}
@@ -94,6 +96,9 @@ func (p *AIFilterProcessor) Process(ctx context.Context, feed *model.CraftFeed) 
 		if article == nil {
 			return true
 		}
+		if err := ctx.Err(); err != nil {
+			return false
+		}
 		decision, err := p.evaluateAIFilterArticle(article)
 		if err != nil {
 			logrus.Warnf("failed to evaluate ai-filter for article [%s], err: %v", article.Title, err)
@@ -101,6 +106,9 @@ func (p *AIFilterProcessor) Process(ctx context.Context, feed *model.CraftFeed) 
 		}
 		return decision.Result == aiFilterResultDrop
 	})
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 
 	filtered := make([]*model.CraftArticle, 0, len(cloned.Articles))
 	for idx, article := range cloned.Articles {

--- a/internal/craft/ai_filter.go
+++ b/internal/craft/ai_filter.go
@@ -340,6 +340,9 @@ func buildRawRSSItemJSON(article *model.CraftArticle) (string, error) {
 	if article.Link != "" {
 		raw["link"] = article.Link
 	}
+	if article.Source != "" {
+		raw["source"] = article.Source
+	}
 	if article.AuthorName != "" || article.AuthorEmail != "" {
 		raw["author_name"] = article.AuthorName
 		raw["author_email"] = article.AuthorEmail

--- a/internal/craft/ai_filter.go
+++ b/internal/craft/ai_filter.go
@@ -82,11 +82,11 @@ func newAIFilterProcessor(rule string, extraPayloadRaw string) *AIFilterProcesso
 
 func (p *AIFilterProcessor) Process(ctx context.Context, feed *model.CraftFeed) (*model.CraftFeed, error) {
 	_ = ctx
-	if feed == nil || len(feed.Articles) == 0 {
-		return feed, nil
-	}
 	if p.rule == "" {
 		return nil, fmt.Errorf("ai-filter requires rule param")
+	}
+	if feed == nil || len(feed.Articles) == 0 {
+		return feed, nil
 	}
 
 	cloned := cloneCraftFeed(feed)

--- a/internal/craft/ai_filter.go
+++ b/internal/craft/ai_filter.go
@@ -1,11 +1,13 @@
 package craft
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"strings"
 
 	"FeedCraft/internal/constant"
+	"FeedCraft/internal/model"
 	"FeedCraft/internal/util"
 
 	"github.com/gorilla/feeds"
@@ -59,49 +61,81 @@ func GetAIFilterCraftOptions(rule string, extraPayloadRaw string) []LegacyCraftO
 }
 
 func OptionAIFilter(rule string, extraPayloadRaw string) LegacyCraftOption {
-	rule = strings.TrimSpace(rule)
-	payloadTypes := parseAIFilterExtraPayload(extraPayloadRaw)
+	processor := newAIFilterProcessor(rule, extraPayloadRaw)
 	return func(feed *feeds.Feed, payload ExtraPayload) error {
-		if rule == "" {
-			return fmt.Errorf("ai-filter requires rule param")
-		}
-		items := feed.Items
-		if len(items) == 0 {
-			return nil
-		}
-
-		drops := parallel.Map(items, func(item *feeds.Item, _ int) bool {
-			decision, err := evaluateAIFilterItem(item, rule, payloadTypes)
-			if err != nil {
-				logrus.Warnf("failed to evaluate ai-filter for article [%s], err: %v", item.Title, err)
-				return false
-			}
-			return decision.Result == aiFilterResultDrop
-		})
-
-		feed.Items = lo.Filter(items, func(_ *feeds.Item, index int) bool {
-			return !drops[index]
-		})
-		return nil
+		_ = payload
+		return applyLocalProcessorToLegacyFeed(context.Background(), processor, feed)
 	}
 }
 
-func evaluateAIFilterItem(item *feeds.Item, rule string, payloadTypes []aiFilterExtraPayloadType) (aiFilterDecision, error) {
+type AIFilterProcessor struct {
+	rule         string
+	payloadTypes []aiFilterExtraPayloadType
+}
+
+func newAIFilterProcessor(rule string, extraPayloadRaw string) *AIFilterProcessor {
+	return &AIFilterProcessor{
+		rule:         strings.TrimSpace(rule),
+		payloadTypes: parseAIFilterExtraPayload(extraPayloadRaw),
+	}
+}
+
+func (p *AIFilterProcessor) Process(ctx context.Context, feed *model.CraftFeed) (*model.CraftFeed, error) {
+	_ = ctx
+	if feed == nil || len(feed.Articles) == 0 {
+		return feed, nil
+	}
+	if p.rule == "" {
+		return nil, fmt.Errorf("ai-filter requires rule param")
+	}
+
+	cloned := cloneCraftFeed(feed)
+	drops := parallel.Map(cloned.Articles, func(article *model.CraftArticle, _ int) bool {
+		if article == nil {
+			return true
+		}
+		decision, err := p.evaluateAIFilterArticle(article)
+		if err != nil {
+			logrus.Warnf("failed to evaluate ai-filter for article [%s], err: %v", article.Title, err)
+			return false
+		}
+		return decision.Result == aiFilterResultDrop
+	})
+
+	filtered := make([]*model.CraftArticle, 0, len(cloned.Articles))
+	for idx, article := range cloned.Articles {
+		if article == nil {
+			continue
+		}
+		if !drops[idx] {
+			filtered = append(filtered, article)
+		}
+	}
+	cloned.Articles = filtered
+	return cloned, nil
+}
+
+func (p *AIFilterProcessor) evaluateAIFilterArticle(article *model.CraftArticle) (aiFilterDecision, error) {
 	summary := ""
-	if lo.Contains(payloadTypes, aiFilterExtraPayloadArticleSummary) {
-		generated, err := generateAIFilterArticleSummary(item)
+	if lo.Contains(p.payloadTypes, aiFilterExtraPayloadArticleSummary) {
+		generated, err := generateAIFilterArticleSummary(article)
 		if err != nil {
 			return aiFilterDecision{}, err
 		}
 		summary = generated
 	}
 
-	context, err := buildAIFilterArticlePayload(item, payloadTypes, summary)
+	payload, err := buildAIFilterArticlePayload(article, p.payloadTypes, summary)
 	if err != nil {
 		return aiFilterDecision{}, err
 	}
 
-	return cachedAIFilterDecision(item.Title, buildAIFilterPrompt(rule), context)
+	return cachedAIFilterDecision(article.Title, buildAIFilterPrompt(p.rule), payload)
+}
+
+func evaluateAIFilterItem(item *feeds.Item, rule string, payloadTypes []aiFilterExtraPayloadType) (aiFilterDecision, error) {
+	processor := &AIFilterProcessor{rule: strings.TrimSpace(rule), payloadTypes: payloadTypes}
+	return processor.evaluateAIFilterArticle(articleFromFeedItem(item))
 }
 
 func parseAIFilterExtraPayload(raw string) []aiFilterExtraPayloadType {
@@ -191,13 +225,13 @@ func cachedAIFilterDecision(title string, prompt string, context string) (aiFilt
 	return parseAIFilterDecision(cached)
 }
 
-func buildAIFilterArticlePayload(item *feeds.Item, payloadTypes []aiFilterExtraPayloadType, articleSummary string) (string, error) {
-	if item == nil {
+func buildAIFilterArticlePayload(article *model.CraftArticle, payloadTypes []aiFilterExtraPayloadType, articleSummary string) (string, error) {
+	if article == nil {
 		return "", fmt.Errorf("nil rss item")
 	}
 
 	var builder strings.Builder
-	fmt.Fprintf(&builder, "Article Title:\n```text\n%s\n```", strings.TrimSpace(item.Title))
+	fmt.Fprintf(&builder, "Article Title:\n```text\n%s\n```", strings.TrimSpace(article.Title))
 
 	for _, payloadType := range payloadTypes {
 		switch payloadType {
@@ -206,18 +240,18 @@ func buildAIFilterArticlePayload(item *feeds.Item, payloadTypes []aiFilterExtraP
 				fmt.Fprintf(&builder, "\n\nArticle Summary:\n```markdown\n%s\n```", strings.TrimSpace(articleSummary))
 			}
 		case aiFilterExtraPayloadArticleContent:
-			fmt.Fprintf(&builder, "\n\nArticle Content:\n```markdown\n%s\n```", strings.TrimSpace(getPrimaryFeedItemContent(item)))
+			fmt.Fprintf(&builder, "\n\nArticle Content:\n```markdown\n%s\n```", strings.TrimSpace(getPrimaryArticleContent(article)))
 		case aiFilterExtraPayloadArticleDate:
 			builder.WriteString("\n\nArticle Date:\n```text\n")
-			if !item.Created.IsZero() {
-				fmt.Fprintf(&builder, "Created: %s\n", item.Created.Format("2006-01-02T15:04:05Z07:00"))
+			if !article.Created.IsZero() {
+				fmt.Fprintf(&builder, "Created: %s\n", article.Created.Format("2006-01-02T15:04:05Z07:00"))
 			}
-			if !item.Updated.IsZero() {
-				fmt.Fprintf(&builder, "Updated: %s\n", item.Updated.Format("2006-01-02T15:04:05Z07:00"))
+			if !article.Updated.IsZero() {
+				fmt.Fprintf(&builder, "Updated: %s\n", article.Updated.Format("2006-01-02T15:04:05Z07:00"))
 			}
 			builder.WriteString("```")
 		case aiFilterExtraPayloadRawRSSItem:
-			rawJSON, err := buildRawRSSItemJSON(item)
+			rawJSON, err := buildRawRSSItemJSON(article)
 			if err != nil {
 				return "", err
 			}
@@ -228,8 +262,8 @@ func buildAIFilterArticlePayload(item *feeds.Item, payloadTypes []aiFilterExtraP
 	return builder.String(), nil
 }
 
-func generateAIFilterArticleSummary(item *feeds.Item) (string, error) {
-	content := getPrimaryFeedItemContent(item)
+func generateAIFilterArticleSummary(article *model.CraftArticle) (string, error) {
+	content := getPrimaryArticleContent(article)
 	if strings.TrimSpace(content) == "" {
 		return "", nil
 	}
@@ -237,17 +271,14 @@ func generateAIFilterArticleSummary(item *feeds.Item) (string, error) {
 	summaryPrompt := renderTargetLangPrompt("", constant.DefaultPrompts[constant.ProcessorTypeSummary])
 	hashVal := util.GetTextContentHash(strings.Join([]string{
 		util.GetTextContentHash(summaryPrompt),
-		strings.TrimSpace(item.Title),
+		strings.TrimSpace(article.Title),
 		util.GetTextContentHash(content),
 	}, "|"))
 	cacheKey := getCraftCacheKey("ai-filter-article-summary", hashVal)
 
 	return util.CachedFuncWithPreLog(cacheKey, func() (string, error) {
 		processedContent := content
-		domain := ""
-		if item.Link != nil {
-			domain, _ = util.ParseDomainFromUrl(item.Link.Href)
-		}
+		domain, _ := util.ParseDomainFromUrl(article.Link)
 		// Drop inline base64 images before converting: they carry no useful signal
 		// for LLM processing but can dominate the token budget.
 		cleanedContent := util.HTMLToMarkdown(util.RemoveBase64Images(content), domain)
@@ -258,7 +289,7 @@ func generateAIFilterArticleSummary(item *feeds.Item) (string, error) {
 			Temperature: util.LowestLLMTemperaturePtr(),
 		})
 	}, func(isCached bool) {
-		logrus.Infof("generating ai-filter article summary for article [%s], cached: %v", item.Title, isCached)
+		logrus.Infof("generating ai-filter article summary for article [%s], cached: %v", article.Title, isCached)
 	})
 }
 
@@ -299,39 +330,25 @@ func extractAIFilterJSON(raw string) (string, error) {
 	return strings.TrimSpace(trimmed[start : end+1]), nil
 }
 
-func getPrimaryFeedItemContent(item *feeds.Item) string {
-	if item == nil {
-		return ""
-	}
-	content := item.Content
-	if strings.TrimSpace(content) == "" {
-		content = item.Description
-	}
-	return content
-}
-
-func buildRawRSSItemJSON(item *feeds.Item) (string, error) {
+func buildRawRSSItemJSON(article *model.CraftArticle) (string, error) {
 	raw := map[string]string{
-		"title":       item.Title,
-		"description": item.Description,
-		"content":     item.Content,
-		"id":          item.Id,
+		"title":       article.Title,
+		"description": article.Description,
+		"content":     article.Content,
+		"id":          article.Id,
 	}
-	if item.Link != nil {
-		raw["link"] = item.Link.Href
+	if article.Link != "" {
+		raw["link"] = article.Link
 	}
-	if item.Source != nil {
-		raw["source"] = item.Source.Href
+	if article.AuthorName != "" || article.AuthorEmail != "" {
+		raw["author_name"] = article.AuthorName
+		raw["author_email"] = article.AuthorEmail
 	}
-	if item.Author != nil {
-		raw["author_name"] = item.Author.Name
-		raw["author_email"] = item.Author.Email
+	if !article.Created.IsZero() {
+		raw["created"] = article.Created.Format("2006-01-02T15:04:05Z07:00")
 	}
-	if !item.Created.IsZero() {
-		raw["created"] = item.Created.Format("2006-01-02T15:04:05Z07:00")
-	}
-	if !item.Updated.IsZero() {
-		raw["updated"] = item.Updated.Format("2006-01-02T15:04:05Z07:00")
+	if !article.Updated.IsZero() {
+		raw["updated"] = article.Updated.Format("2006-01-02T15:04:05Z07:00")
 	}
 
 	encoded, err := json.Marshal(raw)

--- a/internal/craft/ai_filter_test.go
+++ b/internal/craft/ai_filter_test.go
@@ -120,6 +120,56 @@ func TestAIFilterProcessorRejectsBlankRuleOnEmptyFeed(t *testing.T) {
 	assert.Contains(t, err.Error(), "requires rule param")
 }
 
+func TestAIFilterProcessorHonorsCanceledContextBeforeLLM(t *testing.T) {
+	original := llmContextCaller
+	llmContextCaller = func(prompt, context string, option util.ContentProcessOption) (string, error) {
+		t.Fatal("canceled context should not start LLM evaluation")
+		return "", nil
+	}
+	t.Cleanup(func() { llmContextCaller = original })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	processor := newAIFilterProcessor("只保留科技有关的文章", "article_content")
+	_, err := processor.Process(ctx, &model.CraftFeed{
+		Articles: []*model.CraftArticle{
+			{Title: "Keep", Content: "<p>article</p>"},
+		},
+	})
+	require.ErrorIs(t, err, context.Canceled)
+}
+
+func TestOptionAIFilterPreservesEnclosureAndPermalink(t *testing.T) {
+	setupTestRedis(t)
+
+	original := llmContextCaller
+	llmContextCaller = func(prompt, context string, option util.ContentProcessOption) (string, error) {
+		return `{"reason":"keep","result":"keep"}`, nil
+	}
+	t.Cleanup(func() { llmContextCaller = original })
+
+	enclosure := &feeds.Enclosure{Url: "https://example.com/audio.mp3", Length: "123", Type: "audio/mpeg"}
+	feed := &feeds.Feed{
+		Items: []*feeds.Item{
+			{
+				Title:       "Podcast",
+				Id:          "guid-keep",
+				Link:        &feeds.Link{Href: "https://example.com/post"},
+				Content:     "<p>episode</p>",
+				Enclosure:   enclosure,
+				IsPermaLink: "true",
+			},
+		},
+	}
+
+	err := OptionAIFilter("只保留科技有关的文章", "article_content")(feed, ExtraPayload{})
+	require.NoError(t, err)
+	require.Len(t, feed.Items, 1)
+	assert.Equal(t, enclosure, feed.Items[0].Enclosure)
+	assert.Equal(t, "true", feed.Items[0].IsPermaLink)
+}
+
 func TestAIFilterCraftLoadParamUsesRuleParam(t *testing.T) {
 	setupTestRedis(t)
 

--- a/internal/craft/ai_filter_test.go
+++ b/internal/craft/ai_filter_test.go
@@ -170,6 +170,28 @@ func TestOptionAIFilterPreservesEnclosureAndPermalink(t *testing.T) {
 	assert.Equal(t, "true", feed.Items[0].IsPermaLink)
 }
 
+func TestOptionAIFilterSkipsNilItems(t *testing.T) {
+	setupTestRedis(t)
+
+	original := llmContextCaller
+	llmContextCaller = func(prompt, context string, option util.ContentProcessOption) (string, error) {
+		return `{"reason":"keep","result":"keep"}`, nil
+	}
+	t.Cleanup(func() { llmContextCaller = original })
+
+	feed := &feeds.Feed{
+		Items: []*feeds.Item{
+			nil,
+			{Title: "Keep", Id: "guid-keep", Content: "<p>ok</p>"},
+		},
+	}
+
+	err := OptionAIFilter("只保留科技有关的文章", "article_content")(feed, ExtraPayload{})
+	require.NoError(t, err)
+	require.Len(t, feed.Items, 1)
+	assert.Equal(t, "Keep", feed.Items[0].Title)
+}
+
 func TestAIFilterCraftLoadParamUsesRuleParam(t *testing.T) {
 	setupTestRedis(t)
 

--- a/internal/craft/ai_filter_test.go
+++ b/internal/craft/ai_filter_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"FeedCraft/internal/model"
 	"FeedCraft/internal/util"
 
 	"github.com/gorilla/feeds"
@@ -23,13 +24,13 @@ func TestParseAIFilterDecisionAcceptsFencedJSON(t *testing.T) {
 }
 
 func TestBuildAIFilterArticlePayloadIncludesRequestedContent(t *testing.T) {
-	item := &feeds.Item{
+	article := &model.CraftArticle{
 		Title:       "AI chip news",
 		Description: "short description",
 		Content:     "<p>complete article content</p>",
 	}
 
-	payload, err := buildAIFilterArticlePayload(item, []aiFilterExtraPayloadType{aiFilterExtraPayloadArticleContent}, "")
+	payload, err := buildAIFilterArticlePayload(article, []aiFilterExtraPayloadType{aiFilterExtraPayloadArticleContent}, "")
 
 	require.NoError(t, err)
 	assert.Contains(t, payload, "Article Title:")
@@ -176,7 +177,7 @@ func TestBuildAIFilterArticlePayloadIncludesRawRSSItemAsJSON(t *testing.T) {
 		Created:     time.Date(2026, 5, 16, 10, 0, 0, 0, time.UTC),
 	}
 
-	payload, err := buildAIFilterArticlePayload(item, []aiFilterExtraPayloadType{aiFilterExtraPayloadRawRSSItem}, "")
+	payload, err := buildAIFilterArticlePayload(articleFromFeedItem(item), []aiFilterExtraPayloadType{aiFilterExtraPayloadRawRSSItem}, "")
 
 	require.NoError(t, err)
 	assert.Contains(t, payload, "Raw RSS Item JSON:")

--- a/internal/craft/ai_filter_test.go
+++ b/internal/craft/ai_filter_test.go
@@ -1,6 +1,7 @@
 package craft
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"sync"
@@ -110,6 +111,13 @@ func TestOptionAIFilterKeepsArticleOnInvalidLLMResponse(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, feed.Items, 1)
 	assert.Equal(t, "Keep on malformed response", feed.Items[0].Title)
+}
+
+func TestAIFilterProcessorRejectsBlankRuleOnEmptyFeed(t *testing.T) {
+	processor := newAIFilterProcessor("", "article_content")
+	_, err := processor.Process(context.Background(), &model.CraftFeed{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "requires rule param")
 }
 
 func TestAIFilterCraftLoadParamUsesRuleParam(t *testing.T) {

--- a/internal/craft/ai_filter_test.go
+++ b/internal/craft/ai_filter_test.go
@@ -174,6 +174,7 @@ func TestBuildAIFilterArticlePayloadIncludesRawRSSItemAsJSON(t *testing.T) {
 		Content:     "<p>Raw item content</p>",
 		Id:          "guid-1",
 		Link:        &feeds.Link{Href: "https://example.com/post"},
+		Source:      &feeds.Link{Href: "https://origin.example.com/feed.xml"},
 		Created:     time.Date(2026, 5, 16, 10, 0, 0, 0, time.UTC),
 	}
 
@@ -183,5 +184,6 @@ func TestBuildAIFilterArticlePayloadIncludesRawRSSItemAsJSON(t *testing.T) {
 	assert.Contains(t, payload, "Raw RSS Item JSON:")
 	assert.Contains(t, payload, `"title":"Raw item title"`)
 	assert.Contains(t, payload, `"link":"https://example.com/post"`)
+	assert.Contains(t, payload, `"source":"https://origin.example.com/feed.xml"`)
 	assert.Contains(t, payload, fmt.Sprintf(`"created":%q`, item.Created.Format(time.RFC3339)))
 }

--- a/internal/craft/embedding_filter.go
+++ b/internal/craft/embedding_filter.go
@@ -2,6 +2,7 @@ package craft
 
 import (
 	"FeedCraft/internal/adapter"
+	"FeedCraft/internal/model"
 	"FeedCraft/internal/util"
 	"context"
 	"errors"
@@ -11,7 +12,6 @@ import (
 	"unicode/utf8"
 
 	"github.com/gorilla/feeds"
-	"github.com/samber/lo"
 	"github.com/sirupsen/logrus"
 )
 
@@ -36,107 +36,111 @@ var (
 	EmbeddingExcludeMode EmbeddingFilterMode = "exclude" // 匹配锚点的文章被移除（反选）
 )
 
-// OptionEmbeddingFilter 创建 Embedding 主题过滤器的 CraftOption
-// anchors: 锚点文本列表
-// threshold: 余弦相似度阈值
-// maxContentLen: 文章正文最大截取长度
-// instruction: 传递给 Embedding 模型的 instruction 参数
-// mode: include（匹配即保留，默认）或 exclude（匹配即移除，反选）
-func OptionEmbeddingFilter(anchors []string, threshold float64, maxContentLen int, instruction string, mode EmbeddingFilterMode) LegacyCraftOption {
-	return OptionEmbeddingFilterWithContext(context.Background(), anchors, threshold, maxContentLen, instruction, mode)
+type EmbeddingFilterProcessor struct {
+	anchors       []string
+	threshold     float64
+	maxContentLen int
+	instruction   string
+	mode          EmbeddingFilterMode
 }
 
-func OptionEmbeddingFilterWithContext(ctx context.Context, anchors []string, threshold float64, maxContentLen int, instruction string, mode EmbeddingFilterMode) LegacyCraftOption {
-	return func(feed *feeds.Feed, payload ExtraPayload) error {
-		items := feed.Items
-		if len(items) == 0 {
-			return nil
-		}
+func NewEmbeddingFilterProcessor(anchors []string, threshold float64, maxContentLen int, instruction string, mode EmbeddingFilterMode) *EmbeddingFilterProcessor {
+	return &EmbeddingFilterProcessor{
+		anchors:       anchors,
+		threshold:     threshold,
+		maxContentLen: maxContentLen,
+		instruction:   instruction,
+		mode:          mode,
+	}
+}
 
-		// 0. 阈值 clamp：将 threshold 钳制到 [0, 1] 范围
-		if threshold < 0 {
-			logrus.Warnf("[embedding-filter] threshold %.4f is below 0, clamping to 0", threshold)
-			threshold = 0
-		}
-		if threshold > 1 {
-			logrus.Warnf("[embedding-filter] threshold %.4f is above 1, clamping to 1", threshold)
-			threshold = 1
-		}
+func (p *EmbeddingFilterProcessor) Process(ctx context.Context, feed *model.CraftFeed) (*model.CraftFeed, error) {
+	if feed == nil {
+		return feed, nil
+	}
+	if len(feed.Articles) == 0 {
+		return feed, nil
+	}
 
-		// 1. 校验锚点
-		if len(anchors) == 0 {
-			return errEmbeddingFilterAnchorsRequired
-		}
+	threshold := p.threshold
+	if threshold < 0 {
+		logrus.Warnf("[embedding-filter] threshold %.4f is below 0, clamping to 0", threshold)
+		threshold = 0
+	}
+	if threshold > 1 {
+		logrus.Warnf("[embedding-filter] threshold %.4f is above 1, clamping to 1", threshold)
+		threshold = 1
+	}
 
-		// 2. 获取或计算锚点向量（带内存缓存）
-		anchorVectors, err := adapter.GetOrComputeAnchorVectors(ctx, anchors, instruction)
-		if err != nil {
-			return fmt.Errorf("[embedding-filter] failed to compute anchor vectors: %w", err)
-		}
+	if len(p.anchors) == 0 {
+		return nil, errEmbeddingFilterAnchorsRequired
+	}
 
-		// 3. 收集所有文章文本，批量调用 Embedding
-		texts := make([]string, len(items))
-		for i, item := range items {
-			texts[i] = buildArticleText(item, maxContentLen)
-		}
+	anchorVectors, err := adapter.GetOrComputeAnchorVectors(ctx, p.anchors, p.instruction)
+	if err != nil {
+		return nil, fmt.Errorf("[embedding-filter] failed to compute anchor vectors: %w", err)
+	}
 
-		// 过滤掉空文本的索引，记录有效文本的映射
-		var validTexts []string
-		var validIndices []int
-		// emptyTextSet 记录空文本文章的索引，用于区分"空文本保留"和"计算失败保留"
-		emptyTextSet := make(map[int]bool)
-		for i, text := range texts {
-			if len(strings.TrimSpace(text)) > 0 {
-				validTexts = append(validTexts, text)
-				validIndices = append(validIndices, i)
+	articles := feed.Articles
+	texts := make([]string, len(articles))
+	for i, article := range articles {
+		texts[i] = buildArticleTextFromArticle(article, p.maxContentLen)
+	}
+
+	var validTexts []string
+	var validIndices []int
+	emptyTextSet := make(map[int]bool)
+	for i, text := range texts {
+		if len(strings.TrimSpace(text)) > 0 {
+			validTexts = append(validTexts, text)
+			validIndices = append(validIndices, i)
+		} else {
+			emptyTextSet[i] = true
+		}
+	}
+
+	articleVectors := make([][]float64, len(articles))
+	var embedErr error
+	if len(validTexts) > 0 {
+		vectors, batchErr := adapter.EmbedTexts(ctx, validTexts, p.instruction)
+		if batchErr != nil {
+			embedErr = batchErr
+			logrus.Errorf("[embedding-filter] batch embedding failed: %v", batchErr)
+		} else {
+			if len(vectors) < len(validTexts) {
+				logrus.Warnf("[embedding-filter] embedding returned %d vectors for %d texts, some articles may not be properly filtered", len(vectors), len(validTexts))
+			}
+			for j, idx := range validIndices {
+				if j < len(vectors) {
+					articleVectors[idx] = vectors[j]
+				}
+			}
+		}
+	}
+
+	if embedErr != nil {
+		return nil, fmt.Errorf("[embedding-filter] all article embeddings failed: %w", embedErr)
+	}
+
+	cloned := cloneCraftFeed(feed)
+	filtered := make([]*model.CraftArticle, 0, len(cloned.Articles))
+	totalCount := len(cloned.Articles)
+
+	for index, article := range cloned.Articles {
+		if article == nil {
+			continue
+		}
+		vec := articleVectors[index]
+
+		var keep bool
+		if vec == nil {
+			if emptyTextSet[index] {
+				keep = true
 			} else {
-				emptyTextSet[i] = true
+				logrus.Warnf("[embedding-filter] article [%s] has valid text but nil vector (embedding failed), keeping by default", article.Title)
+				keep = true
 			}
-		}
-
-		// 批量计算文章向量
-		articleVectors := make([][]float64, len(items)) // nil 表示未计算
-		var embedErr error
-		if len(validTexts) > 0 {
-			vectors, batchErr := adapter.EmbedTexts(ctx, validTexts, instruction)
-			if batchErr != nil {
-				embedErr = batchErr
-				logrus.Errorf("[embedding-filter] batch embedding failed: %v", batchErr)
-			} else {
-				// 检查返回的向量数量是否与请求数量一致
-				if len(vectors) < len(validTexts) {
-					logrus.Warnf("[embedding-filter] embedding returned %d vectors for %d texts, some articles may not be properly filtered", len(vectors), len(validTexts))
-				}
-				for j, idx := range validIndices {
-					if j < len(vectors) {
-						articleVectors[idx] = vectors[j]
-					}
-				}
-			}
-		}
-
-		// 4. 如果批量 Embedding 全部失败，返回错误
-		if embedErr != nil {
-			return fmt.Errorf("[embedding-filter] all article embeddings failed: %w", embedErr)
-		}
-
-		// 5. 根据相似度过滤
-		totalCount := len(items)
-		feed.Items = lo.Filter(items, func(item *feeds.Item, index int) bool {
-			vec := articleVectors[index]
-
-			// 向量为 nil 时区分原因
-			if vec == nil {
-				if emptyTextSet[index] {
-					// 空文本文章：保留（行为不变）
-					return true
-				}
-				// 有效文本但向量计算失败：保留但记录警告
-				logrus.Warnf("[embedding-filter] article [%s] has valid text but nil vector (embedding failed), keeping by default", item.Title)
-				return true
-			}
-
-			// 与所有锚点计算相似度，任一超过阈值即保留
+		} else {
 			maxSim := -1.0
 			for _, anchorVec := range anchorVectors {
 				sim := util.CosineSimilarity(vec, anchorVec)
@@ -144,64 +148,83 @@ func OptionEmbeddingFilterWithContext(ctx context.Context, anchors []string, thr
 					maxSim = sim
 				}
 			}
-
 			matched := maxSim >= threshold
-
-			// 根据 mode 决定保留逻辑
-			var keep bool
-			switch mode {
+			switch p.mode {
 			case EmbeddingExcludeMode:
-				keep = !matched // 反选：匹配的移除，不匹配的保留
-			default: // include
-				keep = matched // 选中：匹配的保留，不匹配的移除
+				keep = !matched
+			default:
+				keep = matched
 			}
-
 			if keep {
-				logrus.Debugf("[embedding-filter] article [%s] KEPT (max similarity: %.4f, threshold: %.4f, mode: %s)", item.Title, maxSim, threshold, mode)
+				logrus.Debugf("[embedding-filter] article [%s] KEPT (max similarity: %.4f, threshold: %.4f, mode: %s)", article.Title, maxSim, threshold, p.mode)
 			} else {
-				logrus.Debugf("[embedding-filter] article [%s] DROPPED (max similarity: %.4f, threshold: %.4f, mode: %s)", item.Title, maxSim, threshold, mode)
+				logrus.Debugf("[embedding-filter] article [%s] DROPPED (max similarity: %.4f, threshold: %.4f, mode: %s)", article.Title, maxSim, threshold, p.mode)
 			}
-			return keep
-		})
+		}
 
-		keptCount := len(feed.Items)
-		droppedCount := totalCount - keptCount
-		logrus.Infof("[embedding-filter] filtering complete: %d total, %d kept, %d dropped (threshold: %.4f, mode: %s)", totalCount, keptCount, droppedCount, threshold, mode)
+		if keep {
+			filtered = append(filtered, article)
+		}
+	}
 
-		return nil
+	cloned.Articles = filtered
+	keptCount := len(cloned.Articles)
+	droppedCount := totalCount - keptCount
+	logrus.Infof("[embedding-filter] filtering complete: %d total, %d kept, %d dropped (threshold: %.4f, mode: %s)", totalCount, keptCount, droppedCount, threshold, p.mode)
+
+	return cloned, nil
+}
+
+func OptionEmbeddingFilter(anchors []string, threshold float64, maxContentLen int, instruction string, mode EmbeddingFilterMode) LegacyCraftOption {
+	return OptionEmbeddingFilterWithContext(context.Background(), anchors, threshold, maxContentLen, instruction, mode)
+}
+
+func OptionEmbeddingFilterWithContext(ctx context.Context, anchors []string, threshold float64, maxContentLen int, instruction string, mode EmbeddingFilterMode) LegacyCraftOption {
+	processor := NewEmbeddingFilterProcessor(anchors, threshold, maxContentLen, instruction, mode)
+	return func(feed *feeds.Feed, payload ExtraPayload) error {
+		_ = payload
+		return applyLocalProcessorToLegacyFeed(ctx, processor, feed)
 	}
 }
 
-// buildArticleText 拼接文章标题和正文，正文超过 maxLen 时按 Unicode 字符截取
 func buildArticleText(item *feeds.Item, maxLen int) string {
-	content := item.Content
+	if item == nil {
+		return ""
+	}
+	return buildArticleTextParts(item.Title, item.Content, item.Description, maxLen)
+}
+
+func buildArticleTextFromArticle(article *model.CraftArticle, maxLen int) string {
+	if article == nil {
+		return ""
+	}
+	return buildArticleTextParts(article.Title, article.Content, article.Description, maxLen)
+}
+
+func buildArticleTextParts(title, content, description string, maxLen int) string {
 	if len(content) == 0 {
-		content = item.Description
+		content = description
 	}
 
-	// 按 Unicode 字符（rune）截取正文，避免切断多字节字符
 	if utf8.RuneCountInString(content) > maxLen {
 		runes := []rune(content)
 		content = string(runes[:maxLen])
 	}
 
-	if item.Title != "" && content != "" {
-		return item.Title + "\n" + content
+	if title != "" && content != "" {
+		return title + "\n" + content
 	}
-	if item.Title != "" {
-		return item.Title
+	if title != "" {
+		return title
 	}
 	return content
 }
 
-// GetEmbeddingFilterOptions 返回 Embedding 过滤器的 CraftOption 列表
 func GetEmbeddingFilterOptions(anchors []string, threshold float64, maxContentLen int, instruction string, mode EmbeddingFilterMode) []LegacyCraftOption {
 	return []LegacyCraftOption{
 		OptionEmbeddingFilter(anchors, threshold, maxContentLen, instruction, mode),
 	}
 }
-
-// --- CraftTemplate 参数定义 ---
 
 var embeddingFilterParamTmpl = []ParamTemplate{
 	{
@@ -231,66 +254,77 @@ var embeddingFilterParamTmpl = []ParamTemplate{
 	},
 }
 
-// embeddingFilterLoadParam 从参数 map 加载 Embedding 过滤器配置
-func embeddingFilterLoadParam(m map[string]string) []LegacyCraftOption {
-	// 解析锚点文本（换行分隔）
+type embeddingFilterParsedConfig struct {
+	anchors       []string
+	threshold     float64
+	maxContentLen int
+	instruction   string
+	mode          EmbeddingFilterMode
+}
+
+func parseEmbeddingFilterParams(m map[string]string) (embeddingFilterParsedConfig, error) {
+	cfg := embeddingFilterParsedConfig{
+		threshold:     defaultEmbeddingThreshold,
+		maxContentLen: defaultMaxContentLength,
+		mode:          EmbeddingIncludeMode,
+		instruction:   m["instruction"],
+	}
+
 	anchorsStr := m["anchors"]
 	if anchorsStr == "" {
 		logrus.Warn("[embedding-filter] anchors parameter is empty")
-		return []LegacyCraftOption{embeddingFilterConfigError(errEmbeddingFilterAnchorsRequired)}
+		return cfg, errEmbeddingFilterAnchorsRequired
 	}
 	rawAnchors := strings.Split(anchorsStr, "\n")
-	var anchors []string
 	for _, a := range rawAnchors {
 		a = strings.TrimSpace(a)
 		if a != "" {
-			anchors = append(anchors, a)
+			cfg.anchors = append(cfg.anchors, a)
 		}
 	}
-	if len(anchors) == 0 {
+	if len(cfg.anchors) == 0 {
 		logrus.Warn("[embedding-filter] no valid anchors after parsing")
-		return []LegacyCraftOption{embeddingFilterConfigError(errEmbeddingFilterAnchorsRequired)}
+		return cfg, errEmbeddingFilterAnchorsRequired
 	}
 
-	// 解析阈值
-	threshold := defaultEmbeddingThreshold
 	if thresholdStr, ok := m["threshold"]; ok && thresholdStr != "" {
 		parsed, err := strconv.ParseFloat(thresholdStr, 64)
 		if err != nil || parsed < 0 || parsed > 1 {
 			logrus.Warnf("[embedding-filter] invalid threshold value [%s], using default %.2f", thresholdStr, defaultEmbeddingThreshold)
 		} else {
-			threshold = parsed
+			cfg.threshold = parsed
 		}
 	}
 
-	// 解析最大内容长度
-	maxContentLen := defaultMaxContentLength
 	if maxLenStr, ok := m["max_content_length"]; ok && maxLenStr != "" {
 		parsed, err := strconv.Atoi(maxLenStr)
 		if err != nil || parsed <= 0 {
 			logrus.Warnf("[embedding-filter] invalid max_content_length value [%s], using default %d", maxLenStr, defaultMaxContentLength)
 		} else {
-			maxContentLen = parsed
+			cfg.maxContentLen = parsed
 		}
 	}
 
-	// 解析过滤模式
-	mode := EmbeddingIncludeMode
 	if modeStr, ok := m["mode"]; ok && modeStr != "" {
 		switch strings.ToLower(strings.TrimSpace(modeStr)) {
 		case "exclude":
-			mode = EmbeddingExcludeMode
+			cfg.mode = EmbeddingExcludeMode
 		case "include":
-			mode = EmbeddingIncludeMode
+			cfg.mode = EmbeddingIncludeMode
 		default:
 			logrus.Warnf("[embedding-filter] unknown mode [%s], using default 'include'", modeStr)
 		}
 	}
 
-	// 解析 instruction
-	instruction := m["instruction"]
+	return cfg, nil
+}
 
-	return GetEmbeddingFilterOptions(anchors, threshold, maxContentLen, instruction, mode)
+func embeddingFilterLoadParam(m map[string]string) []LegacyCraftOption {
+	cfg, err := parseEmbeddingFilterParams(m)
+	if err != nil {
+		return []LegacyCraftOption{embeddingFilterConfigError(err)}
+	}
+	return GetEmbeddingFilterOptions(cfg.anchors, cfg.threshold, cfg.maxContentLen, cfg.instruction, cfg.mode)
 }
 
 func embeddingFilterConfigError(err error) LegacyCraftOption {

--- a/internal/craft/runtime.go
+++ b/internal/craft/runtime.go
@@ -66,6 +66,9 @@ var nativeProcessorBuilders = map[string]nativeProcessorBuilder{
 	"beautify-content":            buildWithStringParam("prompt", func(s string) localProcessor { return newBeautifyContentProcessor(s) }),
 	"llm-filter":                  buildWithStringParam("filter_condition", func(s string) localProcessor { return newLLMFilterProcessor(s) }),
 	"ignore-advertorial":          buildWithStringParam("prompt-for-exclude", func(s string) localProcessor { return newIgnoreAdvertorialProcessor(s) }),
+	"embedding-filter":            buildNativeEmbeddingFilterProcessor,
+	"ai-filter":                   buildNativeAIFilterProcessor,
+	"ai-content-process":          buildNativeAIContentProcessProcessor,
 }
 
 func BuildOptionChain(db *gorm.DB, craftName string, feedURL string) (engine.CraftOption, error) {
@@ -368,6 +371,25 @@ func buildNativeFulltextPlusProcessor(atom ResolvedCraftAtom, feedURL string) (e
 	return wrapLocalProcessor(newFulltextPlusProcessor(feedURL, parseFulltextPlusConfig(atom.Params))), nil
 }
 
+func buildNativeEmbeddingFilterProcessor(atom ResolvedCraftAtom, feedURL string) (engine.CraftOption, error) {
+	_ = feedURL
+	cfg, err := parseEmbeddingFilterParams(atom.Params)
+	if err != nil {
+		return nil, err
+	}
+	return wrapLocalProcessor(NewEmbeddingFilterProcessor(cfg.anchors, cfg.threshold, cfg.maxContentLen, cfg.instruction, cfg.mode)), nil
+}
+
+func buildNativeAIFilterProcessor(atom ResolvedCraftAtom, feedURL string) (engine.CraftOption, error) {
+	_ = feedURL
+	return wrapLocalProcessor(newAIFilterProcessor(atom.Params["rule"], atom.Params["extra-payload"])), nil
+}
+
+func buildNativeAIContentProcessProcessor(atom ResolvedCraftAtom, feedURL string) (engine.CraftOption, error) {
+	_ = feedURL
+	return wrapLocalProcessor(newAIContentProcessProcessor(atom.Params["rule"], atom.Params["extra-payload"], atom.Params["placement"])), nil
+}
+
 func buildLegacyOption(atom ResolvedCraftAtom, feedURL string) (engine.CraftOption, error) {
 	tmplDict := GetSysCraftTemplateDict()
 	tmpl, ok := tmplDict[atom.TemplateName]
@@ -408,6 +430,10 @@ func wrapLocalProcessor(processor localProcessor) engine.CraftOption {
 	return func(ctx context.Context, feed *model.CraftFeed) (*model.CraftFeed, error) {
 		return processor.Process(ctx, feed)
 	}
+}
+
+func WrapLocalProcessor(processor localProcessor) engine.CraftOption {
+	return wrapLocalProcessor(processor)
 }
 
 func composeEngineOptions(options ...engine.CraftOption) engine.CraftOption {

--- a/internal/craft/runtime_test.go
+++ b/internal/craft/runtime_test.go
@@ -560,6 +560,87 @@ func TestIgnoreAdvertorialProcessor_KeepsArticleOnLLMError(t *testing.T) {
 	assert.Equal(t, "Maybe Ad", result.Articles[0].Title)
 }
 
+func TestBuildOptionChain_AIFilterUsesNativeProcessor(t *testing.T) {
+	setupTestRedis(t)
+
+	original := llmContextCaller
+	llmContextCaller = func(prompt, context string, option util.ContentProcessOption) (string, error) {
+		if strings.Contains(context, "drop me") {
+			return `{"reason":"excluded","result":"drop"}`, nil
+		}
+		return `{"reason":"kept","result":"keep"}`, nil
+	}
+	t.Cleanup(func() { llmContextCaller = original })
+
+	db := newCraftRuntimeTestDB(t)
+	require.NoError(t, dao.CreateCraftAtom(db, &dao.CraftAtom{
+		Name:         "native-ai-filter",
+		TemplateName: "ai-filter",
+		Params:       map[string]string{"rule": "只保留科技文章", "extra-payload": "article_content"},
+	}))
+
+	processor, err := BuildOptionChain(db, "native-ai-filter", "https://example.com/feed.xml")
+	require.NoError(t, err)
+	require.NotNil(t, processor)
+
+	result, err := processor(context.Background(), &model.CraftFeed{
+		Articles: []*model.CraftArticle{
+			{Title: "Drop", Content: "<p>drop me</p>"},
+			{Title: "Keep", Content: "<p>keep me</p>"},
+		},
+	})
+	require.NoError(t, err)
+	require.Len(t, result.Articles, 1)
+	assert.Equal(t, "Keep", result.Articles[0].Title)
+}
+
+func TestBuildOptionChain_AIContentProcessUsesNativeProcessor(t *testing.T) {
+	setupTestRedis(t)
+
+	original := llmContextCaller
+	llmContextCaller = func(prompt, context string, option util.ContentProcessOption) (string, error) {
+		return "## Note\n\nprocessed", nil
+	}
+	t.Cleanup(func() { llmContextCaller = original })
+
+	db := newCraftRuntimeTestDB(t)
+	require.NoError(t, dao.CreateCraftAtom(db, &dao.CraftAtom{
+		Name:         "native-ai-content",
+		TemplateName: "ai-content-process",
+		Params: map[string]string{
+			"rule":          "提取要点",
+			"extra-payload": "article_content",
+			"placement":     "replace",
+		},
+	}))
+
+	processor, err := BuildOptionChain(db, "native-ai-content", "https://example.com/feed.xml")
+	require.NoError(t, err)
+
+	result, err := processor(context.Background(), &model.CraftFeed{
+		Articles: []*model.CraftArticle{
+			{Title: "Original", Content: "<p>original body</p>"},
+		},
+	})
+	require.NoError(t, err)
+	require.Len(t, result.Articles, 1)
+	assert.Contains(t, result.Articles[0].Content, "processed")
+	assert.NotContains(t, result.Articles[0].Content, "original body")
+}
+
+func TestBuildOptionChain_EmbeddingFilterRejectsEmptyAnchors(t *testing.T) {
+	db := newCraftRuntimeTestDB(t)
+	require.NoError(t, dao.CreateCraftAtom(db, &dao.CraftAtom{
+		Name:         "native-embedding-empty",
+		TemplateName: "embedding-filter",
+		Params:       map[string]string{"anchors": ""},
+	}))
+
+	_, err := BuildOptionChain(db, "native-embedding-empty", "https://example.com/feed.xml")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "anchors")
+}
+
 func newCraftRuntimeTestDB(t *testing.T) *gorm.DB {
 	t.Helper()
 	dsn := "file:" + t.Name() + "?mode=memory&cache=shared"

--- a/internal/model/feed.go
+++ b/internal/model/feed.go
@@ -233,7 +233,10 @@ func FromFeedsFeed(ff *feeds.Feed) *CraftFeed {
 		cf.ImageTitle = ff.Image.Title
 	}
 
-	cf.Articles = lo.Map(ff.Items, func(item *feeds.Item, _ int) *CraftArticle {
+	cf.Articles = lo.FilterMap(ff.Items, func(item *feeds.Item, _ int) (*CraftArticle, bool) {
+		if item == nil {
+			return nil, false
+		}
 		ca := &CraftArticle{
 			Title:       item.Title,
 			Description: item.Description,
@@ -252,7 +255,7 @@ func FromFeedsFeed(ff *feeds.Feed) *CraftFeed {
 		if item.Source != nil {
 			ca.Source = item.Source.Href
 		}
-		return ca
+		return ca, true
 	})
 
 	return cf

--- a/internal/model/feed.go
+++ b/internal/model/feed.go
@@ -39,6 +39,7 @@ type CraftArticle struct {
 	Content     string
 	AuthorName  string
 	AuthorEmail string
+	Source      string // RSS <source> / Atom source href, if present
 
 	// Internal metadata for future expansion (Topic aggregation, fission, etc.)
 	OriginalFeedID string // The ID of the raw source it came from
@@ -198,6 +199,9 @@ func (ca *CraftArticle) ToFeedsItem() *feeds.Item {
 			Email: ca.AuthorEmail,
 		}
 	}
+	if ca.Source != "" {
+		item.Source = &feeds.Link{Href: ca.Source}
+	}
 
 	return item
 }
@@ -244,6 +248,9 @@ func FromFeedsFeed(ff *feeds.Feed) *CraftFeed {
 		if item.Author != nil {
 			ca.AuthorName = item.Author.Name
 			ca.AuthorEmail = item.Author.Email
+		}
+		if item.Source != nil {
+			ca.Source = item.Source.Href
 		}
 		return ca
 	})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 背景

`feat/dev-temp-branch` 相对 `dev` 只有一个 `tmp commit`，且基于很早的 merge-base。其中大量改动是半成品：删除 `option.go` / `common.go`、掏空已经 native 化的 craft，以及回退 Feed Viewer 的 `feedcraft://` / `feedType` 能力。这些**不**应合入。

该分支真正有意义、且 `dev` 尚未完成的部分，是把仍走 gorilla `feeds.Feed` 遗留路径的三项 craft 接到现有 native processor 运行时。

## 本次提取并应用到 dest 的改动

- `ai-filter`、`ai-content-process`、`embedding-filter` 实现为 `CraftFeed` native processor，并注册到 `nativeProcessorBuilders`
- Feed Viewer 预览改为 `BuildOptionChain` / `WrapLocalProcessor` 直接处理 `CraftFeed`，去掉 Atom XML 往返
- 遗留 `Option*` API 改为委托 native processor，现有单测仍覆盖行为
- 保留 dest 后续已落地的行为：base64 图片清理、embedding 空文本默认保留、`feedcraft://` 内部 URI、`feedType`
- `CraftArticle` 保留 RSS `source`，避免 `raw_rss_item` 路径在遗留转换中丢失来源 URL

## 明确未带走的内容

- 删除遗留 `option.go` / `common.go` / `adapter.go`（dest 仍有 ProcessFeed 与模板 OptionFunc）
- 回退 Feed Viewer 的内部 URI 校验与 `feedType`
- 临时分支里过时的 `Html2Markdown` API 与不完整的 embedding 空文本逻辑

## 测试

- `go test ./internal/craft/ ./internal/controller/`
- 新增 `BuildOptionChain` 对 `ai-filter` / `ai-content-process` / `embedding-filter` 的覆盖
- `raw_rss_item` 覆盖带 `feeds.Item.Source` 的 JSON 输出
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7f909ce7-5a4d-495a-9e71-5eafab9dffe5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7f909ce7-5a4d-495a-9e71-5eafab9dffe5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

## Summary by Sourcery

将剩余 AI 和 embedding craft 迁移到原生 CraftFeed 处理链，并保持遗留接口及现有 Feed Viewer 行为兼容。

New Features:
- 将 ai-filter、ai-content-process 和 embedding-filter 接入原生 CraftFeed 处理器运行时。

Bug Fixes:
- 保留 RSS source 信息并修复遗留 Feed 转换中可能丢失的来源 URL；兼容旧 API 时保留 enclosure 和 permalink 元数据。

Enhancements:
- 将 Feed Viewer 预览改为直接处理 CraftFeed，移除 Atom XML 往返转换。
- 让遗留 Option API 委托原生处理器，同时保持空文本 embedding 文章默认保留等既有行为。

Tests:
- 补充三项 craft 通过 BuildOptionChain 使用原生处理器的覆盖，并完善 RSS source、上下文取消及遗留元数据保留测试。