### PR TITLE
fix(admin): 居中 Topic 创建向导核心内容区域

### DIFF
--- a/web/admin/src/views/dashboard/topic_feed/editor.vue
+++ b/web/admin/src/views/dashboard/topic_feed/editor.vue
@@ -6,187 +6,186 @@
     <x-header :title="pageTitle" :description="t('topic.wizard.description')" />
 
     <a-card class="wizard-card">
-      <a-steps :current="currentStep" class="wizard-steps">
-        <a-step
-          :title="t('topic.wizard.step.basic')"
-          :description="t('topic.wizard.step.basic.desc')"
-        />
-        <a-step
-          :title="t('topic.wizard.step.inputs')"
-          :description="t('topic.wizard.step.inputs.desc')"
-        />
-        <a-step
-          :title="t('topic.wizard.step.aggregator')"
-          :description="t('topic.wizard.step.aggregator.desc')"
-        />
-        <a-step
-          :title="t('topic.wizard.step.review')"
-          :description="t('topic.wizard.step.review.desc')"
-        />
-      </a-steps>
+      <div class="wizard-shell">
+        <a-steps :current="currentStep" class="wizard-steps">
+          <a-step
+            :title="t('topic.wizard.step.basic')"
+            :description="t('topic.wizard.step.basic.desc')"
+          />
+          <a-step
+            :title="t('topic.wizard.step.inputs')"
+            :description="t('topic.wizard.step.inputs.desc')"
+          />
+          <a-step
+            :title="t('topic.wizard.step.aggregator')"
+            :description="t('topic.wizard.step.aggregator.desc')"
+          />
+          <a-step
+            :title="t('topic.wizard.step.review')"
+            :description="t('topic.wizard.step.review.desc')"
+          />
+        </a-steps>
 
-      <a-spin :loading="pageLoading" class="wizard-spin">
-        <a-form
-          ref="formRef"
-          :model="formData"
-          layout="vertical"
-          label-align="left"
-          class="wizard-form"
-        >
-          <section
-            v-show="currentStep === 1"
-            class="step-panel step-panel--basic"
+        <a-spin :loading="pageLoading" class="wizard-spin">
+          <a-form
+            ref="formRef"
+            :model="formData"
+            layout="vertical"
+            label-align="left"
+            class="wizard-form"
           >
-            <a-form-item
-              field="id"
-              :label="t('topic.id')"
-              required
-              :rules="getRecipeIdRules(t('topic.idRequired'))"
-            >
-              <a-input
-                v-model="formData.id"
-                :disabled="isEdit"
-                :placeholder="t('topic.id')"
-              />
-            </a-form-item>
-            <a-form-item field="title" :label="t('topic.title')">
-              <a-input
-                v-model="formData.title"
-                :placeholder="t('topic.title')"
-              />
-            </a-form-item>
-            <a-form-item
-              field="description"
-              :label="t('topic.descriptionLabel')"
-            >
-              <a-textarea
-                v-model="formData.description"
-                :placeholder="t('topic.descriptionLabel')"
-                :auto-size="{ minRows: 3, maxRows: 6 }"
-              />
-            </a-form-item>
-          </section>
-
-          <section v-show="currentStep === 2" class="step-panel">
-            <a-alert type="info" class="mb-4" show-icon>
-              {{ t('topic.inputsHelp') }}
-            </a-alert>
-            <TopicInputSourcesEditor
-              v-model="formData.inputSources"
-              :available-recipes="availableRecipes"
-              :available-topics="availableTopics"
-              :available-inboxes="availableInboxes"
-              :picker-loading="pickerLoading"
-              :exclude-topic-id="isEdit ? formData.id : undefined"
-            />
-          </section>
-
-          <section v-show="currentStep === 3" class="step-panel">
-            <a-alert type="info" class="mb-4" show-icon>
-              {{ t('topic.aggregatorHelp') }}
-            </a-alert>
-            <TopicAggregatorEditor v-model="formData.aggregator_config" />
-          </section>
-
-          <section v-show="currentStep === 4" class="step-panel">
-            <a-descriptions :column="1" bordered>
-              <a-descriptions-item :label="t('topic.id')">
-                {{ formData.id || '-' }}
-              </a-descriptions-item>
-              <a-descriptions-item :label="t('topic.title')">
-                {{ formData.title || '-' }}
-              </a-descriptions-item>
-              <a-descriptions-item :label="t('topic.descriptionLabel')">
-                {{ formData.description || '-' }}
-              </a-descriptions-item>
-              <a-descriptions-item :label="t('topic.inputCount')">
-                {{ configuredInputCount }}
-              </a-descriptions-item>
-              <a-descriptions-item :label="t('topic.aggregator')">
-                {{
-                  formatAggregatorSummary(
-                    normalizeTopicPayload(formData).aggregator_config,
-                    t
-                  )
-                }}
-              </a-descriptions-item>
-            </a-descriptions>
-
-            <div class="section-label mt-4">{{ t('topic.inputs') }}</div>
-            <a-list bordered class="mb-4">
-              <a-list-item
-                v-for="(source, idx) in reviewInputs"
-                :key="`review-input-${idx}`"
+            <section v-show="currentStep === 1" class="step-panel">
+              <a-form-item
+                field="id"
+                :label="t('topic.id')"
+                required
+                :rules="getRecipeIdRules(t('topic.idRequired'))"
               >
-                <a-list-item-meta
-                  :title="source.description || source.uri"
-                  :description="source.description ? source.uri : undefined"
+                <a-input
+                  v-model="formData.id"
+                  :disabled="isEdit"
+                  :placeholder="t('topic.id')"
                 />
-                <template #actions>
-                  <a-tag v-if="source.disabled" color="gray">
-                    {{ t('topic.inputDisabled.badge') }}
-                  </a-tag>
-                </template>
-              </a-list-item>
-            </a-list>
-
-            <a-alert v-if="validationErrors.length > 0" type="error">
-              <template #title>{{ t('topic.validationSummary') }}</template>
-              <div
-                v-for="issue in validationErrors"
-                :key="`${issue.field}-${issue.message}`"
-                class="validation-item"
+              </a-form-item>
+              <a-form-item field="title" :label="t('topic.title')">
+                <a-input
+                  v-model="formData.title"
+                  :placeholder="t('topic.title')"
+                />
+              </a-form-item>
+              <a-form-item
+                field="description"
+                :label="t('topic.descriptionLabel')"
               >
-                <strong>{{ issue.field }}</strong
-                >: {{ issue.message }}
-              </div>
-            </a-alert>
-            <a-alert
-              v-if="validationWarnings.length > 0"
-              type="warning"
-              style="margin-top: 12px"
-            >
-              <template #title>{{ t('topic.validationWarnings') }}</template>
-              <div
-                v-for="issue in validationWarnings"
-                :key="`${issue.field}-${issue.message}`"
-                class="validation-item"
-              >
-                <strong>{{ issue.field }}</strong
-                >: {{ issue.message }}
-              </div>
-            </a-alert>
-          </section>
-        </a-form>
-      </a-spin>
+                <a-textarea
+                  v-model="formData.description"
+                  :placeholder="t('topic.descriptionLabel')"
+                  :auto-size="{ minRows: 3, maxRows: 6 }"
+                />
+              </a-form-item>
+            </section>
 
-      <div class="wizard-footer">
-        <a-space>
-          <a-button @click="goBackToList">{{ t('topic.cancel') }}</a-button>
-          <a-button v-if="currentStep > 1" @click="prevStep">
-            {{ t('topic.wizard.prev') }}
-          </a-button>
-          <a-button
-            v-if="currentStep < 4"
-            type="primary"
-            :loading="stepValidating"
-            @click="nextStep"
-          >
-            {{ t('topic.wizard.next') }}
-          </a-button>
-          <template v-else>
-            <a-button :loading="validating" @click="handleValidate">
-              {{ t('topic.validate') }}
+            <section v-show="currentStep === 2" class="step-panel">
+              <a-alert type="info" class="mb-4" show-icon>
+                {{ t('topic.inputsHelp') }}
+              </a-alert>
+              <TopicInputSourcesEditor
+                v-model="formData.inputSources"
+                :available-recipes="availableRecipes"
+                :available-topics="availableTopics"
+                :available-inboxes="availableInboxes"
+                :picker-loading="pickerLoading"
+                :exclude-topic-id="isEdit ? formData.id : undefined"
+              />
+            </section>
+
+            <section v-show="currentStep === 3" class="step-panel">
+              <a-alert type="info" class="mb-4" show-icon>
+                {{ t('topic.aggregatorHelp') }}
+              </a-alert>
+              <TopicAggregatorEditor v-model="formData.aggregator_config" />
+            </section>
+
+            <section v-show="currentStep === 4" class="step-panel">
+              <a-descriptions :column="1" bordered>
+                <a-descriptions-item :label="t('topic.id')">
+                  {{ formData.id || '-' }}
+                </a-descriptions-item>
+                <a-descriptions-item :label="t('topic.title')">
+                  {{ formData.title || '-' }}
+                </a-descriptions-item>
+                <a-descriptions-item :label="t('topic.descriptionLabel')">
+                  {{ formData.description || '-' }}
+                </a-descriptions-item>
+                <a-descriptions-item :label="t('topic.inputCount')">
+                  {{ configuredInputCount }}
+                </a-descriptions-item>
+                <a-descriptions-item :label="t('topic.aggregator')">
+                  {{
+                    formatAggregatorSummary(
+                      normalizeTopicPayload(formData).aggregator_config,
+                      t
+                    )
+                  }}
+                </a-descriptions-item>
+              </a-descriptions>
+
+              <div class="section-label mt-4">{{ t('topic.inputs') }}</div>
+              <a-list bordered class="mb-4">
+                <a-list-item
+                  v-for="(source, idx) in reviewInputs"
+                  :key="`review-input-${idx}`"
+                >
+                  <a-list-item-meta
+                    :title="source.description || source.uri"
+                    :description="source.description ? source.uri : undefined"
+                  />
+                  <template #actions>
+                    <a-tag v-if="source.disabled" color="gray">
+                      {{ t('topic.inputDisabled.badge') }}
+                    </a-tag>
+                  </template>
+                </a-list-item>
+              </a-list>
+
+              <a-alert v-if="validationErrors.length > 0" type="error">
+                <template #title>{{ t('topic.validationSummary') }}</template>
+                <div
+                  v-for="issue in validationErrors"
+                  :key="`${issue.field}-${issue.message}`"
+                  class="validation-item"
+                >
+                  <strong>{{ issue.field }}</strong
+                  >: {{ issue.message }}
+                </div>
+              </a-alert>
+              <a-alert
+                v-if="validationWarnings.length > 0"
+                type="warning"
+                style="margin-top: 12px"
+              >
+                <template #title>{{ t('topic.validationWarnings') }}</template>
+                <div
+                  v-for="issue in validationWarnings"
+                  :key="`${issue.field}-${issue.message}`"
+                  class="validation-item"
+                >
+                  <strong>{{ issue.field }}</strong
+                  >: {{ issue.message }}
+                </div>
+              </a-alert>
+            </section>
+          </a-form>
+        </a-spin>
+
+        <div class="wizard-footer">
+          <a-space>
+            <a-button @click="goBackToList">{{ t('topic.cancel') }}</a-button>
+            <a-button v-if="currentStep > 1" @click="prevStep">
+              {{ t('topic.wizard.prev') }}
             </a-button>
             <a-button
+              v-if="currentStep < 4"
               type="primary"
-              :loading="submitting"
-              @click="handleSubmit"
+              :loading="stepValidating"
+              @click="nextStep"
             >
-              {{ t('topic.save') }}
+              {{ t('topic.wizard.next') }}
             </a-button>
-          </template>
-        </a-space>
+            <template v-else>
+              <a-button :loading="validating" @click="handleValidate">
+                {{ t('topic.validate') }}
+              </a-button>
+              <a-button
+                type="primary"
+                :loading="submitting"
+                @click="handleSubmit"
+              >
+                {{ t('topic.save') }}
+              </a-button>
+            </template>
+          </a-space>
+        </div>
       </div>
     </a-card>
   </div>
@@ -404,6 +403,16 @@
     min-height: 560px;
   }
 
+  .wizard-shell {
+    width: 100%;
+    max-width: 760px;
+    margin: 0 auto;
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+    min-width: 0;
+  }
+
   .wizard-steps {
     margin-bottom: 24px;
     padding-bottom: 20px;
@@ -445,12 +454,6 @@
 
   .step-panel {
     width: 100%;
-    max-width: 720px;
-    margin: 0;
-  }
-
-  .step-panel--basic {
-    max-width: 560px;
   }
 
   .wizard-footer {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 背景

Linear [COL-31](https://linear.app/colin-x-studio/issue/COL-31/feedcraft-topic-创建的页面-表单里布局不合理-核心内容区域应当居中)：Topic 创建页 `/worktable/topic_feed/create` 在宽屏下表单贴左、右侧大片空白。

本地复现确认：`.step-panel` 限制了 `max-width`，但使用 `margin: 0`，没有水平居中。

## 改动

- 将步骤条、表单、底栏包进 `.wizard-shell`
- 居中列 `max-width: 760px; margin: 0 auto`
- 去掉基本信息步骤更窄的 560px 限制，与整列宽度一致
- 创建页与编辑页共用 `editor.vue`

## 验证

- 宽屏下修复前输入框约在 `x=192–559`（贴左）；修复后约在 `x=463–961`（水平居中）
- 浏览器走完创建向导第 1、2 步，内容保持居中
- `pnpm run type:check` 通过；`eslint` 对该文件无 error

[修复前表单贴左](https://cursor.com/agents/bc-21de0502-0c97-4663-b8dc-3b47c7d681f1/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftopic_create_before_left_aligned.webp)
[修复后第1步居中](https://cursor.com/agents/bc-21de0502-0c97-4663-b8dc-3b47c7d681f1/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftopic_create_after_step1_centered.webp)
[topic_create_centered_maximized.mp4](https://cursor.com/agents/bc-21de0502-0c97-4663-b8dc-3b47c7d681f1/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftopic_create_centered_maximized.mp4)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-21de0502-0c97-4663-b8dc-3b47c7d681f1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-21de0502-0c97-4663-b8dc-3b47c7d681f1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

## Summary by Sourcery

将 Topic 向导内容调整为统一宽度并水平居中。

Bug Fixes:
- 居中 Topic 创建和编辑向导的核心内容区域，避免宽屏下内容贴左并留下大面积空白。

Enhancements:
- 统一步骤条、表单和底栏的内容宽度，并移除基本信息步骤的额外窄宽限制。