### PR TITLE
perf(craft): 单 feed 文章并发进入全局 LLM 调度器

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,6 +25,8 @@ FC_LLM_API_KEY=sk-your-api-key-here
 FC_LLM_API_MODEL=gpt-3.5-turbo
 FC_LLM_API_TYPE=openai
 FC_DEFAULT_TARGET_LANG=zh-CN
+# Global max concurrent LLM API requests shared by all feeds and features. Default: 3
+# FC_LLM_MAX_CONCURRENCY=3
 
 # Embedding Configuration (for embedding-filter feature)
 # If type/base/key are not set, they fall back to the LLM type/base/key above.

--- a/doc-site/src/content/docs/en/guides/advanced/customization.md
+++ b/doc-site/src/content/docs/en/guides/advanced/customization.md
@@ -75,7 +75,7 @@ You can configure FeedCraft using environment variables in `docker-compose.yml`.
 - **FC_LLM_API_MODEL**: Default model to use (e.g., `gemini-pro`, `gpt-3.5-turbo`). **Multiple Models Support:** You can provide a comma-separated list of models (e.g., `gpt-3.5-turbo,gpt-4`). FeedCraft will randomly select a model for each request and automatically retry with others if a call fails.
 - **FC_LLM_API_BASE**: API endpoint address. For OpenAI-compatible APIs, usually ends with `/v1`.
 - **FC_LLM_API_TYPE**: (Optional) `openai` (default) or `ollama`.
-- **FC_LLM_MAX_CONCURRENCY**: (Optional) Global maximum concurrency for LLM requests (default: `3`). Limits concurrent API calls to prevent rate limits.
+- **FC_LLM_MAX_CONCURRENCY**: (Optional) Maximum number of LLM API requests executing across the entire FeedCraft process (default: `3`). All feeds, Recipes, AtomCrafts, and other LLM features share this global limit. Article tasks may enter the queue concurrently, but no more than this number of upstream requests execute at once; cache hits do not consume capacity.
 - **FC_DOMAIN_MAX_CONCURRENCY**: (Optional) Maximum concurrent requests per target domain during web scraping like fulltext extraction (default: `3`). Prevents overwhelming target servers.
 - **FC_PREHEATING_MAX_CONCURRENCY**: (Optional) Maximum concurrent background preheating tasks (default: `2`).
 - **FC_PREHEATING_QUEUE_SIZE**: (Optional) Maximum pending preheating tasks; defaults to the preheating concurrency.

--- a/doc-site/src/content/docs/zh-tw/guides/advanced/customization.md
+++ b/doc-site/src/content/docs/zh-tw/guides/advanced/customization.md
@@ -75,7 +75,7 @@ sidebar:
 - **FC_LLM_API_MODEL**: 預設使用的模型（如 `gemini-pro`, `gpt-3.5-turbo`）。**支援多個模型：** 你可以提供一個逗號分隔的模型列表（例如 `gpt-3.5-turbo,gpt-4`）。FeedCraft 會為每個請求隨機選擇一個模型，如果調用失敗，會自動重試列表中的其他模型。
 - **FC_LLM_API_BASE**: API 介面地址。如果是相容 OpenAI 的 API，通常以 `/v1` 結尾。
 - **FC_LLM_API_TYPE**: (可選) `openai` (預設) 或 `ollama`.
-- **FC_LLM_MAX_CONCURRENCY**: (可選) 全局最大 LLM 併發請求數（預設: `3`）。用於限制併發請求數量以防止觸發 API 速率限制。
+- **FC_LLM_MAX_CONCURRENCY**: （可選）整個 FeedCraft 程序同時執行的 LLM API 請求上限（預設：`3`）。所有 feed、Recipe、AtomCraft 及其他 LLM 功能共享這項全域限制。文章任務可以並行進入佇列，但實際同時執行的上游請求不會超過該值；快取命中不占用並行額度。
 - **FC_DOMAIN_MAX_CONCURRENCY**: (可選) 網頁抓取（如全文提取）時每個目標域名的最大併發數（預設: `3`）。防止抓取目標伺服器負載過高。
 - **FC_PREHEATING_MAX_CONCURRENCY**: （可選）背景預熱工作的最大併發數（預設：`2`）。
 - **FC_PREHEATING_QUEUE_SIZE**: （可選）預熱等候佇列的最大工作數；預設與預熱併發數相同。

--- a/doc-site/src/content/docs/zh/guides/advanced/customization.md
+++ b/doc-site/src/content/docs/zh/guides/advanced/customization.md
@@ -75,7 +75,7 @@ sidebar:
 - **FC_LLM_API_MODEL**: 默认使用的模型（如 `gemini-pro`, `gpt-3.5-turbo`）。**支持多个模型：** 你可以提供一个逗号分隔的模型列表（例如 `gpt-3.5-turbo,gpt-4`）。FeedCraft 会为每个请求随机选择一个模型，如果调用失败，会自动重试列表中的其他模型。
 - **FC_LLM_API_BASE**: API 接口地址。如果是兼容 OpenAI 的 API，通常以 `/v1` 结尾。
 - **FC_LLM_API_TYPE**: (可选) `openai` (默认) 或 `ollama`.
-- **FC_LLM_MAX_CONCURRENCY**: (可选) 全局最大 LLM 并发请求数（默认: `3`）。用于限制并发请求数量以防止触发 API 速率限制。
+- **FC_LLM_MAX_CONCURRENCY**: （可选）整个 FeedCraft 进程同时执行的 LLM API 请求上限（默认：`3`）。所有 feed、Recipe、AtomCraft 及其他 LLM 功能共享这一全局限制。文章任务可以并发进入队列，但实际同时执行的上游请求不会超过该值；缓存命中不占用并发额度。
 - **FC_DOMAIN_MAX_CONCURRENCY**: (可选) 网页抓取（如全文提取）时每个目标域名的最大并发数（默认: `3`）。防止抓取目标服务器负载过高。
 - **FC_PREHEATING_MAX_CONCURRENCY**: （可选）后台预热任务的最大并发数（默认：`2`）。
 - **FC_PREHEATING_QUEUE_SIZE**: （可选）预热等待队列的最大任务数；默认与预热并发数相同。

--- a/internal/craft/llm_processors.go
+++ b/internal/craft/llm_processors.go
@@ -99,11 +99,9 @@ func forEachArticleConcurrently(articles []*model.CraftArticle, process func(ind
 		if article == nil {
 			continue
 		}
-		workers.Add(1)
-		go func() {
-			defer workers.Done()
+		workers.Go(func() {
 			process(index, article)
-		}()
+		})
 	}
 	workers.Wait()
 }

--- a/internal/craft/llm_processors.go
+++ b/internal/craft/llm_processors.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"sync"
 	"text/template"
 
 	"FeedCraft/internal/constant"
@@ -28,23 +29,27 @@ func (p *ArticleTextTransformProcessor) Process(ctx context.Context, feed *model
 	}
 
 	cloned := cloneCraftFeed(feed)
+	errs := make([]error, len(cloned.Articles))
+	forEachArticleConcurrently(cloned.Articles, func(index int, article *model.CraftArticle) {
+		errs[index] = p.Mutate(ctx, article)
+	})
+
 	var (
 		lastErr   error
 		successes int
 		attempted int
 	)
-
-	for _, article := range cloned.Articles {
+	for index, article := range cloned.Articles {
 		if article == nil {
 			continue
 		}
-		attempted += 1
-		if err := p.Mutate(ctx, article); err != nil {
+		attempted++
+		if err := errs[index]; err != nil {
 			lastErr = err
 			logrus.Warnf("failed to apply craft [%s] for article [%s], err: %v", p.CraftName, article.Title, err)
 			continue
 		}
-		successes += 1
+		successes++
 	}
 
 	if attempted > 0 && successes == 0 {
@@ -64,23 +69,43 @@ func (p *ArticlePredicateProcessor) Process(ctx context.Context, feed *model.Cra
 	}
 
 	cloned := cloneCraftFeed(feed)
+	matches := make([]bool, len(cloned.Articles))
+	errs := make([]error, len(cloned.Articles))
+	forEachArticleConcurrently(cloned.Articles, func(index int, article *model.CraftArticle) {
+		matches[index], errs[index] = p.Match(ctx, article)
+	})
+
 	filtered := make([]*model.CraftArticle, 0, len(cloned.Articles))
-	for _, article := range cloned.Articles {
+	for index, article := range cloned.Articles {
 		if article == nil {
 			continue
 		}
-		matched, err := p.Match(ctx, article)
-		if err != nil {
+		if err := errs[index]; err != nil {
 			logrus.Warnf("failed to evaluate craft [%s] for article [%s], err: %v", p.CraftName, article.Title, err)
 			filtered = append(filtered, article)
 			continue
 		}
-		if !matched {
+		if !matches[index] {
 			filtered = append(filtered, article)
 		}
 	}
 	cloned.Articles = filtered
 	return cloned, nil
+}
+
+func forEachArticleConcurrently(articles []*model.CraftArticle, process func(index int, article *model.CraftArticle)) {
+	var workers sync.WaitGroup
+	for index, article := range articles {
+		if article == nil {
+			continue
+		}
+		workers.Add(1)
+		go func() {
+			defer workers.Done()
+			process(index, article)
+		}()
+	}
+	workers.Wait()
 }
 
 func CallLLMForArticleTransform(prompt, title, content string, option util.ContentProcessOption) (string, error) {

--- a/internal/craft/llm_processors_test.go
+++ b/internal/craft/llm_processors_test.go
@@ -1,12 +1,16 @@
 package craft
 
 import (
+	"context"
+	"errors"
 	"strings"
 	"testing"
+	"time"
 
 	"FeedCraft/internal/model"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 const testTinyBase64PNG = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg=="
@@ -50,4 +54,163 @@ func TestGetArticleContentForPrompt_KeepsNormalImages(t *testing.T) {
 		strings.Contains(result, "example.com/pic.png") || strings.Contains(result, "diagram"),
 		"normal image reference should be preserved",
 	)
+}
+
+type processorResult struct {
+	feed *model.CraftFeed
+	err  error
+}
+
+func observeConcurrentStart(started <-chan struct{}, release chan struct{}) bool {
+	<-started
+	select {
+	case <-started:
+		close(release)
+		return true
+	case <-time.After(200 * time.Millisecond):
+		close(release)
+		return false
+	}
+}
+
+func TestArticleTextTransformProcessor_Process_RunsConcurrentlyAndPreservesOrder(t *testing.T) {
+	started := make(chan struct{}, 3)
+	release := make(chan struct{})
+	processor := &ArticleTextTransformProcessor{
+		CraftName: "concurrent transform",
+		Mutate: func(_ context.Context, article *model.CraftArticle) error {
+			started <- struct{}{}
+			<-release
+			article.Description = "processed:" + article.Title
+			return nil
+		},
+	}
+	feed := &model.CraftFeed{Articles: []*model.CraftArticle{
+		{Title: "first"},
+		{Title: "second"},
+		{Title: "third"},
+	}}
+
+	done := make(chan processorResult, 1)
+	go func() {
+		processed, err := processor.Process(context.Background(), feed)
+		done <- processorResult{feed: processed, err: err}
+	}()
+
+	concurrent := observeConcurrentStart(started, release)
+	result := <-done
+
+	require.NoError(t, result.err)
+	require.Len(t, result.feed.Articles, 3)
+	assert.True(t, concurrent, "a single feed should start more than one article concurrently")
+	assert.Equal(t, "processed:first", result.feed.Articles[0].Description)
+	assert.Equal(t, "processed:second", result.feed.Articles[1].Description)
+	assert.Equal(t, "processed:third", result.feed.Articles[2].Description)
+}
+
+func TestArticleTextTransformProcessor_Process_PartialFailureKeepsSuccessfulResults(t *testing.T) {
+	processor := &ArticleTextTransformProcessor{
+		CraftName: "partial failure",
+		Mutate: func(_ context.Context, article *model.CraftArticle) error {
+			if article.Title == "failed" {
+				return errors.New("LLM unavailable")
+			}
+			article.Description = "processed"
+			return nil
+		},
+	}
+	feed := &model.CraftFeed{Articles: []*model.CraftArticle{
+		{Title: "successful"},
+		{Title: "failed"},
+		nil,
+	}}
+
+	processed, err := processor.Process(context.Background(), feed)
+
+	require.NoError(t, err)
+	require.Len(t, processed.Articles, 3)
+	assert.Equal(t, "processed", processed.Articles[0].Description)
+	assert.Empty(t, processed.Articles[1].Description)
+	assert.Nil(t, processed.Articles[2])
+}
+
+func TestArticleTextTransformProcessor_Process_AllFailuresReturnError(t *testing.T) {
+	processor := &ArticleTextTransformProcessor{
+		CraftName: "total failure",
+		Mutate: func(_ context.Context, _ *model.CraftArticle) error {
+			return errors.New("LLM unavailable")
+		},
+	}
+	feed := &model.CraftFeed{Articles: []*model.CraftArticle{
+		{Title: "first"},
+		{Title: "second"},
+	}}
+
+	processed, err := processor.Process(context.Background(), feed)
+
+	require.Error(t, err)
+	assert.Nil(t, processed)
+	assert.Contains(t, err.Error(), "all items failed to process")
+}
+
+func TestArticlePredicateProcessor_Process_RunsConcurrentlyAndPreservesOrder(t *testing.T) {
+	started := make(chan struct{}, 4)
+	release := make(chan struct{})
+	processor := &ArticlePredicateProcessor{
+		CraftName: "concurrent predicate",
+		Match: func(_ context.Context, article *model.CraftArticle) (bool, error) {
+			started <- struct{}{}
+			<-release
+			return article.Title == "drop", nil
+		},
+	}
+	feed := &model.CraftFeed{Articles: []*model.CraftArticle{
+		{Title: "keep-first"},
+		{Title: "drop"},
+		{Title: "keep-last"},
+	}}
+
+	done := make(chan processorResult, 1)
+	go func() {
+		processed, err := processor.Process(context.Background(), feed)
+		done <- processorResult{feed: processed, err: err}
+	}()
+
+	concurrent := observeConcurrentStart(started, release)
+	result := <-done
+
+	require.NoError(t, result.err)
+	require.Len(t, result.feed.Articles, 2)
+	assert.True(t, concurrent, "a single feed should evaluate more than one article concurrently")
+	assert.Equal(t, "keep-first", result.feed.Articles[0].Title)
+	assert.Equal(t, "keep-last", result.feed.Articles[1].Title)
+}
+
+func TestArticlePredicateProcessor_Process_FailureKeepsArticleAndNilIsSkipped(t *testing.T) {
+	processor := &ArticlePredicateProcessor{
+		CraftName: "predicate failure",
+		Match: func(_ context.Context, article *model.CraftArticle) (bool, error) {
+			switch article.Title {
+			case "failed":
+				return false, errors.New("LLM unavailable")
+			case "drop":
+				return true, nil
+			default:
+				return false, nil
+			}
+		},
+	}
+	feed := &model.CraftFeed{Articles: []*model.CraftArticle{
+		{Title: "keep"},
+		nil,
+		{Title: "failed"},
+		{Title: "drop"},
+	}}
+
+	processed, err := processor.Process(context.Background(), feed)
+
+	require.NoError(t, err)
+	require.Len(t, processed.Articles, 2)
+	assert.Equal(t, "keep", processed.Articles[0].Title)
+	assert.Equal(t, "failed", processed.Articles[1].Title)
 }

--- a/internal/craft/llm_processors_test.go
+++ b/internal/craft/llm_processors_test.go
@@ -74,6 +74,8 @@ func observeConcurrentStart(started <-chan struct{}, release chan struct{}) bool
 }
 
 func TestArticleTextTransformProcessor_Process_RunsConcurrentlyAndPreservesOrder(t *testing.T) {
+	t.Setenv("FC_LLM_MAX_CONCURRENCY", "1")
+
 	started := make(chan struct{}, 3)
 	release := make(chan struct{})
 	processor := &ArticleTextTransformProcessor{
@@ -154,6 +156,8 @@ func TestArticleTextTransformProcessor_Process_AllFailuresReturnError(t *testing
 }
 
 func TestArticlePredicateProcessor_Process_RunsConcurrentlyAndPreservesOrder(t *testing.T) {
+	t.Setenv("FC_LLM_MAX_CONCURRENCY", "1")
+
 	started := make(chan struct{}, 4)
 	release := make(chan struct{})
 	processor := &ArticlePredicateProcessor{


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 背景

修复 Linear [COL-28](https://linear.app/colin-x-studio/issue/COL-28/perf-craft-文章级-llm-调用串行单-feed-延迟线性放大建议并发化)：文章级 LLM Processor 在单个 feed 内严格串行，导致延迟随文章数线性增长。

## 设计

- craft 层使用 Go 1.25 `sync.WaitGroup.Go` 并发发散文章任务，并将结果写入各自索引后统一顺序汇总。
- adapter 层现有全局 `PriorityDispatcher` 继续作为唯一限流点。
- `FC_LLM_MAX_CONCURRENCY` 的名称、默认值和全局语义保持不变，不在 craft 层增加第二个 semaphore。
- Transform 保留“部分失败返回成功结果、全部失败报错”语义；Predicate 失败仍保留文章。
- 三语文档和 `.env.example` 明确该限制由所有 feed、Recipe、AtomCraft 和其他 LLM 功能共享，缓存命中不占额度。

## 验证

- 回归测试在原串行实现上按预期失败：Transform 与 Predicate 均无法同时启动第二篇文章。
- 测试显式设置 `FC_LLM_MAX_CONCURRENCY=1`，验证 craft fan-out 不会把全局 LLM 上限误作本地 Processor 限制；真实请求仍由 adapter dispatcher 全局限流。
- `go test -race ./internal/craft -run 'TestArticle(TextTransform|Predicate)Processor_Process' -count=1` 通过。
- `task fix`、`go test ./...`、`task backend-build`、`task frontend-build` 均通过。
- 三语文档站点构建通过。
- 独立代码审查无 Critical / Important 问题。
- GitHub CI：8/8 checks 通过。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-79098413-a80f-4c97-8ce9-8049b6b97fc8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-79098413-a80f-4c97-8ce9-8049b6b97fc8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

## Summary by Sourcery

Parallelize per-article LLM processing within feeds while retaining the global dispatcher as the sole concurrency limit.

Bug Fixes:
- Enable article-level LLM transform and predicate processing to run concurrently within a feed, reducing latency that previously increased linearly with article count.

Enhancements:
- Preserve article ordering while retaining partial-success, all-failure, and predicate-error handling semantics during concurrent processing.

Documentation:
- Clarify in English, Simplified Chinese, and Traditional Chinese documentation that FC_LLM_MAX_CONCURRENCY is a process-wide limit shared by all LLM features and that cache hits do not consume capacity.

Tests:
- Add coverage for concurrent article processing, ordering, partial and total transform failures, predicate filtering, and predicate-error handling.