### PR TITLE
fix(admin): HTML 转 RSS 允许抓取内网源并展示可读错误

### DIFF
--- a/internal/controller/html_to_rss.go
+++ b/internal/controller/html_to_rss.go
@@ -51,23 +51,34 @@ type WebMonitorPreviewReq struct {
 func validateURL(rawUrl string) error {
 	u, err := url.Parse(rawUrl)
 	if err != nil {
-		return err
+		return fmt.Errorf("please enter a valid http(s) URL")
 	}
 	if u.Scheme != "http" && u.Scheme != "https" {
-		return fmt.Errorf("invalid scheme: %s", u.Scheme)
+		return fmt.Errorf("please use an http or https URL")
+	}
+	host := u.Hostname()
+	if host == "" {
+		return fmt.Errorf("please enter a valid http(s) URL")
 	}
 
-	ips, err := net.LookupIP(u.Hostname())
+	ips, err := net.LookupIP(host)
 	if err != nil {
-		return err
+		return fmt.Errorf("unable to resolve host %s. Please check the address and try again", host)
 	}
 
 	for _, ip := range ips {
-		if ip.IsLoopback() || ip.IsPrivate() {
-			return fmt.Errorf("access to private IP %s is forbidden", ip.String())
+		if isBlockedHTMLFetchIP(ip) {
+			return fmt.Errorf("access to address %s is forbidden. Link-local and cloud metadata addresses cannot be fetched", ip.String())
 		}
 	}
 	return nil
+}
+
+// isBlockedHTMLFetchIP blocks link-local/metadata/multicast targets while
+// allowing loopback and RFC1918 addresses so admin HTML-to-RSS can fetch
+// local mock sources (localhost, host.docker.internal, LAN).
+func isBlockedHTMLFetchIP(ip net.IP) bool {
+	return ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() || ip.IsMulticast() || ip.IsUnspecified()
 }
 
 // fetchHTML extracts common fetching logic with browser emulation and error handling

--- a/internal/controller/html_to_rss_test.go
+++ b/internal/controller/html_to_rss_test.go
@@ -1,0 +1,120 @@
+package controller
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+func TestValidateURLAllowsPrivateAndLoopbackAddresses(t *testing.T) {
+	t.Parallel()
+
+	cases := []string{
+		"http://127.0.0.1/article/1.html",
+		"http://192.168.5.2:10089/article/1.html",
+		"http://10.0.0.8/page",
+		"http://172.16.0.4/page",
+	}
+	for _, raw := range cases {
+		if err := validateURL(raw); err != nil {
+			t.Errorf("validateURL(%q) = %v, want nil (admin HTML fetch should allow local/private sources)", raw, err)
+		}
+	}
+}
+
+func TestValidateURLRejectsLinkLocalMetadataAddresses(t *testing.T) {
+	t.Parallel()
+
+	err := validateURL("http://169.254.169.254/latest/meta-data/")
+	if err == nil {
+		t.Fatal("validateURL allowed link-local metadata address, want rejection")
+	}
+	if !strings.Contains(strings.ToLower(err.Error()), "forbidden") {
+		t.Fatalf("error = %q, want a forbidden message", err)
+	}
+}
+
+func TestValidateURLRejectsNonHTTPSchemes(t *testing.T) {
+	t.Parallel()
+
+	err := validateURL("file:///etc/passwd")
+	if err == nil {
+		t.Fatal("validateURL allowed file scheme, want rejection")
+	}
+}
+
+func TestHtmlFetchAllowsLoopbackSource(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		_, _ = w.Write([]byte(`<html><head><title>Local Mock</title></head><body><h1>ok</h1></body></html>`))
+	}))
+	defer upstream.Close()
+
+	recorder := performHtmlFetchRequest(t, FetchReq{URL: upstream.URL})
+
+	var response struct {
+		Code int    `json:"code"`
+		Data string `json:"data"`
+		Msg  string `json:"msg"`
+	}
+	if err := json.Unmarshal(recorder.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if recorder.Code != http.StatusOK || response.Code != 0 {
+		t.Fatalf("expected fetch success for loopback URL, got http %d code %d msg %q body %s",
+			recorder.Code, response.Code, response.Msg, recorder.Body.String())
+	}
+	if !strings.Contains(response.Data, "Local Mock") {
+		t.Fatalf("expected fetched HTML, got %q", response.Data)
+	}
+}
+
+func TestHtmlFetchRejectsLinkLocalWithReadableMessage(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	recorder := performHtmlFetchRequest(t, FetchReq{URL: "http://169.254.169.254/latest/meta-data/"})
+
+	var response struct {
+		Code int    `json:"code"`
+		Msg  string `json:"msg"`
+	}
+	if err := json.Unmarshal(recorder.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if response.Code == 0 {
+		t.Fatalf("expected validation failure, got success body %s", recorder.Body.String())
+	}
+	msg := strings.ToLower(response.Msg)
+	if strings.Contains(msg, "request failed with status code") {
+		t.Fatalf("msg should be human-readable, got %q", response.Msg)
+	}
+	if !strings.Contains(msg, "forbidden") && !strings.Contains(msg, "not allowed") {
+		t.Fatalf("msg = %q, want a readable SSRF/forbidden explanation", response.Msg)
+	}
+}
+
+func performHtmlFetchRequest(t *testing.T, body FetchReq) *httptest.ResponseRecorder {
+	t.Helper()
+	payload, err := json.Marshal(body)
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.POST("/fetch", HtmlFetch)
+	req, err := http.NewRequest(http.MethodPost, "/fetch", bytes.NewReader(payload))
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	recorder := httptest.NewRecorder()
+	r.ServeHTTP(recorder, req)
+	return recorder
+}

--- a/web/admin/src/api/interceptor.ts
+++ b/web/admin/src/api/interceptor.ts
@@ -108,6 +108,9 @@ axios.interceptors.response.use(
     }
 
     const respMsg = error?.response?.data?.msg;
+    if (respMsg && typeof respMsg === 'string') {
+      error.message = respMsg;
+    }
     Message.error({
       content: respMsg || error.message || 'Request Error',
       duration: 5 * 1000,

--- a/web/admin/src/views/dashboard/html_to_rss/html_to_rss.vue
+++ b/web/admin/src/views/dashboard/html_to_rss/html_to_rss.vue
@@ -873,8 +873,10 @@
         fetchError.value = errorMsg;
       }
     } catch (err: any) {
-      // Axios interceptor throws an error with the backend message
-      const errorMsg = err.message || t('htmlToRss.msg.errorFetching');
+      const errorMsg =
+        err?.response?.data?.msg ||
+        err.message ||
+        t('htmlToRss.msg.errorFetching');
       fetchError.value = errorMsg;
     } finally {
       fetching.value = false;

--- a/web/admin/src/views/dashboard/web_monitor/web_monitor.vue
+++ b/web/admin/src/views/dashboard/web_monitor/web_monitor.vue
@@ -596,7 +596,10 @@
         fetchError.value = res.msg || t('webMonitor.msg.fetchFailed');
       }
     } catch (err: any) {
-      fetchError.value = err.message || t('webMonitor.msg.errorFetching');
+      fetchError.value =
+        err?.response?.data?.msg ||
+        err.message ||
+        t('webMonitor.msg.errorFetching');
     } finally {
       fetching.value = false;
     }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
对应 Linear [COL-22](https://linear.app/colin-x-studio/issue/COL-22/e2e-s6a-htmlrss-向导获取源返回-400ssrf-拦截私有-ip-19216852断言仍误报获取源成功假阳性)。

## 问题

HTML→RSS「获取并下一步」对 `host.docker.internal` / RFC1918 / 回环地址做 DNS 解析后按 SSRF 直接 400。管理后台表单 catch 用 Axios 默认 `error.message`，所以页面粉框显示 `Request failed with status code 400`，而 Toast 才是后端 `access to private IP ... is forbidden`。

自托管场景下，管理员需要抓取局域网或 Docker mock 源；Feed 预览已经允许私网 URL。同时链路本地/云 metadata（`169.254.169.254`）原先未被拦截。

E2E 脚本断言假阳性不在本仓库，本 PR 只修产品侧。

## 改动

- `validateURL`：允许 loopback 与 RFC1918，继续拒绝 link-local / multicast / unspecified，错误文案可读
- Axios 错误拦截器把后端 `msg` 写回 `error.message`
- HTML→RSS 与 Web Monitor 表单优先展示 `response.data.msg`
- 补充 `html_to_rss` 单测（私网允许、metadata 拒绝、loopback 抓取成功）

## 验证

- `go test ./internal/controller -run 'TestValidateURL|TestHtmlFetch'`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b8da6355-7d12-49b3-a2de-574445fc081b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b8da6355-7d12-49b3-a2de-574445fc081b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

## Summary by Sourcery

Allow administrators to fetch local HTML sources while preserving protections against metadata and other unsafe network addresses, and surface actionable errors in the admin UI.

Bug Fixes:
- Allow HTML-to-RSS and web monitor requests to access loopback and RFC1918 sources while continuing to block link-local, multicast, unspecified, and cloud metadata addresses.
- Show readable backend validation errors in admin forms instead of generic Axios status messages.

Enhancements:
- Improve URL validation messages for invalid schemes, hosts, and DNS resolution failures.
- Add coverage for private-source access, blocked metadata addresses, scheme validation, and successful loopback fetching.

Tests:
- Add controller tests covering HTML fetch URL validation and loopback retrieval.