### PR TITLE
fix(cache): CachedFunc 同 key 并发 miss 用 singleflight 防击穿

### DIFF
--- a/internal/util/cache.go
+++ b/internal/util/cache.go
@@ -4,13 +4,16 @@ import (
 	"FeedCraft/internal/constant"
 	"context"
 	"errors"
+	"log"
 	"strings"
+	"time"
 
 	"github.com/redis/go-redis/v9"
 	"github.com/sirupsen/logrus"
-	"log"
-	"time"
+	"golang.org/x/sync/singleflight"
 )
+
+var cachedFuncFlight singleflight.Group
 
 // GetRedisClient 返回一个非空的redis client
 func GetRedisClient() *redis.Client {
@@ -83,32 +86,35 @@ func CacheGetString(key string) (string, error) {
 	return rdb.Get(context.Background(), key).Result()
 }
 
-// CachedFuncWithPreLog tries to get from cache, invokes preLog if provided, and if absent, calls valFunc and saves to cache
+// CachedFuncWithPreLog tries to get from cache, invokes preLog if provided, and if absent, calls valFunc and saves to cache.
+// Concurrent misses for the same key share one in-flight valFunc (singleflight) to avoid cache stampede.
 func CachedFuncWithPreLog(cacheKey string, valFunc func() (string, error), preLog func(isCached bool)) (string, error) {
-	final := ""
-	cached, err := CacheGetString(cacheKey)
-	isCached := err == nil && cached != ""
+	result, err, _ := cachedFuncFlight.Do(cacheKey, func() (interface{}, error) {
+		cached, getErr := CacheGetString(cacheKey)
+		isCached := getErr == nil && cached != ""
 
-	if preLog != nil {
-		preLog(isCached)
-	}
+		if preLog != nil {
+			preLog(isCached)
+		}
 
-	if !isCached {
+		if isCached {
+			return cached, nil
+		}
+
 		processedContent, getValErr := valFunc()
 		if getValErr != nil {
 			return "", getValErr
-		} else {
-			final = processedContent
-			cacheErr := CacheSetString(cacheKey, processedContent, constant.WebContentExpire)
-			if cacheErr != nil {
-				logrus.Warn("failed to cache result")
-			}
 		}
-	} else {
-		final = cached
+		if cacheErr := CacheSetString(cacheKey, processedContent, constant.WebContentExpire); cacheErr != nil {
+			logrus.Warn("failed to cache result")
+		}
+		return processedContent, nil
+	})
+	if err != nil {
+		return "", err
 	}
-
-	return final, nil
+	value, _ := result.(string)
+	return value, nil
 }
 
 // CachedFunc 先尝试取缓存, 如不存在, 则调用valFunc 获取值并写入缓存

--- a/internal/util/cache_test.go
+++ b/internal/util/cache_test.go
@@ -1,0 +1,155 @@
+package util
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+)
+
+func setupTestRedis(tb testing.TB) *miniredis.Miniredis {
+	tb.Helper()
+
+	server, err := miniredis.Run()
+	if err != nil {
+		tb.Fatalf("could not start miniredis: %v", err)
+	}
+	tb.Setenv("FC_REDIS_URI", fmt.Sprintf("redis://%s", server.Addr()))
+	tb.Cleanup(server.Close)
+	return server
+}
+
+func TestCachedFuncCoalescesConcurrentMisses(t *testing.T) {
+	setupTestRedis(t)
+
+	var calls atomic.Int32
+	started := make(chan struct{})
+	release := make(chan struct{})
+
+	valFunc := func() (string, error) {
+		if calls.Add(1) == 1 {
+			close(started)
+		}
+		<-release
+		return "computed-once", nil
+	}
+
+	const goroutines = 8
+	errCh := make(chan error, goroutines)
+	results := make([]string, goroutines)
+
+	var wg sync.WaitGroup
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			value, err := CachedFunc("stampede-key", valFunc)
+			if err != nil {
+				errCh <- err
+				return
+			}
+			results[idx] = value
+		}(i)
+	}
+
+	select {
+	case <-started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("valFunc was never invoked")
+	}
+	time.Sleep(50 * time.Millisecond)
+	close(release)
+	wg.Wait()
+	close(errCh)
+
+	for err := range errCh {
+		t.Fatalf("CachedFunc returned error: %v", err)
+	}
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("expected valFunc to run once for concurrent cache misses, got %d calls", got)
+	}
+	for i, value := range results {
+		if value != "computed-once" {
+			t.Fatalf("result[%d] = %q, want computed-once", i, value)
+		}
+	}
+}
+
+func TestCachedFuncDifferentKeysDoNotShareFlight(t *testing.T) {
+	setupTestRedis(t)
+
+	var calls atomic.Int32
+	valFunc := func() (string, error) {
+		n := calls.Add(1)
+		return fmt.Sprintf("value-%d", n), nil
+	}
+
+	first, err := CachedFunc("key-a", valFunc)
+	if err != nil {
+		t.Fatalf("key-a: %v", err)
+	}
+	second, err := CachedFunc("key-b", valFunc)
+	if err != nil {
+		t.Fatalf("key-b: %v", err)
+	}
+	if calls.Load() != 2 {
+		t.Fatalf("expected 2 valFunc calls for different keys, got %d", calls.Load())
+	}
+	if first == second {
+		t.Fatalf("different keys unexpectedly shared result %q", first)
+	}
+}
+
+func TestCachedFuncHitSkipsValFunc(t *testing.T) {
+	setupTestRedis(t)
+
+	var calls atomic.Int32
+	valFunc := func() (string, error) {
+		calls.Add(1)
+		return "fresh", nil
+	}
+
+	if _, err := CachedFunc("hit-key", valFunc); err != nil {
+		t.Fatalf("first fill: %v", err)
+	}
+	value, err := CachedFunc("hit-key", valFunc)
+	if err != nil {
+		t.Fatalf("second read: %v", err)
+	}
+	if value != "fresh" {
+		t.Fatalf("cached value = %q, want fresh", value)
+	}
+	if calls.Load() != 1 {
+		t.Fatalf("expected valFunc once on cache hit path, got %d", calls.Load())
+	}
+}
+
+func TestCachedFuncErrorIsNotCached(t *testing.T) {
+	setupTestRedis(t)
+
+	var calls atomic.Int32
+	valFunc := func() (string, error) {
+		if calls.Add(1) == 1 {
+			return "", errors.New("llm timeout")
+		}
+		return "recovered", nil
+	}
+
+	if _, err := CachedFunc("err-key", valFunc); err == nil {
+		t.Fatal("expected first call to fail")
+	}
+	value, err := CachedFunc("err-key", valFunc)
+	if err != nil {
+		t.Fatalf("retry after error: %v", err)
+	}
+	if value != "recovered" {
+		t.Fatalf("retry value = %q, want recovered", value)
+	}
+	if calls.Load() != 2 {
+		t.Fatalf("expected valFunc to retry after error, got %d calls", calls.Load())
+	}
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 背景

Linear [COL-33](https://linear.app/colin-x-studio/issue/COL-33/robust-ai-处理缓存击穿-同配方并发请求-50percent-失败cachedfunc-无-singleflight-mock)：同一配方并发请求在缓存未命中时会同时调用 LLM，部分请求超时失败。根因是 `util.CachedFunc` / `CachedFuncWithPreLog` 为无锁 GET→SET。

关联：COL-29 的 #897 含同类改动但尚未合入 `dev`。本 PR 只修击穿保护，保持现有 `CachedFunc` 签名，便于独立合入。

## 改动

- 使用已有依赖 `golang.org/x/sync/singleflight` 合并同 key 的 in-flight 计算
- 错误结果不写入 Redis；后续请求会再次调用 `valFunc`
- 新增并发 miss / 不同 key / 命中 / 失败不缓存 单测（miniredis）

## 验证

- 修复前：`TestCachedFuncCoalescesConcurrentMisses` 失败（`expected valFunc to run once ... got 8 calls`）
- 修复后：`go test ./internal/util/ -run TestCachedFunc -count=20 -race` 通过
- `go test ./...` 通过
- `task backend-build` 通过
- `golangci-lint run ./...` 0 issues
- `task fix` 的前端 ESLint 在本分支未改动的既有 vitest/js-beautify `import/no-unresolved` 上报错，与本次改动无关
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-41f6c948-bcb8-4d4c-bcdf-5e217527eb3f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-41f6c948-bcb8-4d4c-bcdf-5e217527eb3f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

## Summary by Sourcery

Protect cached computations from concurrent same-key misses while preserving retry behavior for failed requests.

Bug Fixes:
- Prevent cache stampedes by coalescing concurrent cache misses for the same key into a single in-flight computation.
- Avoid caching failed computations so subsequent requests can retry successfully.

Tests:
- Add Redis-backed tests covering concurrent misses, key isolation, cache hits, and retry behavior after failures.