### PR TITLE
fix(admin): 自定义配方空表单保存前校验 (COL-27)

### DIFF
--- a/internal/controller/custom_recipe.go
+++ b/internal/controller/custom_recipe.go
@@ -17,7 +17,7 @@ const msgRecipeNameExists = "A recipe with this name already exists. Please choo
 func CreateCustomRecipe(c *gin.Context) {
 	var recipeData dao.CustomRecipeV2
 	if err := c.ShouldBindJSON(&recipeData); err != nil {
-		c.JSON(http.StatusBadRequest, util.APIResponse[any]{Msg: err.Error()})
+		c.JSON(http.StatusBadRequest, util.APIResponse[any]{Msg: util.FriendlyBindError(err)})
 		return
 	}
 
@@ -95,7 +95,7 @@ func UpdateCustomRecipe(c *gin.Context) {
 	id := c.Param("id")
 	var recipeData dao.CustomRecipeV2
 	if err := c.ShouldBindJSON(&recipeData); err != nil {
-		c.JSON(http.StatusBadRequest, util.APIResponse[any]{Msg: err.Error()})
+		c.JSON(http.StatusBadRequest, util.APIResponse[any]{Msg: util.FriendlyBindError(err)})
 		return
 	}
 	db := util.GetDatabase()

--- a/internal/controller/custom_recipe_test.go
+++ b/internal/controller/custom_recipe_test.go
@@ -50,6 +50,29 @@ func TestCreateCustomRecipe_DuplicateIDReturnsConflictWithoutSQL(t *testing.T) {
 	assert.NotContains(t, response.Msg, "custom_recipes_v2")
 }
 
+func TestCreateCustomRecipe_MissingRequiredFieldsReturnsFriendlyMessage(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	db := customRecipeTestDatabase(t)
+	require.NoError(t, db.AutoMigrate(&dao.CustomRecipeV2{}))
+
+	router := gin.New()
+	router.POST("/api/admin/recipes", CreateCustomRecipe)
+
+	recorder := postCustomRecipe(t, router, map[string]string{
+		"description": "empty required fields",
+	})
+
+	assert.Equal(t, http.StatusBadRequest, recorder.Code, recorder.Body.String())
+
+	var response util.APIResponse[any]
+	require.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &response))
+	assert.Contains(t, response.Msg, "name is required")
+	assert.Contains(t, response.Msg, "craft is required")
+	assert.NotContains(t, response.Msg, "Key:")
+	assert.NotContains(t, response.Msg, "CustomRecipeV2")
+	assert.NotContains(t, response.Msg, "failed on the")
+}
+
 func TestCreateCustomRecipe_InvalidID(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	db := customRecipeTestDatabase(t)

--- a/internal/util/bind.go
+++ b/internal/util/bind.go
@@ -1,0 +1,47 @@
+package util
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/go-playground/validator/v10"
+)
+
+// FriendlyBindError turns gin/validator bind failures into a short, user-facing
+// message instead of dumping struct tags like `Key: 'CustomRecipeV2.ID'`.
+func FriendlyBindError(err error) string {
+	if err == nil {
+		return ""
+	}
+
+	var ve validator.ValidationErrors
+	if errors.As(err, &ve) && len(ve) > 0 {
+		parts := make([]string, 0, len(ve))
+		for _, fieldErr := range ve {
+			parts = append(parts, formatFieldValidation(fieldErr))
+		}
+		return strings.Join(parts, "; ")
+	}
+
+	return "invalid request body"
+}
+
+func formatFieldValidation(fieldErr validator.FieldError) string {
+	name := friendlyFieldName(fieldErr.Field())
+	if fieldErr.Tag() == "required" {
+		return name + " is required"
+	}
+	return fmt.Sprintf("%s is invalid", name)
+}
+
+func friendlyFieldName(field string) string {
+	switch field {
+	case "ID":
+		return "name"
+	case "Craft":
+		return "craft"
+	default:
+		return strings.ToLower(field)
+	}
+}

--- a/internal/util/bind_test.go
+++ b/internal/util/bind_test.go
@@ -1,0 +1,38 @@
+package util
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/go-playground/validator/v10"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type bindSample struct {
+	ID    string `json:"id" validate:"required"`
+	Craft string `json:"craft" validate:"required"`
+}
+
+func TestFriendlyBindError_RequiredFields(t *testing.T) {
+	validate := validator.New()
+	err := validate.Struct(bindSample{})
+	require.Error(t, err)
+
+	msg := FriendlyBindError(err)
+	assert.Contains(t, msg, "name is required")
+	assert.Contains(t, msg, "craft is required")
+	assert.NotContains(t, msg, "Key:")
+	assert.NotContains(t, msg, "CustomRecipeV2")
+	assert.NotContains(t, msg, "failed on the")
+}
+
+func TestFriendlyBindError_NonValidation(t *testing.T) {
+	err := json.Unmarshal([]byte("{"), &map[string]any{})
+	require.Error(t, err)
+	assert.Equal(t, "invalid request body", FriendlyBindError(err))
+}
+
+func TestFriendlyBindError_Nil(t *testing.T) {
+	assert.Equal(t, "", FriendlyBindError(nil))
+}

--- a/web/admin/src/utils/validator.ts
+++ b/web/admin/src/utils/validator.ts
@@ -1,6 +1,10 @@
 // eslint-disable-next-line import/prefer-default-export
 export const namingValidator = {
   validator: (value: string, cb: (err?: string) => void) => {
+    if (!value) {
+      cb();
+      return;
+    }
     const regex = /^[a-z0-9-_]+$/;
     if (!regex.test(value)) {
       cb(

--- a/web/admin/src/views/dashboard/custom_recipe/custom_recipe.vue
+++ b/web/admin/src/views/dashboard/custom_recipe/custom_recipe.vue
@@ -537,6 +537,10 @@
   };
 
   const saveRecipe = async () => {
+    if (quickCreate.value && !editing.value) {
+      form.value.feed_url = form.value.feed_url.trim();
+    }
+
     const invalid = await formRef.value?.validate();
     if (invalid) {
       return;
@@ -545,7 +549,7 @@
     if (quickCreate.value && !editing.value) {
       form.value.source_config = JSON.stringify({
         http_fetcher: {
-          url: form.value.feed_url.trim(),
+          url: form.value.feed_url,
         },
       });
       form.value.source_type = 'rss';
@@ -601,6 +605,9 @@
   function resetForm() {
     form.value = emptyRecipeForm();
     quickCreate.value = false;
+    editing.value = false;
+    isUpdating.value = false;
+    selectedRecipe.value = null;
   }
 </script>
 

--- a/web/admin/src/views/dashboard/custom_recipe/custom_recipe.vue
+++ b/web/admin/src/views/dashboard/custom_recipe/custom_recipe.vue
@@ -168,10 +168,7 @@
 
         <!-- Quick Create Fields -->
         <template v-if="quickCreate">
-          <a-form-item
-            :label="t('customRecipe.form.feedURL')"
-            field="feed_url"
-          >
+          <a-form-item :label="t('customRecipe.form.feedURL')" field="feed_url">
             <a-input
               v-model="form.feed_url"
               :placeholder="t('customRecipe.form.placeholder.rssUrl')"
@@ -256,7 +253,14 @@
 </template>
 
 <script setup lang="ts">
-  import { ref, onMounted, computed, nextTick, watch, type ComputedRef } from 'vue';
+  import {
+    ref,
+    onMounted,
+    computed,
+    nextTick,
+    watch,
+    type ComputedRef,
+  } from 'vue';
   import {
     createCustomRecipe,
     CustomRecipe,

--- a/web/admin/src/views/dashboard/custom_recipe/custom_recipe.vue
+++ b/web/admin/src/views/dashboard/custom_recipe/custom_recipe.vue
@@ -143,6 +143,7 @@
       "
     >
       <a-form
+        ref="formRef"
         :model="form"
         :label-col="{ span: 6 }"
         :rules="rules"
@@ -170,15 +171,9 @@
           <a-form-item
             :label="t('customRecipe.form.feedURL')"
             field="feed_url"
-            :rules="[
-              {
-                required: true,
-                message: t('customRecipe.form.rule.rssUrlRequired'),
-              },
-            ]"
           >
             <a-input
-              v-model="rssUrl"
+              v-model="form.feed_url"
               :placeholder="t('customRecipe.form.placeholder.rssUrl')"
             />
           </a-form-item>
@@ -261,7 +256,7 @@
 </template>
 
 <script setup lang="ts">
-  import { ref, onMounted, computed } from 'vue';
+  import { ref, onMounted, computed, nextTick, watch, type ComputedRef } from 'vue';
   import {
     createCustomRecipe,
     CustomRecipe,
@@ -288,16 +283,29 @@
   const showConfigModal = ref(false);
   const currentConfig = ref('');
   const currentLink = ref('');
-  const quickCreate = ref(false);
-  const rssUrl = ref('');
+  type RecipeForm = CustomRecipe & { feed_url: string };
 
-  const form = ref<CustomRecipe>({
+  const emptyRecipeForm = (): RecipeForm => ({
     id: '',
     description: '',
     craft: '',
     source_type: 'rss',
     source_config: '',
+    feed_url: '',
   });
+
+  const toRecipePayload = (value: RecipeForm): CustomRecipe => ({
+    id: value.id,
+    description: value.description,
+    craft: value.craft,
+    source_type: value.source_type,
+    source_config: value.source_config,
+  });
+
+  const quickCreate = ref(false);
+
+  const form = ref<RecipeForm>(emptyRecipeForm());
+  const formRef = ref();
 
   const craftList = computed({
     get: () =>
@@ -414,37 +422,64 @@
   onMounted(() => {
     listCustomRecipes();
   });
-  const rules = {
-    id: [
-      {
-        required: true,
-        message: t('customRecipe.form.rule.nameRequired'),
-        trigger: 'blur',
-      },
-      namingValidator,
-    ],
-    craft: [
-      {
-        required: true,
-        message: t('customRecipe.form.rule.craftRequired'),
-        trigger: 'blur',
-      },
-    ],
-    source_type: [
-      {
-        required: true,
-        message: t('customRecipe.form.rule.sourceTypeRequired'),
-        trigger: 'change',
-      },
-    ],
-    source_config: [
-      {
-        required: true,
-        message: t('customRecipe.form.rule.sourceConfigRequired'),
-        trigger: 'blur',
-      },
-    ],
-  };
+
+  watch(showModal, (visible) => {
+    if (visible) {
+      nextTick(() => {
+        formRef.value?.clearValidate();
+      });
+    }
+  });
+  const rules: ComputedRef<Record<string, unknown[]>> = computed(() => {
+    const requiredNameAndCraft = {
+      id: [
+        {
+          required: true,
+          message: t('customRecipe.form.rule.nameRequired'),
+          trigger: 'blur',
+        },
+        namingValidator,
+      ],
+      craft: [
+        {
+          required: true,
+          message: t('customRecipe.form.rule.craftRequired'),
+          trigger: 'change',
+        },
+      ],
+    };
+
+    if (quickCreate.value) {
+      return {
+        ...requiredNameAndCraft,
+        feed_url: [
+          {
+            required: true,
+            message: t('customRecipe.form.rule.rssUrlRequired'),
+            trigger: 'blur',
+          },
+        ],
+      };
+    }
+
+    return {
+      ...requiredNameAndCraft,
+      source_type: [
+        {
+          required: true,
+          message: t('customRecipe.form.rule.sourceTypeRequired'),
+          trigger: 'change',
+        },
+      ],
+      source_config: [
+        {
+          required: true,
+          message: t('customRecipe.form.rule.sourceConfigRequired'),
+          trigger: 'blur',
+        },
+      ],
+    };
+  });
 
   const humanReadableConfig = (configStr: string) => {
     try {
@@ -492,22 +527,25 @@
       craft: recipe.craft,
       source_type: recipe.source_type,
       source_config: prettyConfig,
+      feed_url: '',
     };
     showModal.value = true;
   };
 
   const saveRecipe = async () => {
+    const invalid = await formRef.value?.validate();
+    if (invalid) {
+      return;
+    }
+
     if (quickCreate.value && !editing.value) {
-      // Construct JSON for Quick Create
-      const config = {
+      form.value.source_config = JSON.stringify({
         http_fetcher: {
-          url: rssUrl.value,
+          url: form.value.feed_url.trim(),
         },
-      };
-      form.value.source_config = JSON.stringify(config);
+      });
       form.value.source_type = 'rss';
     } else {
-      // Validate JSON before saving in Advanced mode
       try {
         JSON.parse(form.value.source_config);
       } catch (e) {
@@ -518,31 +556,25 @@
 
     saving.value = true;
     try {
+      const payload = toRecipePayload(form.value);
       if (editing.value) {
         if (selectedRecipe.value) {
-          await updateCustomRecipe(form.value);
-          selectedRecipe.value.description = form.value.description;
-          selectedRecipe.value.craft = form.value.craft;
-          selectedRecipe.value.source_type = form.value.source_type;
-          selectedRecipe.value.source_config = form.value.source_config;
+          await updateCustomRecipe(payload);
+          selectedRecipe.value.description = payload.description;
+          selectedRecipe.value.craft = payload.craft;
+          selectedRecipe.value.source_type = payload.source_type;
+          selectedRecipe.value.source_config = payload.source_config;
         }
       } else {
-        await createCustomRecipe(form.value as CustomRecipe);
+        await createCustomRecipe(payload);
         await listCustomRecipes();
       }
       showModal.value = false;
-      form.value = {
-        id: '',
-        description: '',
-        craft: '',
-        source_type: 'rss',
-        source_config: '',
-      };
+      form.value = emptyRecipeForm();
       editing.value = false;
       isUpdating.value = false;
       selectedRecipe.value = null;
       quickCreate.value = false;
-      rssUrl.value = '';
     } catch {
       // Axios interceptor already displays the API error toast.
     } finally {
@@ -563,15 +595,8 @@
   };
 
   function resetForm() {
-    form.value = {
-      id: '',
-      description: '',
-      craft: '',
-      source_type: 'rss',
-      source_config: '',
-    };
+    form.value = emptyRecipeForm();
     quickCreate.value = false;
-    rssUrl.value = '';
   }
 </script>
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 背景

Linear [COL-27](https://linear.app/colin-x-studio/issue/COL-27)：工作台 → 自定义配方 → 快速创建 (RSS)，名称/工艺为空直接点保存时，前端未做必填校验，Toast 会展示 gin validator 原文（`Key: 'CustomRecipeV2.ID' Error:Field validation for 'ID' failed...`）。

先前 PR #890 已关闭且未合入 `dev`，当前 `dev` 仍可复现。

## 改动

- 前端保存前调用表单 `validate()`：拦截名称、工艺；快速创建额外校验 RSS URL。就地标红，不再发请求。
- 快速创建先修剪 URL，空白字符串按缺失值拦截，不会生成空 `source_config`。
- 新建表单重置时同步清理编辑状态，避免取消编辑后误更新原记录。
- 快速创建不再误用「源配置必填」规则（该字段在快速创建里是保存时才生成的）。
- 后端 `ShouldBindJSON` 失败改为可读提示（`name is required; craft is required`），避免 validator dump 透传到 Toast。
- `namingValidator` 空值交给 `required` 规则，避免空表单先报「只能包含小写字母…」。

## 验证

- `task fix` 通过（ESLint 0 errors；保留仓库已有 warnings）
- `go test ./...` 通过
- `task backend-build` 通过
- `task frontend-build` 通过
- `pnpm test`：7 个测试文件、21 项测试全部通过
- 浏览器验证：
  - 空表单保存出现「名称必填 / 工艺必填 / RSS URL 必填」，无 validator Toast
  - 编辑 `col-27-ok` 后取消，再快速创建时表单为空
  - 仅空格 URL 被「RSS URL 必填」拦截
  - 改为有效 URL 后创建 `col-27-review-ok`，原记录与新记录同时存在

## Linear

https://linear.app/colin-x-studio/issue/COL-27

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fb733154-a0c0-478e-8cb0-b18865788cda?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fb733154-a0c0-478e-8cb0-b18865788cda&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

## Summary by Sourcery

Enforce required-field validation for custom recipe creation and replace backend validator dumps with readable error messages.

Bug Fixes:
- Prevent saving custom recipes with missing required fields and show concise, user-friendly validation messages instead of raw validator errors.
- Ensure quick-create recipes validate their RSS URL and do not require source configuration before it is generated.

Enhancements:
- Run form validation before submitting custom recipe requests and reset validation state when opening or resetting the form.
- Treat empty recipe names as required-field errors before applying naming-format validation.

Tests:
- Add coverage for friendly bind-error formatting and missing required fields in custom recipe creation.