### PR TITLE
fix(admin): 修复全部 Craft 列表名称列英文中途折行 (COL-18)

### DIFF
--- a/web/admin/src/components/craft/CraftManagePage.vue
+++ b/web/admin/src/components/craft/CraftManagePage.vue
@@ -51,6 +51,13 @@
     background: var(--color-fill-1);
   }
 
+  /* Override Arco's default word-break: break-all so English identifiers
+     wrap at word/hyphen boundaries instead of mid-token. */
+  :deep(.arco-table-td) {
+    word-break: normal;
+    overflow-wrap: break-word;
+  }
+
   @media (max-width: 768px) {
     .craft-manage-page {
       padding: 20px 16px;

--- a/web/admin/src/views/dashboard/all_craft_list/all_craft_list.columns.test.ts
+++ b/web/admin/src/views/dashboard/all_craft_list/all_craft_list.columns.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import {
+  ALL_CRAFT_ID_CELL_CLASS,
+  ALL_CRAFT_LIST_SCROLL_X,
+  getAllCraftListColumns,
+} from './all_craft_list.columns';
+
+const t = (key: string) => key;
+
+describe('all craft list table columns', () => {
+  it('reserves enough width so long English craft names stay on one line', () => {
+    const name = getAllCraftListColumns(t).find(
+      (column) => column.dataIndex === 'name'
+    );
+
+    expect(name?.width).toBeGreaterThanOrEqual(320);
+    expect(name?.ellipsis).toBe(true);
+    expect(name?.bodyCellClass).toBe(ALL_CRAFT_ID_CELL_CLASS);
+  });
+
+  it('keeps type identifiers like @sys/atom from wrapping mid-token', () => {
+    const type = getAllCraftListColumns(t).find(
+      (column) => column.slotName === 'type'
+    );
+
+    expect(type?.width).toBeGreaterThanOrEqual(120);
+    expect(type?.ellipsis).toBe(true);
+    expect(type?.bodyCellClass).toBe(ALL_CRAFT_ID_CELL_CLASS);
+  });
+
+  it('enables horizontal scroll so fixed identifier columns are not crushed', () => {
+    expect(ALL_CRAFT_LIST_SCROLL_X).toBeGreaterThanOrEqual(800);
+  });
+});

--- a/web/admin/src/views/dashboard/all_craft_list/all_craft_list.columns.ts
+++ b/web/admin/src/views/dashboard/all_craft_list/all_craft_list.columns.ts
@@ -1,0 +1,34 @@
+export const ALL_CRAFT_LIST_SCROLL_X = 1000;
+export const ALL_CRAFT_ID_CELL_CLASS = 'all-craft-id-cell';
+
+export function getAllCraftListColumns(t: (key: string) => string) {
+  return [
+    {
+      title: t('allCraftList.table.name'),
+      dataIndex: 'name',
+      slotName: 'name',
+      width: 360,
+      ellipsis: true,
+      tooltip: true,
+      bodyCellClass: ALL_CRAFT_ID_CELL_CLASS,
+    },
+    {
+      title: t('allCraftList.table.type'),
+      slotName: 'type',
+      width: 160,
+      ellipsis: true,
+      tooltip: true,
+      bodyCellClass: ALL_CRAFT_ID_CELL_CLASS,
+    },
+    {
+      title: t('allCraftList.table.templateOnly'),
+      slotName: 'templateOnly',
+      width: 140,
+    },
+    {
+      title: t('allCraftList.table.description'),
+      dataIndex: 'description',
+      bodyCellClass: 'all-craft-desc-cell',
+    },
+  ];
+}

--- a/web/admin/src/views/dashboard/all_craft_list/all_craft_list.vue
+++ b/web/admin/src/views/dashboard/all_craft_list/all_craft_list.vue
@@ -13,13 +13,20 @@
     </template>
 
     <a-table
+      class="all-craft-list-table"
       row-key="row_key"
       :data="allCraftRows"
       :columns="columns"
       :loading="isLoading"
       :bordered="false"
       :pagination="{ pageSize: 10, showTotal: true }"
+      :scroll="{ x: ALL_CRAFT_LIST_SCROLL_X }"
     >
+      <template #name="{ record }">
+        <span class="all-craft-name" :title="record.name">{{
+          record.name
+        }}</span>
+      </template>
       <template #type="{ record }">
         <a-tag :color="getCraftTypeColor(record.type)">
           {{ record.type }}
@@ -44,6 +51,10 @@
   import { Message } from '@arco-design/web-vue';
   import { useI18n } from 'vue-i18n';
   import { CraftItem, listAllCrafts } from '@/api/craft_flow';
+  import {
+    ALL_CRAFT_LIST_SCROLL_X,
+    getAllCraftListColumns,
+  } from './all_craft_list.columns';
 
   const { t } = useI18n();
 
@@ -56,16 +67,7 @@
     }))
   );
 
-  const columns = [
-    { title: t('allCraftList.table.name'), dataIndex: 'name' },
-    { title: t('allCraftList.table.type'), slotName: 'type', width: 160 },
-    {
-      title: t('allCraftList.table.templateOnly'),
-      slotName: 'templateOnly',
-      width: 140,
-    },
-    { title: t('allCraftList.table.description'), dataIndex: 'description' },
-  ];
+  const columns = getAllCraftListColumns(t);
 
   const getCraftTypeColor = (type: string) => {
     if (type?.toLowerCase().includes('flow')) return 'purple';
@@ -90,4 +92,30 @@
   });
 </script>
 
-<style scoped></style>
+<style scoped>
+  /* Arco Table defaults to word-break: break-all, which splits English
+     identifiers mid-token (ignore-advertorial → advert / orial). */
+  .all-craft-list-table :deep(.arco-table-td) {
+    word-break: normal;
+  }
+
+  .all-craft-list-table :deep(.all-craft-id-cell),
+  .all-craft-list-table :deep(.all-craft-id-cell .arco-table-td-content),
+  .all-craft-name {
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    word-break: keep-all;
+    overflow-wrap: normal;
+  }
+
+  .all-craft-name {
+    display: inline-block;
+    max-width: 100%;
+    vertical-align: bottom;
+  }
+
+  .all-craft-list-table :deep(.all-craft-desc-cell) {
+    overflow-wrap: break-word;
+  }
+</style>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 背景

Linear [COL-18](https://linear.app/colin-x-studio/issue/COL-18/全部-craft-列表表格名称列宽不足长英文名折行断裂)：`/dashboard/all_craft_list` 名称列宽不足，Arco Table 默认 `word-break: break-all`，长英文 craft 名会在单词中间断开（如 `ignore-advertorial` → `advert` / `orial`）。

先前 PR #889 已关闭且未合入。COL-19 验证时确认类型列已修好，名称列问题仍在。

## 改动

- 名称列固定 360px，类型列保持 160px，标识列 `nowrap` + ellipsis
- 表格 `scroll.x = 1000`，窄视口横向滚动而不是把标识列压断
- `CraftManagePage` 覆盖 Arco 默认 `break-all`，其它 Craft 列表页一并受益
- 增加列配置单测

## 验证

- `pnpm test`：`all_craft_list.columns.test.ts`
- 浏览器：登录后打开 `/dashboard/all_craft_list`，确认长名称单行显示

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2aab507a-4cb8-4644-8b63-4a3349501f20?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2aab507a-4cb8-4644-8b63-4a3349501f20&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

## Summary by Sourcery

Keep Craft list identifiers readable by preventing mid-word wrapping and preserving usable column widths.

Bug Fixes:
- Prevent long English Craft names and type identifiers from breaking mid-token in Craft list tables.

Enhancements:
- Standardize Craft list column sizing and truncation behavior, including horizontal scrolling for narrow viewports.

Tests:
- Add unit tests covering Craft list column widths, ellipsis behavior, and horizontal scrolling.