### PR TITLE
fix(admin): 文档中心菜单按当前 UI 语言跳转 (COL-37)

### DIFF
--- a/web/admin/src/components/menu/index.vue
+++ b/web/admin/src/components/menu/index.vue
@@ -6,12 +6,13 @@
   import { useAppStore } from '@/store';
   import { listenerRouteChange } from '@/utils/route-listener';
   import { openWindow, regexUrl } from '@/utils';
+  import { resolveExternalMenuUrl } from '@/utils/docsUrl';
   import useMenuTree from '@/components/menu/use-menu-tree';
 
   export default defineComponent({
     emit: ['collapse'],
     setup() {
-      const { t } = useI18n();
+      const { t, locale } = useI18n();
       const appStore = useAppStore();
       const router = useRouter();
       const route = useRoute();
@@ -33,7 +34,9 @@
       const goto = (item: RouteRecordRaw) => {
         // Open external link
         if (regexUrl.test(item.path)) {
-          openWindow(item.path);
+          openWindow(
+            resolveExternalMenuUrl(item.path, locale.value, item.name)
+          );
           selectedKey.value = [item.name as string];
           return;
         }

--- a/web/admin/src/router/routes/externalModules/doc.ts
+++ b/web/admin/src/router/routes/externalModules/doc.ts
@@ -1,6 +1,8 @@
+import { DOCS_CENTER_ROUTE_NAME, DOCS_ORIGIN } from '@/utils/docsUrl';
+
 export default {
-  path: 'https://feed-craft-doc.vercel.app/en',
-  name: 'doc-center',
+  path: DOCS_ORIGIN,
+  name: DOCS_CENTER_ROUTE_NAME,
   meta: {
     locale: 'menu.doc',
     icon: 'icon-book',

--- a/web/admin/src/utils/docsUrl.test.ts
+++ b/web/admin/src/utils/docsUrl.test.ts
@@ -62,6 +62,15 @@ describe('resolveExternalMenuUrl', () => {
     ).toBe('https://feed-craft-doc.vercel.app/en/');
   });
 
+  it('leaves deep docs paths unchanged unless the route is the docs center menu', () => {
+    expect(
+      resolveExternalMenuUrl(
+        `${DOCS_ORIGIN}/zh/guides/start/quick-start/`,
+        'en-US'
+      )
+    ).toBe(`${DOCS_ORIGIN}/zh/guides/start/quick-start/`);
+  });
+
   it('leaves unrelated external links unchanged', () => {
     expect(
       resolveExternalMenuUrl('https://github.com/Colin-XKL/FeedCraft', 'zh-CN')

--- a/web/admin/src/utils/docsUrl.test.ts
+++ b/web/admin/src/utils/docsUrl.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest';
-import { buildDocsUrl } from '@/utils/docsUrl';
+import {
+  buildDocsUrl,
+  DOCS_ORIGIN,
+  resolveExternalMenuUrl,
+} from '@/utils/docsUrl';
 
 describe('buildDocsUrl', () => {
   it('maps zh-CN to the simplified Chinese docs site', () => {
@@ -27,5 +31,40 @@ describe('buildDocsUrl', () => {
     expect(buildDocsUrl('zh-CN', '/guides/start/quick-start/')).toBe(
       'https://feed-craft-doc.vercel.app/zh/guides/start/quick-start/'
     );
+  });
+
+  it('returns the locale homepage without a double slash when path is empty', () => {
+    expect(buildDocsUrl('zh-CN', '')).toBe(
+      'https://feed-craft-doc.vercel.app/zh/'
+    );
+    expect(buildDocsUrl('zh-TW')).toBe(
+      'https://feed-craft-doc.vercel.app/zh-tw/'
+    );
+    expect(buildDocsUrl('en-US', '')).toBe(
+      'https://feed-craft-doc.vercel.app/en/'
+    );
+    expect(buildDocsUrl('fr-FR', '/')).toBe(
+      'https://feed-craft-doc.vercel.app/en/'
+    );
+  });
+});
+
+describe('resolveExternalMenuUrl', () => {
+  it('rewrites the docs center menu to the current UI language homepage', () => {
+    expect(resolveExternalMenuUrl(DOCS_ORIGIN, 'zh-CN', 'doc-center')).toBe(
+      'https://feed-craft-doc.vercel.app/zh/'
+    );
+    expect(
+      resolveExternalMenuUrl(`${DOCS_ORIGIN}/en`, 'zh-TW', 'doc-center')
+    ).toBe('https://feed-craft-doc.vercel.app/zh-tw/');
+    expect(
+      resolveExternalMenuUrl(`${DOCS_ORIGIN}/en`, 'en-US', 'doc-center')
+    ).toBe('https://feed-craft-doc.vercel.app/en/');
+  });
+
+  it('leaves unrelated external links unchanged', () => {
+    expect(
+      resolveExternalMenuUrl('https://github.com/Colin-XKL/FeedCraft', 'zh-CN')
+    ).toBe('https://github.com/Colin-XKL/FeedCraft');
   });
 });

--- a/web/admin/src/utils/docsUrl.ts
+++ b/web/admin/src/utils/docsUrl.ts
@@ -24,10 +24,15 @@ export function buildDocsUrl(locale: string, path = ''): string {
 }
 
 export function isDocsCenterLink(path: string, routeName?: unknown): boolean {
+  if (routeName === DOCS_CENTER_ROUTE_NAME) {
+    return true;
+  }
+  const normalized = path.replace(/\/+$/, '');
   return (
-    routeName === DOCS_CENTER_ROUTE_NAME ||
-    path === DOCS_ORIGIN ||
-    path.startsWith(`${DOCS_ORIGIN}/`)
+    normalized === DOCS_ORIGIN ||
+    normalized === `${DOCS_ORIGIN}/en` ||
+    normalized === `${DOCS_ORIGIN}/zh` ||
+    normalized === `${DOCS_ORIGIN}/zh-tw`
   );
 }
 

--- a/web/admin/src/utils/docsUrl.ts
+++ b/web/admin/src/utils/docsUrl.ts
@@ -1,4 +1,5 @@
-const DOCS_ORIGIN = 'https://feed-craft-doc.vercel.app';
+export const DOCS_ORIGIN = 'https://feed-craft-doc.vercel.app';
+export const DOCS_CENTER_ROUTE_NAME = 'doc-center';
 
 const LOCALE_TO_DOCS_LANG: Record<string, string> = {
   'zh-CN': 'zh',
@@ -13,8 +14,30 @@ export function docsLangForLocale(locale?: string): string {
   return LOCALE_TO_DOCS_LANG[locale] ?? 'en';
 }
 
-export function buildDocsUrl(locale: string, path: string): string {
+export function buildDocsUrl(locale: string, path = ''): string {
   const lang = docsLangForLocale(locale);
   const normalizedPath = path.replace(/^\/+/, '').replace(/\/+$/, '');
+  if (!normalizedPath) {
+    return `${DOCS_ORIGIN}/${lang}/`;
+  }
   return `${DOCS_ORIGIN}/${lang}/${normalizedPath}/`;
+}
+
+export function isDocsCenterLink(path: string, routeName?: unknown): boolean {
+  return (
+    routeName === DOCS_CENTER_ROUTE_NAME ||
+    path === DOCS_ORIGIN ||
+    path.startsWith(`${DOCS_ORIGIN}/`)
+  );
+}
+
+export function resolveExternalMenuUrl(
+  path: string,
+  locale: string,
+  routeName?: unknown
+): string {
+  if (isDocsCenterLink(path, routeName)) {
+    return buildDocsUrl(locale, '');
+  }
+  return path;
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 关联

Linear: [COL-37](https://linear.app/colin-x-studio/issue/COL-37/featadmin-文档中心菜单按当前语言跳转对应语言-doc-站点)

## 问题

侧栏「帮助文档 / 文档中心」原先硬编码 `https://feed-craft-doc.vercel.app/en`，点击后始终打开英文文档，不会跟随 Admin 当前 UI 语言。同时 `buildDocsUrl(locale, '')` 会生成双斜杠（如 `/zh//`）。

## 改动

- `docsUrl.ts`：空 path 返回 `{origin}/{lang}/`；导出 `DOCS_ORIGIN` / `resolveExternalMenuUrl`
- `doc.ts`：菜单 path 改为文档站点根，不再带 `/en`
- 侧栏 `goto()`：文档中心链接用当前 `locale` 动态拼接后再 `openWindow`
- 仅匹配文档中心路由及站点首页/语言首页，避免误改深层文档链接
- 补充空 path 与菜单 URL 解析单测

## 验收

- zh-CN → `https://feed-craft-doc.vercel.app/zh/`
- zh-TW → `https://feed-craft-doc.vercel.app/zh-tw/`
- en-US / 未知语言 → `https://feed-craft-doc.vercel.app/en/`
- 页面内 `topic_feed` / `craft_atom` / `craft_flow` 文档链接行为不变

说明：文档站点备注里英文可能是无前缀根路径，本 PR 按 issue 验收标准与现有 `buildDocsUrl` 行为使用 `/en/`。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-38b0c589-1bdc-43ee-82d3-9fe899786acf?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-38b0c589-1bdc-43ee-82d3-9fe899786acf&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

## Summary by Sourcery

Update the Admin documentation center navigation to follow the current UI language while preserving existing documentation links.

Bug Fixes:
- Make the Admin documentation center open the documentation homepage in the language matching the current UI locale.
- Prevent documentation homepage URLs from generating duplicate slashes.

Enhancements:
- Preserve deep documentation links and unrelated external links while resolving the documentation center menu URL.

Tests:
- Add coverage for locale-specific documentation homepages, URL normalization, and external menu URL resolution.