### PR TITLE
fix(admin): 强制 Craft 名称列 nowrap（COL-18 补充）

### DIFF
--- a/web/admin/src/components/craft/CraftManagePage.vue
+++ b/web/admin/src/components/craft/CraftManagePage.vue
@@ -55,7 +55,6 @@
      wrap at word/hyphen boundaries instead of mid-token. */
   :deep(.arco-table-td) {
     word-break: normal;
-    overflow-wrap: break-word;
   }
 
   @media (max-width: 768px) {

--- a/web/admin/src/views/dashboard/all_craft_list/all_craft_list.columns.test.ts
+++ b/web/admin/src/views/dashboard/all_craft_list/all_craft_list.columns.test.ts
@@ -14,6 +14,7 @@ describe('all craft list table columns', () => {
     );
 
     expect(name?.width).toBeGreaterThanOrEqual(320);
+    expect(name?.minWidth).toBeGreaterThanOrEqual(320);
     expect(name?.ellipsis).toBe(true);
     expect(name?.bodyCellClass).toBe(ALL_CRAFT_ID_CELL_CLASS);
   });

--- a/web/admin/src/views/dashboard/all_craft_list/all_craft_list.columns.ts
+++ b/web/admin/src/views/dashboard/all_craft_list/all_craft_list.columns.ts
@@ -8,6 +8,7 @@ export function getAllCraftListColumns(t: (key: string) => string) {
       dataIndex: 'name',
       slotName: 'name',
       width: 360,
+      minWidth: 360,
       ellipsis: true,
       tooltip: true,
       bodyCellClass: ALL_CRAFT_ID_CELL_CLASS,

--- a/web/admin/src/views/dashboard/all_craft_list/all_craft_list.vue
+++ b/web/admin/src/views/dashboard/all_craft_list/all_craft_list.vue
@@ -101,12 +101,13 @@
 
   .all-craft-list-table :deep(.all-craft-id-cell),
   .all-craft-list-table :deep(.all-craft-id-cell .arco-table-td-content),
+  .all-craft-list-table :deep(.all-craft-id-cell .arco-table-cell),
   .all-craft-name {
     overflow: hidden;
-    white-space: nowrap;
+    white-space: nowrap !important;
     text-overflow: ellipsis;
-    word-break: keep-all;
-    overflow-wrap: normal;
+    word-break: keep-all !important;
+    overflow-wrap: normal !important;
   }
 
   .all-craft-name {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 背景

[COL-18](https://linear.app/colin-x-studio/issue/COL-18/全部-craft-列表表格名称列宽不足长英文名折行断裂) 的主体修复已通过 #908 合入 `dev`。浏览器复核时，最长名称 `translate-content-immersive` 仍可能被父级表格的 `overflow-wrap: break-word` 拆成两行。

## 改动

- 名称列增加 `minWidth: 360`
- 标识单元格强制 `nowrap` / `keep-all`
- `CraftManagePage` 不再对整表设置 `overflow-wrap: break-word`

## 验证

登录 Admin → `/dashboard/all_craft_list`：`translate-content-immersive`、`ignore-advertorial`、`beautify-content` 均为单行。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2aab507a-4cb8-4644-8b63-4a3349501f20?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2aab507a-4cb8-4644-8b63-4a3349501f20&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

## Summary by Sourcery

Keep Craft names and identifiers on a single line in the admin Craft list.

Bug Fixes:
- Prevent long Craft names and identifiers in the admin list from wrapping or breaking across lines.

Enhancements:
- Ensure the Craft name column retains sufficient width and remove the table-wide wrapping behavior that caused identifier text to split.

Tests:
- Update column configuration tests to verify the minimum width requirement.