### PR TITLE
ci(ossar): 修复 ossar-action 引用不存在的 v2 标签

### DIFF
--- a/.github/workflows/ossar.yml
+++ b/.github/workflows/ossar.yml
@@ -45,7 +45,7 @@ jobs:
       #     dotnet-version: '3.1.x'
       # Run open source static analysis tools
       - name: Run OSSAR
-        uses: github/ossar-action@v2
+        uses: github/ossar-action@4e96c4f6e591eb4b991abfd459e40b136a317aea # v2.0.0
         id: ossar
 
         # Upload results to the Security tab


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
修复 `OSSAR-Scan` 检查失败。

## 问题

PR #912 的 CI 中 `OSSAR-Scan` 失败，日志报：

```
##[error]Unable to resolve action `github/ossar-action@v2`, unable to find version `v2`
```

`github/ossar-action` 仓库只有 `v1.0.0` / `v1.1.0` / `v2.0.0` 三个标签和一个 `v1` 分支（`main` 上写的 `@v1` 实际解析到分支），没有浮动的 `v2` 引用，所以 action 在解析阶段就失败，作业无法启动。

该问题由 `dev` 上的 `60f91d3`（ci: upgrade Actions to Node 24）引入，把 `@v1` 升成了 `@v2`。之前没暴露是因为 OSSAR 工作流只在 push 到 `main` 或 PR 目标为 `main` 时触发。

## 修复

按仓库中 `docker-publish.yml` 已有的约定，固定到 `v2.0.0` 的 commit SHA 并附版本注释。

## 验证

- `github/ossar-action` 的 `v2.0.0` 对应 SHA `4e96c4f6e591eb4b991abfd459e40b136a317aea`，且该 SHA 下 `action.yml` 存在（GitHub API 核对）
- `refs/tags/v2` 查询返回 404，确认原引用无效
- `task fix` 退出码 0
- `go test ./...` 全部通过

OSSAR 工作流不会在本 PR（目标 `dev`）上触发，合并进 `dev` 后 PR #912 重跑即可生效。

## 备注

同一提交上另外 3 项失败与本次改动无关，且在合并前的 `dev` 上已存在：`Vercel – feed-craft-doc` / `Vercel – feed-craft-admin` 为部署额度限流（`Deployment rate limited — retry in 24 hours`），`security/snyk` 在 `245f21f` 上同样失败。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0d564d52-1049-4be3-ad2c-fcf0491b5d32?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0d564d52-1049-4be3-ad2c-fcf0491b5d32&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

## Summary by Sourcery

Pin the OSSAR action to a valid immutable release reference so the security workflow runs successfully.

Bug Fixes:
- Fix the OSSAR workflow by pinning github/ossar-action to the available v2.0.0 release commit.

CI:
- Ensure OSSAR checks can resolve and start reliably in CI.