### PR TITLE
fix(ci): 让 release-please 读取 config extra-files (COL-40)

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -13,9 +13,12 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
+      # Do not pass `release-type` here. In googleapis/release-please-action@v4,
+      # a set release-type input forces Manifest.fromConfig and ignores
+      # release-please-config.json (including extra-files that bump package.json).
+      # Keep release-type inside the config file instead.
       - uses: googleapis/release-please-action@v4
         with:
           target-branch: main
-          release-type: simple
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 背景

Linear [COL-40](https://linear.app/colin-x-studio/issue/COL-40/fixci-release-please-未更新-packagejson-workflow-的-release-type-参数导致)：release-please 自动生成的 release PR #918 只改了 `.release-please-manifest.json` 和 `CHANGELOG.md`，没有更新 `web/admin/package.json` 与 `doc-site/package.json` 的 `version`。

## 根因

`googleapis/release-please-action@v4` 的 `loadOrBuildManifest()`：只要 workflow 传入 `release-type`，就走 `Manifest.fromConfig`，**不读** `release-please-config.json`。config 里的 `extra-files`（jsonpath `$.version`）因此完全失效。

已用 PR #918 文件列表 + `dev` 上的 workflow/config + action 源码交叉验证，问题存在。

## 改动

- 从 `.github/workflows/release-please.yml` 删除 `release-type: simple`
- `release-type: simple` 仍保留在 `release-please-config.json` 的 `packages["."]`
- 增加注释，避免以后再把 `release-type` 写回 workflow

## 合并后建议

workflow 只在 push `main` 时运行。合入 `dev` 并进入 `main` 后，可用空 commit 触发 release-please 向已有 PR #918 追加两个 package.json 的 version bump，无需关掉重开。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-12484d16-7e17-4849-a507-09d66b1e5384?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-12484d16-7e17-4849-a507-09d66b1e5384&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

## Summary by Sourcery

Fix release-please configuration loading so release automation updates all configured package versions.

Bug Fixes:
- Ensure release-please loads the repository configuration so configured extra files, including package.json version fields, are updated in release pull requests.

CI:
- Remove the workflow-level release type override and document that the release type must remain in the release-please configuration.