### PR TITLE
fix(admin): 配方管理操作列删除按钮不再被裁切 (COL-43)

### DIFF
--- a/web/admin/src/views/dashboard/custom_recipe/custom_recipe.columns.test.ts
+++ b/web/admin/src/views/dashboard/custom_recipe/custom_recipe.columns.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import {
+  CUSTOM_RECIPE_ACTIONS_CELL_CLASS,
+  CUSTOM_RECIPE_SCROLL_X,
+  getCustomRecipeColumns,
+} from './custom_recipe.columns';
+
+const t = (key: string) => key;
+
+describe('custom recipe table columns', () => {
+  const columns = getCustomRecipeColumns(t);
+  const actions = columns.find((column) => column.slotName === 'actions');
+
+  it('pins the action column and reserves room for Edit/Preview/Copy Link/Delete', () => {
+    expect(actions?.fixed).toBe('right');
+    expect(actions?.width).toBeGreaterThanOrEqual(360);
+    expect(actions?.bodyCellClass).toBe(CUSTOM_RECIPE_ACTIONS_CELL_CLASS);
+  });
+
+  it('gives every column an explicit width so Arco enables horizontal scroll and sticky actions', () => {
+    const widths = columns.map((column) => column.width ?? 0);
+    expect(widths.every((width) => width > 0)).toBe(true);
+
+    const totalWidth = widths.reduce((sum, width) => sum + width, 0);
+    expect(CUSTOM_RECIPE_SCROLL_X).toBeGreaterThanOrEqual(totalWidth);
+  });
+});

--- a/web/admin/src/views/dashboard/custom_recipe/custom_recipe.columns.ts
+++ b/web/admin/src/views/dashboard/custom_recipe/custom_recipe.columns.ts
@@ -1,0 +1,52 @@
+export const CUSTOM_RECIPE_SCROLL_X = 1410;
+export const CUSTOM_RECIPE_ACTIONS_CELL_CLASS = 'custom-recipe-actions-cell';
+
+export function getCustomRecipeColumns(t: (key: string) => string) {
+  return [
+    {
+      title: t('customRecipe.form.name'),
+      dataIndex: 'id',
+      width: 200,
+      ellipsis: true,
+      tooltip: true,
+    },
+    {
+      title: t('customRecipe.form.description'),
+      dataIndex: 'description',
+      width: 180,
+      ellipsis: true,
+      tooltip: true,
+    },
+    {
+      title: t('customRecipe.form.craft'),
+      dataIndex: 'craft',
+      slotName: 'craft',
+      width: 220,
+      ellipsis: true,
+      tooltip: true,
+    },
+    {
+      title: t('customRecipe.status.active'),
+      slotName: 'status',
+      width: 100,
+    },
+    {
+      title: t('customRecipe.form.sourceType'),
+      dataIndex: 'source_type',
+      width: 110,
+    },
+    {
+      title: t('customRecipe.form.sourceConfig'),
+      dataIndex: 'source_config',
+      slotName: 'source_config',
+      width: 240,
+    },
+    {
+      title: t('customRecipe.actions'),
+      slotName: 'actions',
+      width: 360,
+      fixed: 'right' as const,
+      bodyCellClass: CUSTOM_RECIPE_ACTIONS_CELL_CLASS,
+    },
+  ];
+}

--- a/web/admin/src/views/dashboard/custom_recipe/custom_recipe.vue
+++ b/web/admin/src/views/dashboard/custom_recipe/custom_recipe.vue
@@ -43,7 +43,7 @@
       :columns="columns"
       :bordered="true"
       :loading="isLoading"
-      :scroll="{ x: 1280 }"
+      :scroll="{ x: CUSTOM_RECIPE_SCROLL_X }"
     >
       <template #status="{ record }">
         <a-tooltip
@@ -100,7 +100,7 @@
         }}</span>
       </template>
       <template #actions="{ record }">
-        <a-space>
+        <a-space :size="8" :wrap="false">
           <a-button
             type="primary"
             size="small"
@@ -278,6 +278,10 @@
   import { useClipboard } from '@vueuse/core';
   import buildPublicFeedUrl from '@/utils/publicFeedUrl';
   import CraftSelector from '@/views/dashboard/craft_flow/CraftSelector.vue';
+  import {
+    CUSTOM_RECIPE_SCROLL_X,
+    getCustomRecipeColumns,
+  } from './custom_recipe.columns';
 
   const { t } = useI18n();
   const router = useRouter();
@@ -370,52 +374,7 @@
   const isUpdating = ref(false);
   const saving = ref(false);
 
-  const columns = [
-    {
-      title: t('customRecipe.form.name'),
-      dataIndex: 'id',
-      minWidth: 200,
-      ellipsis: true,
-      tooltip: true,
-    },
-    {
-      title: t('customRecipe.form.description'),
-      dataIndex: 'description',
-      minWidth: 180,
-      ellipsis: true,
-      tooltip: true,
-    },
-    {
-      title: t('customRecipe.form.craft'),
-      dataIndex: 'craft',
-      slotName: 'craft',
-      minWidth: 200,
-      ellipsis: true,
-      tooltip: true,
-    },
-    {
-      title: t('customRecipe.status.active'),
-      slotName: 'status',
-      width: 100,
-    },
-    {
-      title: t('customRecipe.form.sourceType'),
-      dataIndex: 'source_type',
-      width: 110,
-    },
-    {
-      title: t('customRecipe.form.sourceConfig'),
-      dataIndex: 'source_config',
-      slotName: 'source_config',
-      minWidth: 240,
-    },
-    {
-      title: t('customRecipe.actions'),
-      slotName: 'actions',
-      width: 280,
-      fixed: 'right' as const,
-    },
-  ];
+  const columns = getCustomRecipeColumns(t);
 
   async function listCustomRecipes() {
     isLoading.value = true;
@@ -617,6 +576,13 @@
     white-space: nowrap;
     word-break: normal;
     overflow-wrap: normal;
+  }
+
+  /* Keep four action buttons on one line inside the sticky column instead of
+     letting nowrap content overflow the table's right edge. */
+  .custom-recipe-table :deep(.custom-recipe-actions-cell),
+  .custom-recipe-table :deep(.custom-recipe-actions-cell .arco-table-cell) {
+    overflow: visible;
   }
 
   .custom-recipe-table__text {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- 复现并修复 [COL-43](https://linear.app/colin-x-studio/issue/COL-43)：1024px 视口下「配方管理」表格操作列最右侧「删除」按钮被裁切。
- 根因：操作列固定 280px，四个 nowrap 按钮（含「复制链接」）实际需要约 307px，按钮溢出表格右边缘约 27px。
- 改动：抽出列配置；每列显式 `width`；操作列加宽到 360px 并保持右侧固定；`scroll.x` 等于列宽总和。

## Test plan
- [x] `pnpm exec vitest run`（含新列配置测试，43 passed）
- [x] `pnpm run type:check` / `pnpm run lint`（无新增 error）
- [x] `task frontend-build`
- [x] `go test ./...`
- [x] 浏览器 1024px：登录 → `/worktable/custom_recipe`，确认「删除」完整可见可点

Linear 已评论并附本 PR 链接。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6a211f40-3a05-47d3-bd83-accd646b7f44?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6a211f40-3a05-47d3-bd83-accd646b7f44&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

## Summary by Sourcery

Ensure all custom recipe table actions remain fully visible and usable by widening and stabilizing the fixed action column.

Bug Fixes:
- Prevent the custom recipe table’s rightmost delete action from being clipped at narrower viewport widths.

Enhancements:
- Define explicit custom recipe table column widths and reserve sufficient space for the fixed action column.
- Add coverage validating column sizing, horizontal scroll configuration, and sticky action-column behavior.

Tests:
- Add Vitest coverage for custom recipe table column widths and action-column layout.